### PR TITLE
Fix stray commas in CMakeLists.txt

### DIFF
--- a/aws-encryption-sdk-cpp/CMakeLists.txt
+++ b/aws-encryption-sdk-cpp/CMakeLists.txt
@@ -15,10 +15,10 @@
 
 # This is useful for CodeBuild tests since we want to avoid cases where KMS dependencies are missing and
 # we are not building aws-encryption-sdk-cpp.
-option(FORCE_KMS_KEYRING_BUILD, "Fail build if KMS Keyring dependencies are not satisfied")
+option(FORCE_KMS_KEYRING_BUILD "Fail build if KMS Keyring dependencies are not satisfied")
 
 # End-to-End tests might require special permissions
-option(AWS_ENC_SDK_END_TO_END_TESTS, "Enable End-to-End tests")
+option(AWS_ENC_SDK_END_TO_END_TESTS "Enable End-to-End tests")
 
 
 # By default we will try to build KMS Keyring only if we find AwsSdk


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

These stray commas cause variables "FORCE_KMS_KEYRING_BUILD," and
"AWS_ENC_SDK_END_TO_END_TESTS," to be defined and appear in the ccmake TUI (and
cmake GUI). They don't break the build, because the correct variables
FORCE_KMS_KEYRING_BUILD and AWS_ENC_SDK_END_TO_END_TESTS default to the same
value - false - but can confuse people looking at the TUIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
