### PR TITLE
Name change of the enums used for the hash function in HKDF

### DIFF
--- a/include/aws/cryptosdk/hkdf.h
+++ b/include/aws/cryptosdk/hkdf.h
@@ -19,9 +19,9 @@
 #include <aws/common/byte_buf.h>
 
 enum aws_cryptosdk_sha_version { 
-    NOSHA,
-    SHA256, 
-    SHA384, 
+    AWS_CRYPTOSDK_NOSHA,
+    AWS_CRYPTOSDK_SHA256, 
+    AWS_CRYPTOSDK_SHA384, 
 };
 
 /**

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -81,15 +81,15 @@ const struct aws_cryptosdk_alg_properties *aws_cryptosdk_alg_props(enum aws_cryp
 static enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id alg_id) {
     switch (alg_id) {
         case AES_256_GCM_IV12_AUTH16_KDSHA384_SIGEC384:
-        case AES_192_GCM_IV12_AUTH16_KDSHA384_SIGEC384: return SHA384;
+        case AES_192_GCM_IV12_AUTH16_KDSHA384_SIGEC384: return AWS_CRYPTOSDK_SHA384;
         case AES_128_GCM_IV12_AUTH16_KDSHA256_SIGEC256:
         case AES_256_GCM_IV12_AUTH16_KDSHA256_SIGNONE:
         case AES_192_GCM_IV12_AUTH16_KDSHA256_SIGNONE:
-        case AES_128_GCM_IV12_AUTH16_KDSHA256_SIGNONE: return SHA256;
+        case AES_128_GCM_IV12_AUTH16_KDSHA256_SIGNONE: return AWS_CRYPTOSDK_SHA256;
         case AES_256_GCM_IV12_AUTH16_KDNONE_SIGNONE:
         case AES_192_GCM_IV12_AUTH16_KDNONE_SIGNONE:
         case AES_128_GCM_IV12_AUTH16_KDNONE_SIGNONE:
-        default: return NOSHA;
+        default: return  AWS_CRYPTOSDK_NOSHA;
     }
 }
 
@@ -105,7 +105,7 @@ int aws_cryptosdk_derive_key(
     info[1] = alg_id & 0xFF;
     memcpy(&info[2], message_id, sizeof(info) - 2);
     enum aws_cryptosdk_sha_version which_sha = aws_cryptosdk_which_sha(props->alg_id);
-    if (which_sha == NOSHA) {
+    if (which_sha ==  AWS_CRYPTOSDK_NOSHA) {
         memcpy(content_key->keybuf, data_key->keybuf, props->data_key_len);
         return AWS_OP_SUCCESS;
     }

--- a/source/hkdf.c
+++ b/source/hkdf.c
@@ -22,8 +22,8 @@
 
 static const EVP_MD *aws_cryptosdk_which_sha(enum aws_cryptosdk_sha_version which_sha) {
     switch (which_sha) {
-        case SHA256: return EVP_sha256();
-        case SHA384: return EVP_sha384();
+        case AWS_CRYPTOSDK_SHA256: return EVP_sha256();
+        case AWS_CRYPTOSDK_SHA384: return EVP_sha384();
         default: return NULL;
     }
 }

--- a/tests/unit/t_hkdf.c
+++ b/tests/unit/t_hkdf.c
@@ -135,7 +135,7 @@ static const uint8_t tv_5_okm_desired[] = { 0xc8, 0xc9, 0x6e, 0x71, 0x0f, 0x89, 
 static const uint8_t tv_6_ikm[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
 
 struct hkdf_test_vectors tv[] = {
-    { .which_sha   = SHA256,
+    { .which_sha   = AWS_CRYPTOSDK_SHA256,
       .ikm         = tv_0_ikm,
       .ikm_len     = 22,
       .salt        = tv_0_salt,
@@ -145,7 +145,7 @@ struct hkdf_test_vectors tv[] = {
       .okm_desired = tv_0_okm_desired,
       .okm_len     = 42 },
 
-    { .which_sha   = SHA256,
+    { .which_sha   = AWS_CRYPTOSDK_SHA256,
       .ikm         = tv_1_ikm,
       .ikm_len     = 80,
       .salt        = tv_1_salt,
@@ -155,7 +155,7 @@ struct hkdf_test_vectors tv[] = {
       .okm_desired = tv_1_okm_desired,
       .okm_len     = 82 },
 
-    { .which_sha   = SHA256,
+    { .which_sha   = AWS_CRYPTOSDK_SHA256,
       .ikm         = tv_2_ikm,
       .ikm_len     = 22,
       .salt        = NULL,
@@ -165,7 +165,7 @@ struct hkdf_test_vectors tv[] = {
       .okm_desired = tv_2_okm_desired,
       .okm_len     = 42 },
 
-    { .which_sha   = SHA384,
+    { .which_sha   = AWS_CRYPTOSDK_SHA384,
       .ikm         = tv_3_ikm,
       .ikm_len     = 22,
       .salt        = tv_3_salt,
@@ -175,7 +175,7 @@ struct hkdf_test_vectors tv[] = {
       .okm_desired = tv_3_okm_desired,
       .okm_len     = 42 },
 
-    { .which_sha   = SHA384,
+    { .which_sha   = AWS_CRYPTOSDK_SHA384,
       .ikm         = tv_4_ikm,
       .ikm_len     = 80,
       .salt        = tv_4_salt,
@@ -185,7 +185,7 @@ struct hkdf_test_vectors tv[] = {
       .okm_desired = tv_4_okm_desired,
       .okm_len     = 82 },
 
-    { .which_sha   = SHA384,
+    { .which_sha   = AWS_CRYPTOSDK_SHA384,
       .ikm         = tv_5_ikm,
       .ikm_len     = 22,
       .salt        = NULL,
@@ -195,7 +195,7 @@ struct hkdf_test_vectors tv[] = {
       .okm_desired = tv_5_okm_desired,
       .okm_len     = 42 },
 
-    { .which_sha   = NOSHA,
+    { .which_sha   = AWS_CRYPTOSDK_NOSHA,
       .ikm         = tv_6_ikm,
       .ikm_len     = 10 },
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR includes a minor name change of the ``enum aws_cryptosdk_sha_version`` from ``SHA256/SHA384/NOSHA`` to`` AWS_CRYPTOSDK_SHA256/AWS_CRYPTOSDK_SHA384/AWS_CRYPTOSDK_NOSHA``, due to name collision with OPENSSL library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
