### PR TITLE
Use default value of cbmc.tar.gz when running verification

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_derive_key/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_derive_key/cbmc-batch.yaml
@@ -11,7 +11,6 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_cryptosdk_derive_key_verify;--pointer-check;--trace;--unwinding-assertions"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_hdr_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hdr_clean_up/cbmc-batch.yaml
@@ -11,7 +11,6 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_cryptosdk_hdr_clean_up_verify;--unwindset;__builtin___memcpy_chk.0:4,memcpy_chk.0:4,memcpy.0:4,aws_cryptosdk_hdr_clean_up.0:2,aws_cryptosdk_hdr_clean_up.1:2,get_aws_cryptosdk_hdr_ptr.0:2,get_aws_cryptosdk_hdr_ptr.1:2;--unwinding-assertions;--trace;--memory-leak-check"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_hdr_size/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hdr_size/cbmc-batch.yaml
@@ -11,7 +11,6 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_cryptosdk_hdr_size_verify;--unwindset;aws_cryptosdk_hdr_size.0:2,aws_cryptosdk_hdr_size.1:2,get_aws_cryptosdk_hdr_ptr.0:2,get_aws_cryptosdk_hdr_ptr.1:2;--pointer-check;--trace;--unwinding-assertions"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_hdr_write/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hdr_write/cbmc-batch.yaml
@@ -11,7 +11,6 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;aws_cryptosdk_hdr_write_verify;--unwindset;__builtin___memcpy_chk.0:5,memcpy_chk.0:5,memcpy.0:5,aws_cryptosdk_hdr_clean_up.0:0,aws_cryptosdk_hdr_clean_up.1:0,aws_mem_release:0,__builtin__memset_chk.0:2,memset.0:2,aws_cryptosdk_hdr_write.0:4,aws_cryptosdk_hdr_write.1:2,aws_cryptosdk_hdr_write.2:2,get_aws_cryptosdk_hdr_ptr.0:2,get_aws_cryptosdk_hdr_ptr.1:2;--pointer-check;--trace;--unwinding-assertions"
 goto: proofs.goto

--- a/.cbmc-batch/jobs/hdr_zeroize/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/hdr_zeroize/cbmc-batch.yaml
@@ -11,7 +11,6 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-cbmcpkg: cbmc-ubuntu16.tar.gz
 jobos: ubuntu16
 cbmcflags: "--bounds-check;--pointer-check;--function;hdr_zeroize_verify"
 goto: proofs.goto


### PR DESCRIPTION
The default used by CBMC Batch is just fine, no need to use a different name.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
