### PR TITLE
Bug fix:  missing fclose() and memory leak in testutils.c file

### DIFF
--- a/tests/lib/testutil.c
+++ b/tests/lib/testutil.c
@@ -119,7 +119,6 @@ int test_loadfile(const char *filename, uint8_t **buf, size_t *datasize) {
         }
 
         *datasize = offset;
-        if (tmpbuf) free(tmpbuf);
         if (fp) fclose(fp);
         return 0;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
