### PR TITLE
Add a sample integration test that uses the C++ SDK to call out to lambda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,11 @@ set(USE_ASM TRUE
 set(SPECTRE_MITIGATIONS TRUE
     CACHE BOOL "Attempt to mitigate SPECTRE attacks, at a potential performance cost")
 
-set(AWS_C_COMMON_PATH "" CACHE STRING "Path to the directory containing aws-c-common-config.cmake")
-include(${AWS_C_COMMON_PATH}/aws-c-common-config.cmake)
+find_package(aws-c-common REQUIRED)
+
+# C++ SDK
+find_package(AWSSDK)
+link_directories("${AWSSDK_LIB_DIR}")
 
 if(USE_ASM)
     CHECK_CXX_SOURCE_COMPILES("
@@ -94,6 +97,7 @@ endif()
 
 add_library(aws-encryption-sdk ${LIBTYPE} ${CORE_HEADERS} ${CORE_SRC})
 set_target_properties(aws-encryption-sdk PROPERTIES LINKER_LANGUAGE C C_STANDARD 99)
+
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
 if(CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES DEBUG)
@@ -114,11 +118,15 @@ file(GLOB UNIT_TEST_SRC "tests/unit/*.c")
 file(GLOB UNIT_TEST_HDRS "tests/*.h")
 file(GLOB UNIT_TESTS ${TEST_HDRS} ${TEST_SRC})
 file(GLOB TEST_LIB "tests/lib/*.c")
-  
+
+include(CTest)
+enable_testing()
+
 add_executable(unit-test-suite ${UNIT_TEST_SRC})
 target_link_libraries(unit-test-suite ${PROJECT_NAME} ${OPENSSL_LDFLAGS})
 set_target_properties(unit-test-suite PROPERTIES LINKER_LANGUAGE C C_STANDARD 99)
-target_include_directories(unit-test-suite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit${CMAKE_CURRENT_SOURCE_DIR}/source)
+target_link_libraries(unit-test-suite aws-encryption-sdk)
+target_include_directories(unit-test-suite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)
 
 add_executable(test_decrypt "tests/decrypt.c" ${TEST_LIB})
 target_link_libraries(test_decrypt ${PROJECT_NAME} ${OPENSSL_LDFLAGS})
@@ -130,8 +138,19 @@ target_link_libraries(test_decryption_vectors ${PROJECT_NAME} ${OPENSSL_LDFLAGS}
 set_target_properties(test_decryption_vectors PROPERTIES LINKER_LANGUAGE C C_STANDARD 99)
 target_include_directories(test_decryption_vectors PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests/lib)
 
-include(CTest)
-enable_testing()
+if(AWSSDK_FOUND)
+    add_executable(t_encrypt_compat tests/integration/t_encrypt_compat.cpp)
+    set_target_properties(t_encrypt_compat PROPERTIES
+        LINKER_LANGUAGE CXX
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED O
+        C_STANDARD 99
+    )
+    target_link_libraries(t_encrypt_compat aws-cpp-sdk-lambda aws-cpp-sdk-core ${PROJECT_NAME})
+    target_include_directories(t_encrypt_compat PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit ${AWSSDK_INCLUDE_DIR})
+    target_sources(t_encrypt_compat PRIVATE ${UNIT_TEST_SRC_CPP})
+    add_test(integration_encrypt_compatibility t_encrypt_compat)
+endif(AWSSDK_FOUND)
 
 add_test(cipher unit-test-suite cipher)
 add_test(header unit-test-suite header)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,44 @@
 
 AWS Encryption SDK for C
 
+## Building
+
+You'll first need to build the
+[aws-c-common](https://github.com/awslabs/aws-c-common) and (optionally)
+[aws-sdk-cpp](https://github.com/aws/aws-sdk-cpp) packages. You'll also need to
+build and install openssl 1.1.0 or higher.
+
+Once you've built them, you have two ways of providing their paths to this
+package. First, you can `make install` the dependencies to some directory (you
+can set `CMAKE_INSTALL_PREFIX` to install to an arbitrary directory), then
+configure aws-encryption-sdk-c like so:
+
+    cmake -DCMAKE_PREFIX_PATH=[path to where aws-c-common and aws-sdk-cpp were installed] \
+          -DOPENSSL_ROOT_DIR=[path to where openssl was installed] \
+          [path to aws-encryption-sdk-c source]
+
+If these dependencies were installed in the default location for library
+installations on your system, cmake may be able to find them without these
+defines.
+
+You can also point cmake to the `aws-c-common` build directory if you prefer
+not to install it, with:
+
+    -Daws-c-common_DIR=[path to the aws-c-common build directory]
+
+Currently, this mode of operation is not supported for the AWS C++ SDK; you
+must install that, but you can install it to an alternate installation
+directory referenced by `CMAKE_PREFIX_PATH` if you prefer.
+
+### Tips and tricks
+
+When building aws-sdk-cpp, you can save time by only building the subcomponents we need:
+
+    cmake -DBUILD_ONLY="lambda;kms" [path to aws-sdk-cpp source]
+
+To enable debug symbols, set `-DCMAKE_BUILD_TYPE=Debug` at initial cmake time,
+or use `ccmake .` to update the configuration after the fact.
+
 ## License
 
 This library is licensed under the Apache 2.0 License. 

--- a/build-tools/bin/codebuild-build-dependency
+++ b/build-tools/bin/codebuild-build-dependency
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Some of our dependencies take a long time to build; this script
+# caches the binaries resulting from such builds until the upstream
+# git revision changes.
+
+# Note that we're not using codebuild's native caching support as it's
+# not compatible with the barebones ubuntu docker image we're using
+# (which in turn we're using because we need recent openssl).
+
+set -u
+set -e
+set -x
+
+GIT_URL="$1"
+shift
+
+BASENAME="$(basename "$GIT_URL" .git)"
+ROOT="/deps/$BASENAME"
+
+mkdir -p "$ROOT"
+git clone --depth=1 "$GIT_URL" "$ROOT/git"
+GITREV="$(cd "$ROOT/git"; git rev-parse HEAD)"
+ID_HASH="$(echo "$GITREV $@" | sha512sum | sed 's/ .*//')"
+S3PATH=s3://awsct-csdk-buildcache/$BASENAME/$ID_HASH.tar.xz
+
+if aws s3 cp $S3PATH "$ROOT/prebuilt.tar.xz"; then
+    tar -C "$ROOT" -xvf "$ROOT/prebuilt.tar.xz"
+else
+    mkdir -p "$ROOT/build"
+    (cd $ROOT/build; cmake "$ROOT/git" "$@" -DCMAKE_INSTALL_PREFIX="$ROOT/install" && make -j4 && make install)
+    tar -C "$ROOT" -cJvf prebuilt.tar.xz install
+    aws s3 cp prebuilt.tar.xz "$S3PATH"
+fi

--- a/build-tools/bin/codebuild-test.sh
+++ b/build-tools/bin/codebuild-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e # Fail if a subcommand fails
+set -u # Fail if an unset variable is used
+set -x # Echo commands as they're executed
+
+PATH=$PWD/build-tools/bin:$PATH
+
+build-tools/bin/codebuild-build-dependency https://github.com/awslabs/aws-c-common.git
+build-tools/bin/codebuild-build-dependency https://github.com/awslabs/aws-sdk-cpp.git -DBUILD_ONLY="kms;lambda"
+mkdir build
+ls -l /deps/aws-c-common/install/lib/aws-c-common/cmake
+(cd build;
+    cmake -DCMAKE_PREFIX_PATH='/deps/aws-c-common/install;/deps/aws-sdk-cpp/install' .. &&
+    make VERBOSE=1 &&
+    (make test || (ctest -V; exit 1)))

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,16 +4,8 @@ phases:
   pre_build:
     commands:
       - apt-get update
-      - apt-get -y install build-essential cmake git libssl-dev
+      - env DEBIAN_FRONTEND=noninteractive apt-get -y install build-essential cmake git libssl-dev libcurl4-openssl-dev zlib1g-dev awscli
   build:
     commands:
-      - git clone https://github.com/awslabs/aws-c-common.git
-      - mkdir c-common-build
-      - (cd c-common-build; cmake ../aws-c-common; make -j4)
-      - mkdir build
-      - (cd build; cmake -DAWS_C_COMMON_PATH=$PWD/../c-common-build ..)
-      - (cd build; make -j4)
-  post_build:
-    commands:
-      - (cd build; make test)
+      - build-tools/bin/codebuild-test.sh
 

--- a/tests/integration/t_encrypt_compat.cpp
+++ b/tests/integration/t_encrypt_compat.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "testing.h"
+
+#include <memory>
+#include <sstream>
+
+#include <aws/common/encoding.h>
+#include <aws/core/Aws.h>
+#include <aws/lambda/LambdaClient.h>
+#include <aws/lambda/model/InvokeRequest.h>
+#include <aws/lambda/model/InvokeResult.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/utils/base64/Base64.h>
+
+#include <aws/core/utils/logging/AWSLogging.h>
+#include <aws/core/utils/logging/ConsoleLogSystem.h>
+
+// This lambda function attempts to decrypt a base-64 encoded ciphertext
+// encrypted with an all-zero data key.
+static const char *decrypt_null_fn = "arn:aws:lambda:us-west-2:518866784541:function:AWSCryptoolsSDKOracleJavaLambda-Decrypt-1JPQJY7GZGKHK";
+
+static int sdk_init_depth = 0;
+
+class SDKInitializer {
+private:
+    Aws::SDKOptions options;
+public:
+    SDKInitializer() {
+        using namespace Aws::Utils::Logging;
+        if (!sdk_init_depth++) {
+            Aws::InitAPI(options);
+            Aws::Utils::Logging::InitializeAWSLogging(
+                std::shared_ptr<Aws::Utils::Logging::LogSystemInterface>(
+                    new Aws::Utils::Logging::ConsoleLogSystem(
+                        Aws::Utils::Logging::LogLevel::Warn
+                    )
+                )
+            );
+        }
+    }
+
+    ~SDKInitializer() {
+        if (!--sdk_init_depth) {
+            Aws::Utils::Logging::ShutdownAWSLogging();
+            Aws::ShutdownAPI(options);
+        }
+    }
+};
+
+static Aws::Lambda::LambdaClient lambda_client() {
+    Aws::Client::ClientConfiguration config;
+    config.region = Aws::String("us-west-2");
+
+    return Aws::Lambda::LambdaClient(config);
+}
+
+#define ASSERT_OUTCOME(invocation, expected, size) \
+    do { \
+        if (!assert_successful_outcome(invocation, expected, size, #invocation, __FILE__, __LINE__)) { \
+            return 1; \
+        } \
+    } while (0)
+
+using Aws::Utils::Base64::Base64;
+using Aws::Utils::ByteBuffer;
+
+void hexdump(const uint8_t *buf, size_t size) {
+    for (size_t row = 0; row < size; row += 16) {
+        fprintf(stderr, "%08zx ", row);
+        for (int idx = 0; idx < 16; idx++) {
+            if (idx + row < size) {
+                fprintf(stderr, "%s%02x", (idx == 8) ? "  " : " ", buf[idx + row]);
+            } else {
+                fprintf(stderr, (idx == 8) ? "    " : "   ");
+            }
+        }
+        fprintf(stderr, "  |");
+        for (int idx = 0; idx < 16 && idx + row < size; idx++) {
+            uint8_t ch = buf[idx + row];
+            fprintf(stderr, "%c", isprint(ch) ? ch : '.');
+        }
+        fprintf(stderr, "|\n");
+    }
+}
+
+static int assert_successful_outcome(
+    Aws::Lambda::Model::InvokeOutcome outcome,
+    const uint8_t *expected,
+    size_t expected_size,
+    const char *debug_expr,
+    const char *file,
+    int line
+) {
+    (void)debug_expr;
+
+    if (!outcome.IsSuccess()) {
+        auto error = outcome.GetError();
+        fprintf(stderr, "Lambda invocation failed at %s:%d: %s\n",
+            file, line, error.GetMessage().c_str());
+        return 0;
+    }
+
+    auto result = outcome.GetResultWithOwnership();
+    auto &payload = result.GetPayload();
+
+    int chunk_size = 4096;
+    std::vector<char> payload_buf;
+    bool eof = false;
+    do {
+        int offset = payload_buf.size();
+        payload_buf.resize(offset + chunk_size, 0);
+
+        payload.read((char *)&payload_buf[offset], chunk_size);
+        eof = payload.gcount() != chunk_size;
+        offset += payload.gcount();
+        payload_buf.resize(offset, 0);
+    } while (!eof);
+
+    if (payload_buf.size() < 2 || payload_buf[0] != '"' || payload_buf[payload_buf.size() - 1] != '"' ||
+        memchr(&payload_buf[1], '"', payload_buf.size() - 2) != NULL) {
+        payload_buf.push_back(0);
+
+        fprintf(stderr, "Lambda invocation returned something that wasn't a string at %s:%d: %s\n",
+            file, line, &payload_buf[0]);
+        return 0;
+    }
+
+    Aws::String payload_str(&payload_buf[1], payload_buf.size() - 2);
+    auto raw_buf = Base64().Decode(payload_str);
+
+    if (raw_buf.GetLength() != expected_size || memcmp(expected, &raw_buf[0], expected_size)) {
+        fprintf(stderr, "Lambda invocation returned unexpected result at %s:%d. Expected:\n", file, line);
+        hexdump(expected, expected_size);
+        fprintf(stderr, "Actual:\n");
+        hexdump(&raw_buf[0], raw_buf.GetLength());
+        return 0;
+    }
+
+    return 1;
+}
+
+static Aws::Lambda::Model::InvokeOutcome invoke(uint8_t *ciphertext, size_t length) {
+    ByteBuffer ciphertext_buf(ciphertext, length);
+    std::string json_buf("\"");
+
+    json_buf += std::string(Base64().Encode(ciphertext_buf).c_str());
+    json_buf += '"';
+
+    auto client = lambda_client();
+    Aws::Lambda::Model::InvokeRequest request;
+
+    request.SetFunctionName(decrypt_null_fn);
+    request.SetInvocationType(Aws::Lambda::Model::InvocationType::RequestResponse);
+    auto body = std::make_shared<std::stringstream>(json_buf);
+    request.SetBody(
+        std::static_pointer_cast<Aws::IOStream>(body)
+    );
+
+    return client.Invoke(request);
+}
+
+static int test() {
+    uint8_t ciphertext[] = {
+        0x01, 0x80, 0x03, 0x78, 0x24, 0xd8, 0xf4, 0x60, 0x3e, 0xa9, 0xc1, 0x66,
+        0x85, 0x8e, 0x6d, 0x55, 0xd3, 0x1b, 0x78, 0xd0, 0x00, 0x5f, 0x00, 0x01,
+        0x00, 0x15, 0x61, 0x77, 0x73, 0x2d, 0x63, 0x72, 0x79, 0x70, 0x74, 0x6f,
+        0x2d, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x2d, 0x6b, 0x65, 0x79, 0x00,
+        0x44, 0x41, 0x73, 0x45, 0x78, 0x44, 0x35, 0x2f, 0x43, 0x53, 0x79, 0x49,
+        0x50, 0x6b, 0x6e, 0x4f, 0x6e, 0x57, 0x67, 0x6f, 0x73, 0x33, 0x69, 0x6c,
+        0x43, 0x61, 0x64, 0x39, 0x4e, 0x55, 0x49, 0x45, 0x79, 0x72, 0x47, 0x41,
+        0x2f, 0x58, 0x33, 0x43, 0x41, 0x39, 0x51, 0x6d, 0x74, 0x61, 0x72, 0x57,
+        0x30, 0x54, 0x58, 0x48, 0x6a, 0x56, 0x70, 0x56, 0x79, 0x78, 0x2f, 0x78,
+        0x50, 0x58, 0x4d, 0x6c, 0x76, 0x67, 0x51, 0x3d, 0x3d, 0x00, 0x01, 0x00,
+        0x04, 0x6e, 0x75, 0x6c, 0x6c, 0x00, 0x04, 0x6e, 0x75, 0x6c, 0x6c, 0x00,
+        0x04, 0x6e, 0x75, 0x6c, 0x6c, 0x02, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x00,
+        0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x88, 0x72, 0x9d, 0x82, 0x66, 0x0a, 0x41, 0x77, 0x3c,
+        0x53, 0x39, 0x72, 0x7e, 0xa4, 0x54, 0x3b, 0xff, 0xff, 0xff, 0xff, 0x00,
+        0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0d, 0x2b, 0x40, 0x10, 0x6a, 0x3e,
+        0xfd, 0xab, 0x39, 0x2e, 0xe8, 0x52, 0x85, 0x74, 0x0d, 0x21, 0xa1, 0xc9,
+        0x71, 0x03, 0x54, 0xdd, 0xd0, 0xce, 0xa5, 0x69, 0x5b, 0xbf, 0x51, 0x2b,
+        0x00, 0x67, 0x30, 0x65, 0x02, 0x31, 0x00, 0xba, 0x33, 0x0b, 0xed, 0x8a,
+        0xb7, 0xdd, 0x57, 0xaf, 0xff, 0x1c, 0xd2, 0x3b, 0x54, 0xf3, 0x0a, 0x32,
+        0x8a, 0x30, 0xe8, 0xdc, 0xac, 0xb0, 0x11, 0x3f, 0x0b, 0xf6, 0x90, 0xd2,
+        0x9f, 0x12, 0x87, 0xe0, 0x95, 0xf1, 0xb3, 0x27, 0xb1, 0x40, 0x46, 0x09,
+        0xc7, 0x00, 0xed, 0xbb, 0x7c, 0x62, 0x85, 0x02, 0x30, 0x1c, 0x93, 0x56,
+        0x49, 0x3b, 0xd7, 0xc6, 0xb1, 0x94, 0xab, 0x8f, 0x8c, 0x0e, 0xeb, 0x86,
+        0x92, 0x0b, 0x80, 0xb8, 0x81, 0xde, 0xf2, 0x47, 0x4a, 0x02, 0x58, 0x13,
+        0xf2, 0x8c, 0x31, 0x61, 0xea, 0x8e, 0xa1, 0xd6, 0x51, 0xe8, 0xac, 0xbb,
+        0x46, 0xc0, 0x16, 0xa2, 0xac, 0x01, 0x8c, 0xa2, 0x27
+    };
+    uint8_t expected[] = "Hello, world!";
+
+    ASSERT_OUTCOME(invoke(ciphertext, sizeof(ciphertext)), expected, sizeof(expected) - 1);
+
+    return 0;
+}
+
+int main() {
+    SDKInitializer init;
+
+    fprintf(stderr, "[RUNNING] Encrypt compat test...\r");
+
+    int result = test();
+
+    fprintf(stderr, "%s Encrypt compat test    \n", result ? "\n[ FAILED]" : "[ PASSED]");
+
+    return result;
+}
+
+


### PR DESCRIPTION
This test will evolve into a decrypt test vector test for testing the
encryption path; I'm shipping it with a hardcoded vector for review on
the build framework/etc.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
