### PR TITLE
Add a cmake option to run a faster test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ set(USE_ASM TRUE
 set(SPECTRE_MITIGATIONS TRUE
     CACHE BOOL "Attempt to mitigate SPECTRE attacks, at a potential performance cost")
 
+set(REDUCE_TEST_ITERATIONS FALSE
+    CACHE BOOL "Reduce the number of iterations done on some exhaustive tests. This is particularly helpful when running under valgrind")
+
 option(VALGRIND_TEST_SUITE "Run the test suite under valgrind")
 set(VALGRIND_OPTIONS "" CACHE STRING "Additional options to pass to valgrind")
 
@@ -195,6 +198,10 @@ add_executable(unit-test-suite ${UNIT_TEST_SRC})
 target_link_libraries(unit-test-suite ${PROJECT_NAME} ${OPENSSL_LDFLAGS} testlib)
 set_target_properties(unit-test-suite PROPERTIES LINKER_LANGUAGE C C_STANDARD 99)
 target_include_directories(unit-test-suite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)
+
+if (REDUCE_TEST_ITERATIONS)
+    target_compile_definitions(unit-test-suite PRIVATE REDUCE_TEST_ITERATIONS)
+endif()
 
 add_executable(test_decrypt "tests/decrypt.c" ${TEST_LIB})
 target_link_libraries(test_decrypt ${PROJECT_NAME} ${OPENSSL_LDFLAGS} testlib)

--- a/tests/unit/t_cipher.c
+++ b/tests/unit/t_cipher.c
@@ -779,9 +779,13 @@ static const size_t test_sizes[] = {
     65535,
     65536,
     65537,
+#ifndef REDUCE_TEST_ITERATIONS
     1024*1024*64 - 1,
     1024*1024*64,
-    1024*1024*64 + 1
+    1024*1024*64 + 1,
+#endif
+    // Make sure we don't end the list with a conditonal entry, to avoid problems with trailing commas
+    42
 };
 
 static int test_encrypt_body() {

--- a/tests/unit/t_signature.c
+++ b/tests/unit/t_signature.c
@@ -124,12 +124,17 @@ static int t_signature_length() {
     FOREACH_ALGORITHM(props) {
         size_t len = props->signature_len;
         struct aws_string *pub_key, *sig;
+#ifndef REDUCE_TEST_ITERATIONS
+        const int iterations = 256;
+#else
+        const int iterations = 8;
+#endif
 
         /*
          * Normally, EC signatures have slightly non-deterministic length in DER encoding, make sure that
          * we've successfully made them deterministic
          */
-        for (int i = 0; i < 256; i++) {
+        for (int i = 0; i < iterations; i++) {
             size_t decoded_len;
             TEST_ASSERT_SUCCESS(sign_message(props, &pub_key, &sig, &test_cursor));
             TEST_ASSERT_SUCCESS(aws_base64_compute_decoded_len((const char *)aws_string_bytes(sig), sig->len, &decoded_len));
@@ -151,7 +156,13 @@ static int t_bad_signatures() {
         TEST_ASSERT_SUCCESS(sign_message(props, &pub_key, &sig, &test_cursor));
         uint8_t *buffer = (uint8_t *)aws_string_bytes(sig);
 
-        for (size_t i = 0; i < sig->len * 8; i++) {
+#ifndef REDUCE_TEST_ITERATIONS
+        const size_t increment = 1;
+#else
+        const size_t increment = 8;
+#endif
+
+        for (size_t i = 0; i < sig->len * 8; i += increment) {
             if (i < (sig->len - 1) * 8 && buffer[i/8 + 1] == '=') {
                 /* The last few bits before the "=" padding don't affect the base64-decoded signature. */
                 break;
@@ -201,7 +212,13 @@ static int t_corrupt_key() {
 
         uint8_t *buffer = (uint8_t *)aws_string_bytes(pub_key);
 
-        for (size_t i = 0; i < pub_key->len * 8; i++) {
+#ifndef REDUCE_TEST_ITERATIONS
+        const size_t increment = 1;
+#else
+        const size_t increment = 8;
+#endif
+
+        for (size_t i = 0; i < pub_key->len * 8; i += increment) {
             /* The base64 decoding logic ignores nonzero padding bits, so skip the last byte before an = */
             if (i < (pub_key->len - 1) * 8 && buffer[i / 8 + 1] == '=') {
                 continue;


### PR DESCRIPTION
With RUN_SLOW_TESTS=false, valgrind can run the full unit-test-suite in about
20 seconds.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
