### PR TITLE
Small fixes to header parsing code

### DIFF
--- a/include/aws/cryptosdk/private/header.h
+++ b/include/aws/cryptosdk/private/header.h
@@ -67,35 +67,49 @@ enum aws_cryptosdk_hdr_content_type {
  * Frees all memory which has been allocated to hdr object and zeroizes hdr.
  * This is idempotent. Multiple frees are safe.
  */
-void aws_cryptosdk_hdr_free(struct aws_allocator * allocator, struct aws_cryptosdk_hdr *hdr);
+void aws_cryptosdk_hdr_clean_up(struct aws_allocator * allocator,
+                                struct aws_cryptosdk_hdr *hdr);
 
 /**
- * Reads raw header data from src and populates hdr with all of the information about the message.
- * hdr is assumed to be an uninitialized hdr struct when this is called. If hdr has any memory already allocated to it,
- * that memory will be lost.
- * If this succeeds, hdr will have memory allocated to it, which must be freed with aws_cryptosdk_hdr_free.
+ * Reads raw header data from src and populates hdr with all of the information about the
+ * message. hdr is assumed to be an uninitialized hdr struct when this is called. If hdr
+ * has any memory already allocated to it, that memory will be lost.
+ *
+ * If this succeeds, hdr will have memory allocated to it, which must be freed with
+ * aws_cryptosdk_hdr_clean_up.
+ *
  * If this fails, no memory will be allocated and hdr will be zeroized.
  */
-int aws_cryptosdk_hdr_parse(struct aws_allocator * allocator, struct aws_cryptosdk_hdr *hdr, const uint8_t *src, size_t src_len);
+int aws_cryptosdk_hdr_parse_init(struct aws_allocator * allocator,
+                                 struct aws_cryptosdk_hdr *hdr,
+                                 const uint8_t *src,
+                                 size_t src_len);
 
 /**
- * Reads information from already parsed hdr object and determines how many bytes are needed to serialize.
+ * Reads information from already parsed hdr object and determines how many bytes are
+ * needed to serialize.
+ *
  * Returns number of bytes, or zero if hdr was not parsed correctly.
  *
- * Warning: running this on a hdr which has not already been run through aws_cryptosdk_hdr_parse (or which has been zeroized)
- * can result in a seg fault.
+ * Warning: running this on a hdr which has not already been run through
+ * aws_cryptosdk_hdr_parse_init (or which has been zeroized) can result in a seg fault.
  */
 int aws_cryptosdk_hdr_size(const struct aws_cryptosdk_hdr *hdr);
 
 /**
  * Attempts to write a parsed header.
  *
- * The number of bytes written to outbuf is placed at *bytes_written.
- * If outbuf is too small, returns AWS_ERR_OOM and zeroizes the output buffer.
+ * The number of bytes written to outbuf is placed at *bytes_written. If outbuf is too
+ * small, returns AWS_OP_ERR, sets the error code to AWS_ERROR_SHORT_BUFFER, and zeroizes
+ * the output buffer.
  *
- * Using aws_cryptosdk_hdr_size to determine how much memory to allocate to outbuf ahead of time prevents AWS_ERR_OOM.
+ * Using aws_cryptosdk_hdr_size to determine how much memory to allocate to outbuf ahead
+ * of time guarantees that the short buffer error will not occur.
  */
-int aws_cryptosdk_hdr_write(const struct aws_cryptosdk_hdr *hdr, size_t * bytes_written, uint8_t *outbuf, size_t outlen);
+int aws_cryptosdk_hdr_write(const struct aws_cryptosdk_hdr *hdr,
+                            size_t * bytes_written,
+                            uint8_t *outbuf,
+                            size_t outlen);
 
 /**
  * Returns 1 if alg_id is a known value, 0 if not.

--- a/source/session.c
+++ b/source/session.c
@@ -101,7 +101,7 @@ static void session_reset(struct aws_cryptosdk_session *session) {
     session->header_copy = NULL;
     session->header_size = 0;
 
-    aws_cryptosdk_hdr_free(session->alloc, &session->header);
+    aws_cryptosdk_hdr_clean_up(session->alloc, &session->header);
 
     aws_cryptosdk_secure_zero(&session->content_key, sizeof(session->content_key));
 
@@ -205,7 +205,7 @@ static int try_parse_header(
     struct aws_cryptosdk_session * restrict session,
     struct aws_byte_cursor * restrict input
 ) {
-    int rv = aws_cryptosdk_hdr_parse(session->alloc, &session->header, input->ptr, input->len);
+    int rv = aws_cryptosdk_hdr_parse_init(session->alloc, &session->header, input->ptr, input->len);
 
     if (rv != AWS_OP_SUCCESS) {
         if (aws_last_error() == AWS_ERROR_SHORT_BUFFER) {

--- a/tests/unit/t_header.c
+++ b/tests/unit/t_header.c
@@ -184,7 +184,7 @@ int simple_header_parse() {
     struct aws_cryptosdk_hdr hdr;
 
     TEST_ASSERT_INT_EQ(AWS_OP_SUCCESS,
-                       aws_cryptosdk_hdr_parse(allocator, &hdr, test_header_1, sizeof(test_header_1) - 1));
+                       aws_cryptosdk_hdr_parse_init(allocator, &hdr, test_header_1, sizeof(test_header_1) - 1));
 
     // Known answer tests
     TEST_ASSERT_INT_EQ(hdr.alg_id, AES_128_GCM_IV12_AUTH16_KDSHA256_SIGEC256);
@@ -230,7 +230,7 @@ int simple_header_parse() {
 
     TEST_ASSERT_INT_EQ(aws_cryptosdk_hdr_size(&hdr), hdr.auth_len + hdr.auth_tag.len + hdr.iv.len);
 
-    aws_cryptosdk_hdr_free(allocator, &hdr);
+    aws_cryptosdk_hdr_clean_up(allocator, &hdr);
     return 0;
 }
 
@@ -239,7 +239,7 @@ int simple_header_parse2() {
     struct aws_cryptosdk_hdr hdr;
 
     TEST_ASSERT_INT_EQ(AWS_OP_SUCCESS,
-                       aws_cryptosdk_hdr_parse(allocator, &hdr, test_header_2, sizeof(test_header_2)));
+                       aws_cryptosdk_hdr_parse_init(allocator, &hdr, test_header_2, sizeof(test_header_2)));
 
     // Known answer tests
     TEST_ASSERT_INT_EQ(hdr.alg_id, AES_128_GCM_IV12_AUTH16_KDSHA256_SIGEC256);
@@ -280,7 +280,7 @@ int simple_header_parse2() {
 
     TEST_ASSERT_INT_EQ(aws_cryptosdk_hdr_size(&hdr), hdr.auth_len + hdr.auth_tag.len + hdr.iv.len);
 
-    aws_cryptosdk_hdr_free(allocator, &hdr);
+    aws_cryptosdk_hdr_clean_up(allocator, &hdr);
     return 0;
 }
 
@@ -291,14 +291,14 @@ int failed_parse() {
     // incomplete header
     struct aws_cryptosdk_hdr hdr;
     TEST_ASSERT_INT_NE(AWS_OP_SUCCESS,
-                       aws_cryptosdk_hdr_parse(allocator, &hdr, test_header_1, sizeof(test_header_1) - 5));
+                       aws_cryptosdk_hdr_parse_init(allocator, &hdr, test_header_1, sizeof(test_header_1) - 5));
 
     TEST_ASSERT_INT_EQ(aws_cryptosdk_hdr_size(&hdr), 0);
 
     // faulty header
     struct aws_cryptosdk_hdr hdr2;
     TEST_ASSERT_INT_NE(AWS_OP_SUCCESS,
-                       aws_cryptosdk_hdr_parse(allocator, &hdr2, bad_header_1, sizeof(bad_header_1)));
+                       aws_cryptosdk_hdr_parse_init(allocator, &hdr2, bad_header_1, sizeof(bad_header_1)));
 
     TEST_ASSERT_INT_EQ(aws_cryptosdk_hdr_size(&hdr2), 0);
 
@@ -350,12 +350,12 @@ static void overread_once(const uint8_t *inbuf, size_t inlen, ssize_t flip_bit_i
 
     struct aws_cryptosdk_hdr hdr;
     // We don't care about the return value as long as we don't actually crash.
-    aws_cryptosdk_hdr_parse(allocator, &hdr, phdr, inlen);
+    aws_cryptosdk_hdr_parse_init(allocator, &hdr, phdr, inlen);
 
-    // This is only necessary when aws_cryptosdk_hdr_parse succeeds,
+    // This is only necessary when aws_cryptosdk_hdr_parse_init succeeds,
     // but including it all the time is also a good test that we have made
-    // aws_cryptosdk_hdr_free idempotent.
-    aws_cryptosdk_hdr_free(allocator, &hdr);
+    // aws_cryptosdk_hdr_clean_up idempotent.
+    aws_cryptosdk_hdr_clean_up(allocator, &hdr);
     munmap(pbuffer, total_size);
 }
 


### PR DESCRIPTION
- better handling of error codes/remove redundancy
- use AWS_ERROR_SHORT_BUFFER when output buffer too short on write
- rename header allocation/deallocation functions to use _init and
  _clean_up naming conventions
- don't raise AWS_ERROR_OOM code, because aws_mem_acquire does so
- reformat private/header.h for better line spacing

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
