### PR TITLE
Doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,3 @@ build
 *~
 *.[ch]-e
 .DS_Store
-
-#doxygen
-doxygen/html/
-doxygen/latex/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,9 +222,11 @@ option(BUILD_DOC "Build documentation" OFF)
 if (BUILD_DOC)
     find_package(Doxygen)
     if (DOXYGEN_FOUND)
-        set(DOXYGEN_CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/doxygen.config)
+        set(DOXYGEN_CONFIG_FILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/doxygen.config.in)
+        set(DOXYGEN_CONFIG_FILE_GENERATED ${CMAKE_CURRENT_BINARY_DIR}/doxygen/doxygen.config)
+        configure_file(${DOXYGEN_CONFIG_FILE_IN} ${DOXYGEN_CONFIG_FILE_GENERATED} @ONLY)
         add_custom_target(doc_doxygen ALL
-                COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE}
+                COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE_GENERATED}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 COMMENT "Generating Doxygen documentation"
                 VERBATIM)

--- a/doxygen/doxygen.config.in
+++ b/doxygen/doxygen.config.in
@@ -111,7 +111,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = ./
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.h \
                          *.md


### PR DESCRIPTION
Doxygen documentation 

Adds Doxygen configuration file (based on the config from aws-sdk-cpp) and creates a new cmake option to generate documentation when needed. 
By default it will not automatically generate documentation. To enable it you will need to pass to cmake "-DBUILD_DOC=ON"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
