### PR TITLE
Rename ERROR labels

### DIFF
--- a/source/default_cmm.c
+++ b/source/default_cmm.c
@@ -39,26 +39,26 @@ static int default_cmm_generate_encryption_materials(struct aws_cryptosdk_cmm * 
         return AWS_OP_ERR;
     }
 
-    if (aws_cryptosdk_mkp_get_master_keys(self->mkp, &master_keys, request->enc_context)) goto ERROR;
+    if (aws_cryptosdk_mkp_get_master_keys(self->mkp, &master_keys, request->enc_context)) goto err;
 
     num_keys = master_keys.length;
-    if (!num_keys) { aws_raise_error(AWS_CRYPTOSDK_ERR_NO_MASTER_KEYS_FOUND); goto ERROR; }
+    if (!num_keys) { aws_raise_error(AWS_CRYPTOSDK_ERR_NO_MASTER_KEYS_FOUND); goto err; }
 
     enc_mat = aws_cryptosdk_encryption_materials_new(self->alloc, request->requested_alg, num_keys);
-    if (!enc_mat) goto ERROR;
+    if (!enc_mat) goto err;
 
     enc_mat->enc_context = request->enc_context;
 
     /* Produce unencrypted data key and first encrypted data key from the first master key. */
-    if (aws_array_list_get_at(&master_keys, (void *)&master_key, 0)) goto ERROR;
+    if (aws_array_list_get_at(&master_keys, (void *)&master_key, 0)) goto err;
 
-    if (aws_cryptosdk_mk_generate_data_key(master_key, enc_mat)) goto ERROR;
+    if (aws_cryptosdk_mk_generate_data_key(master_key, enc_mat)) goto err;
 
     /* Re-encrypt unencrypted data key with each other master key. */
     for (size_t key_idx = 1 ; key_idx < num_keys ; ++key_idx) {
-        if (aws_array_list_get_at(&master_keys, (void *)&master_key, key_idx)) goto ERROR;
+        if (aws_array_list_get_at(&master_keys, (void *)&master_key, key_idx)) goto err;
 
-        if (aws_cryptosdk_mk_encrypt_data_key(master_key, enc_mat)) goto ERROR;
+        if (aws_cryptosdk_mk_encrypt_data_key(master_key, enc_mat)) goto err;
     }
 
 // TODO: implement trailing signatures
@@ -67,7 +67,7 @@ static int default_cmm_generate_encryption_materials(struct aws_cryptosdk_cmm * 
     aws_array_list_clean_up(&master_keys);
     return AWS_OP_SUCCESS;
 
-ERROR:
+err:
     *output = NULL;
     aws_array_list_clean_up(&master_keys);
     aws_cryptosdk_encryption_materials_destroy(enc_mat);
@@ -81,15 +81,15 @@ static int default_cmm_decrypt_materials(struct aws_cryptosdk_cmm * cmm,
     struct default_cmm * self = (struct default_cmm *) cmm;
 
     dec_mat = aws_cryptosdk_decryption_materials_new(self->alloc, request->alg);
-    if (!dec_mat) goto ERROR;
+    if (!dec_mat) goto err;
 
     if (aws_cryptosdk_mkp_decrypt_data_key(self->mkp,
                                            dec_mat,
-                                           &request->encrypted_data_keys)) goto ERROR;
+                                           &request->encrypted_data_keys)) goto err;
 
     if (!dec_mat->unencrypted_data_key.buffer) {
         aws_raise_error(AWS_CRYPTOSDK_ERR_CANNOT_DECRYPT);
-        goto ERROR;
+        goto err;
     }
 
 // TODO: implement trailing signatures
@@ -97,7 +97,7 @@ static int default_cmm_decrypt_materials(struct aws_cryptosdk_cmm * cmm,
     *output = dec_mat;
     return AWS_OP_SUCCESS;
 
-ERROR:
+err:
     *output = NULL;
     aws_cryptosdk_decryption_materials_destroy(dec_mat);
     return AWS_OP_ERR;


### PR DESCRIPTION
ERROR is defined as a constant on Windows, so using it as a label causes
build failures.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
