### PR TITLE
Pin C++ SDK dependency to a specific tag

### DIFF
--- a/build-tools/bin/codebuild-build-dependency
+++ b/build-tools/bin/codebuild-build-dependency
@@ -28,11 +28,20 @@ set -x
 GIT_URL="$1"
 shift
 
+GIT_REV=HEAD
+
+if [ "x${1:-}" == "x--git-rev" ]; then
+    shift
+    GIT_REV=$1
+    shift
+fi
+
 BASENAME="$(basename "$GIT_URL" .git)"
 ROOT="/deps/$BASENAME"
 
 mkdir -p "$ROOT"
-git clone --depth=1 "$GIT_URL" "$ROOT/git"
+git clone "$GIT_URL" "$ROOT/git"
+(cd $ROOT/git; git reset --hard $GIT_REV)
 GITREV="$(cd "$ROOT/git"; git rev-parse HEAD)"
 ID_HASH="$(echo "$GITREV $@" | sha512sum | sed 's/ .*//')"
 S3PATH=s3://awsct-csdk-buildcache/$BASENAME/$ID_HASH.tar.xz

--- a/build-tools/bin/codebuild-test.sh
+++ b/build-tools/bin/codebuild-test.sh
@@ -20,7 +20,7 @@ set -x # Echo commands as they're executed
 PATH=$PWD/build-tools/bin:$PATH
 
 build-tools/bin/codebuild-build-dependency https://github.com/awslabs/aws-c-common.git
-build-tools/bin/codebuild-build-dependency https://github.com/awslabs/aws-sdk-cpp.git -DBUILD_ONLY="kms;lambda"
+build-tools/bin/codebuild-build-dependency https://github.com/awslabs/aws-sdk-cpp.git --git-rev 1.5.20 -DBUILD_ONLY="kms;lambda"
 mkdir build
 ls -l /deps/aws-c-common/install/lib/aws-c-common/cmake
 (cd build;


### PR DESCRIPTION
Extracted from https://github.com/awslabs/aws-encryption-sdk-c/pull/74 into a separate PR, both to break PRs into separate, manageable pieces, and because this issue was blocking the build and is somewhat urgent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
