### PR TITLE
Move KmsKeyring class to private header file, now Aws::Cryptosdk::Private::KmsKeyringImpl

### DIFF
--- a/aws-encryption-sdk-cpp/include/aws/cryptosdk/kms_keyring.h
+++ b/aws-encryption-sdk-cpp/include/aws/cryptosdk/kms_keyring.h
@@ -31,11 +31,9 @@
 
 namespace Aws {
 namespace Cryptosdk {
-
-class KmsKeyring : public aws_cryptosdk_keyring {
-  public:
+namespace KmsKeyring {
     class ClientSupplier;
-
+    
     /**
      * Helper class for building a new KmsKeyring object. You cannot construct a KmsKeyring directly
      * and must use this class instead. This class is the only API you need to interact with KmsKeyrings.
@@ -148,97 +146,6 @@ class KmsKeyring : public aws_cryptosdk_keyring {
         std::shared_ptr<ClientSupplier> client_supplier;
     };
 
-    ~KmsKeyring();
-    // non-copyable
-    KmsKeyring(const KmsKeyring &) = delete;
-    KmsKeyring &operator=(const KmsKeyring &) = delete;
-
-  protected:
-    /**
-     * Constructor of KmsKeyring for internal use only. Use KmsKeyring::Builder to make a new KmsKeyring.
-     *
-     * @param key_ids List of KMS customer master keys (CMK)
-     * @param grant_tokens A list of grant tokens.
-     * @param default_region Region used for non-ARN key IDs.
-     * @param supplier Object that supplies the KMSClient instances to use for each region.
-     */
-    KmsKeyring(
-        const Aws::Vector<Aws::String> &key_ids,
-        const String &default_region,
-        const Aws::Vector<Aws::String> &grant_tokens,
-        std::shared_ptr<ClientSupplier> supplier);
-
-    /**
-     * This is the function that will be called virtually by calling aws_cryptosdk_keyring_on_decrypt
-     * on the KmsKeyring pointer. See aws_cryptosdk_keyring_on_decrypt in
-     * include/aws/cryptosdk/materials.h for general information on this interface.
-     */
-    static int OnDecrypt(struct aws_cryptosdk_keyring *keyring,
-                         struct aws_allocator *request_alloc,
-                         struct aws_byte_buf *unencrypted_data_key,
-                         const struct aws_array_list *edks,
-                         const struct aws_hash_table *enc_context,
-                         enum aws_cryptosdk_alg_id alg);
-
-    /**
-     * This is the function that will be called virtually by calling aws_cryptosdk_keyring_on_encrypt
-     * on the KmsKeyring pointer. See aws_cryptosdk_keyring_on_encrypt in
-     * include/aws/cryptosdk/materials.h for general information on this interface.
-     */
-    static int OnEncrypt(struct aws_cryptosdk_keyring *keyring,
-                         struct aws_allocator *request_alloc,
-                         struct aws_byte_buf *unencrypted_data_key,
-                         struct aws_array_list *edks,
-                         const struct aws_hash_table *enc_context,
-                         enum aws_cryptosdk_alg_id alg);
-
-    /**
-     * This is the function that will be called virtually by calling aws_cryptosdk_keyring_release
-     * on the KmsKeyring pointer. See aws_cryptosdk_keyring_release in
-     * include/aws/cryptosdk/materials.h for general information on this interface.
-     */
-    static void DestroyAwsCryptoKeyring(aws_cryptosdk_keyring *keyring);
-
-    /**
-     * Creates a new KMS Encrypt request
-     */
-    Aws::KMS::Model::EncryptRequest CreateEncryptRequest(const Aws::String &key_id,
-                                                         const Aws::Vector<Aws::String> &grant_tokens,
-                                                         const Utils::ByteBuffer &plaintext,
-                                                         const Aws::Map<Aws::String,
-                                                                        Aws::String> &encryption_context) const;
-
-    /**
-     * Creates a new KMS Decrypt request
-     */
-    Aws::KMS::Model::DecryptRequest CreateDecryptRequest(const Aws::Vector<Aws::String> &grant_tokens,
-                                                         const Utils::ByteBuffer &ciphertext,
-                                                         const Aws::Map<Aws::String,
-                                                                        Aws::String> &encryption_context) const;
-
-    /**
-     * Creates a new KMS Generate Data Key request
-     */
-    Aws::KMS::Model::GenerateDataKeyRequest CreateGenerateDataKeyRequest(
-        const Aws::String &key_id,
-        const Aws::Vector<Aws::String> &grant_tokens,
-        int number_of_bytes,
-        const Aws::Map<Aws::String, Aws::String> &encryption_context) const;
-
-    /**
-     * Returns the KMS Client for a specific key ID
-     */
-    std::shared_ptr<KMS::KMSClient> GetKmsClient(const Aws::String &key_id) const;
-
-  private:
-    const aws_byte_buf key_provider;
-    std::shared_ptr<ClientSupplier> kms_client_supplier;
-
-    const Aws::String default_region;  // if no region can be extracted from key_id this will be used as default
-    Aws::Vector<Aws::String> grant_tokens;
-    Aws::Vector<Aws::String> key_ids;
-
-  public:
     /**
      * Provides KMS clients in multiple regions, and allows caching of clients between
      * multiple KMS keyrings.

--- a/aws-encryption-sdk-cpp/include/aws/cryptosdk/private/kms_keyring.h
+++ b/aws-encryption-sdk-cpp/include/aws/cryptosdk/private/kms_keyring.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef AWS_ENCRYPTION_SDK_PRIVATE_KMS_KEYRING_H
+#define AWS_ENCRYPTION_SDK_PRIVATE_KMS_KEYRING_H
+
+#include <aws/cryptosdk/kms_keyring.h>
+
+namespace Aws {
+namespace Cryptosdk {
+namespace Private {
+
+class KmsKeyringImpl : public aws_cryptosdk_keyring {
+  public:
+    ~KmsKeyringImpl();
+    // non-copyable
+    KmsKeyringImpl(const KmsKeyringImpl &) = delete;
+    KmsKeyringImpl &operator=(const KmsKeyringImpl &) = delete;
+
+  protected:
+    /**
+     * Constructor of KmsKeyring for internal use only. Use KmsKeyring::Builder to make a new KmsKeyring.
+     *
+     * @param key_ids List of KMS customer master keys (CMK)
+     * @param grant_tokens A list of grant tokens.
+     * @param default_region Region used for non-ARN key IDs.
+     * @param supplier Object that supplies the KMSClient instances to use for each region.
+     */
+    KmsKeyringImpl(
+        const Aws::Vector<Aws::String> &key_ids,
+        const String &default_region,
+        const Aws::Vector<Aws::String> &grant_tokens,
+        std::shared_ptr<Aws::Cryptosdk::KmsKeyring::ClientSupplier> supplier);
+
+    /**
+     * This is the function that will be called virtually by calling aws_cryptosdk_keyring_on_decrypt
+     * on the KmsKeyring pointer. See aws_cryptosdk_keyring_on_decrypt in
+     * include/aws/cryptosdk/materials.h for general information on this interface.
+     */
+    static int OnDecrypt(struct aws_cryptosdk_keyring *keyring,
+                         struct aws_allocator *request_alloc,
+                         struct aws_byte_buf *unencrypted_data_key,
+                         const struct aws_array_list *edks,
+                         const struct aws_hash_table *enc_context,
+                         enum aws_cryptosdk_alg_id alg);
+
+    /**
+     * This is the function that will be called virtually by calling aws_cryptosdk_keyring_on_encrypt
+     * on the KmsKeyring pointer. See aws_cryptosdk_keyring_on_encrypt in
+     * include/aws/cryptosdk/materials.h for general information on this interface.
+     */
+    static int OnEncrypt(struct aws_cryptosdk_keyring *keyring,
+                         struct aws_allocator *request_alloc,
+                         struct aws_byte_buf *unencrypted_data_key,
+                         struct aws_array_list *edks,
+                         const struct aws_hash_table *enc_context,
+                         enum aws_cryptosdk_alg_id alg);
+
+    /**
+     * This is the function that will be called virtually by calling aws_cryptosdk_keyring_release
+     * on the KmsKeyring pointer. See aws_cryptosdk_keyring_release in
+     * include/aws/cryptosdk/materials.h for general information on this interface.
+     */
+    static void DestroyAwsCryptoKeyring(aws_cryptosdk_keyring *keyring);
+
+    /**
+     * Creates a new KMS Encrypt request
+     */
+    Aws::KMS::Model::EncryptRequest CreateEncryptRequest(const Aws::String &key_id,
+                                                         const Aws::Vector<Aws::String> &grant_tokens,
+                                                         const Utils::ByteBuffer &plaintext,
+                                                         const Aws::Map<Aws::String,
+                                                                        Aws::String> &encryption_context) const;
+
+    /**
+     * Creates a new KMS Decrypt request
+     */
+    Aws::KMS::Model::DecryptRequest CreateDecryptRequest(const Aws::Vector<Aws::String> &grant_tokens,
+                                                         const Utils::ByteBuffer &ciphertext,
+                                                         const Aws::Map<Aws::String,
+                                                                        Aws::String> &encryption_context) const;
+
+    /**
+     * Creates a new KMS Generate Data Key request
+     */
+    Aws::KMS::Model::GenerateDataKeyRequest CreateGenerateDataKeyRequest(
+        const Aws::String &key_id,
+        const Aws::Vector<Aws::String> &grant_tokens,
+        int number_of_bytes,
+        const Aws::Map<Aws::String, Aws::String> &encryption_context) const;
+
+    /**
+     * Returns the KMS Client for a specific key ID
+     */
+    std::shared_ptr<KMS::KMSClient> GetKmsClient(const Aws::String &key_id) const;
+
+  private:
+    const aws_byte_buf key_provider;
+    std::shared_ptr<Aws::Cryptosdk::KmsKeyring::ClientSupplier> kms_client_supplier;
+
+    const Aws::String default_region;  // if no region can be extracted from key_id this will be used as default
+    Aws::Vector<Aws::String> grant_tokens;
+    Aws::Vector<Aws::String> key_ids;
+};
+
+}  // namespace Private
+}  // namespace Cryptosdk
+}  // namespace Aws
+
+#endif // AWS_ENCRYPTION_SDK_PRIVATE_KMS_KEYRING_H

--- a/aws-encryption-sdk-cpp/source/kms_keyring.cpp
+++ b/aws-encryption-sdk-cpp/source/kms_keyring.cpp
@@ -12,7 +12,7 @@
  * implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <aws/cryptosdk/kms_keyring.h>
+#include <aws/cryptosdk/private/kms_keyring.h>
 
 #include <stddef.h>
 #include <stdlib.h>
@@ -41,18 +41,18 @@ using Private::append_key_dup_to_edks;
 static const char *AWS_CRYPTO_SDK_KMS_CLASS_TAG = "KmsKeyring";
 static const char *KEY_PROVIDER_STR = "aws-kms";
 
-void KmsKeyring::DestroyAwsCryptoKeyring(struct aws_cryptosdk_keyring *keyring) {
-    auto keyring_data_ptr = static_cast<Aws::Cryptosdk::KmsKeyring *>(keyring);
+void Private::KmsKeyringImpl::DestroyAwsCryptoKeyring(struct aws_cryptosdk_keyring *keyring) {
+    auto keyring_data_ptr = static_cast<Aws::Cryptosdk::Private::KmsKeyringImpl *>(keyring);
     Aws::Delete(keyring_data_ptr);
 }
 
-int KmsKeyring::OnDecrypt(struct aws_cryptosdk_keyring *keyring,
-                          struct aws_allocator *request_alloc,
-                          struct aws_byte_buf *unencrypted_data_key,
-                          const struct aws_array_list *edks,
-                          const struct aws_hash_table *enc_context,
-                          enum aws_cryptosdk_alg_id alg) {
-    auto self = static_cast<Aws::Cryptosdk::KmsKeyring *>(keyring);
+int Private::KmsKeyringImpl::OnDecrypt(struct aws_cryptosdk_keyring *keyring,
+                                       struct aws_allocator *request_alloc,
+                                       struct aws_byte_buf *unencrypted_data_key,
+                                       const struct aws_array_list *edks,
+                                       const struct aws_hash_table *enc_context,
+                                       enum aws_cryptosdk_alg_id alg) {
+    auto self = static_cast<Aws::Cryptosdk::Private::KmsKeyringImpl *>(keyring);
     if (!self || !request_alloc || !unencrypted_data_key || !edks || !enc_context) {
         abort();
     }
@@ -127,12 +127,12 @@ int KmsKeyring::OnDecrypt(struct aws_cryptosdk_keyring *keyring,
     return AWS_OP_SUCCESS;
 }
 
-int KmsKeyring::OnEncrypt(struct aws_cryptosdk_keyring *keyring,
-                          struct aws_allocator *request_alloc,
-                          struct aws_byte_buf *unencrypted_data_key,
-                          struct aws_array_list *edk_list,
-                          const struct aws_hash_table *enc_context,
-                          enum aws_cryptosdk_alg_id alg) {
+int Private::KmsKeyringImpl::OnEncrypt(struct aws_cryptosdk_keyring *keyring,
+                                   struct aws_allocator *request_alloc,
+                                   struct aws_byte_buf *unencrypted_data_key,
+                                   struct aws_array_list *edk_list,
+                                   const struct aws_hash_table *enc_context,
+                                   enum aws_cryptosdk_alg_id alg) {
     // Class that prevents memory leak of aws_list (even if a function throws)
     // When the object will be destroyed it will call aws_cryptosdk_edk_list_clean_up
     class EdksRaii {
@@ -155,7 +155,7 @@ int KmsKeyring::OnEncrypt(struct aws_cryptosdk_keyring *keyring,
     if (!keyring || !request_alloc || !unencrypted_data_key || !edk_list || !enc_context) {
         abort();
     }
-    auto self = static_cast<Aws::Cryptosdk::KmsKeyring *>(keyring);
+    auto self = static_cast<Aws::Cryptosdk::Private::KmsKeyringImpl *>(keyring);
 
     /* When no key IDs are configured, i.e. "discovery mode", this function is a no-op. */
     if (!self->key_ids.size()) {
@@ -257,13 +257,13 @@ out:
     return rv;
 }
 
-Aws::Cryptosdk::KmsKeyring::~KmsKeyring() {
+Aws::Cryptosdk::Private::KmsKeyringImpl::~KmsKeyringImpl() {
 }
 
-Aws::Cryptosdk::KmsKeyring::KmsKeyring(const Aws::Vector<Aws::String> &key_ids,
-                                       const String &default_region,
-                                       const Aws::Vector<Aws::String> &grant_tokens,
-                                       std::shared_ptr<ClientSupplier> client_supplier)
+Aws::Cryptosdk::Private::KmsKeyringImpl::KmsKeyringImpl(const Aws::Vector<Aws::String> &key_ids,
+                                                        const String &default_region,
+                                                        const Aws::Vector<Aws::String> &grant_tokens,
+                                                        std::shared_ptr<Aws::Cryptosdk::KmsKeyring::ClientSupplier> client_supplier)
     : key_provider(aws_byte_buf_from_c_str(KEY_PROVIDER_STR)),
       kms_client_supplier(client_supplier),
       default_region(default_region),
@@ -273,19 +273,19 @@ Aws::Cryptosdk::KmsKeyring::KmsKeyring(const Aws::Vector<Aws::String> &key_ids,
     static const aws_cryptosdk_keyring_vt kms_keyring_vt = {
         sizeof(struct aws_cryptosdk_keyring_vt),  // size
         KEY_PROVIDER_STR,  // name
-        &KmsKeyring::DestroyAwsCryptoKeyring,  // destroy callback
-        &KmsKeyring::OnEncrypt, // on_encrypt callback
-        &KmsKeyring::OnDecrypt  // on_decrypt callback
+        &Private::KmsKeyringImpl::DestroyAwsCryptoKeyring,  // destroy callback
+        &Private::KmsKeyringImpl::OnEncrypt, // on_encrypt callback
+        &Private::KmsKeyringImpl::OnDecrypt  // on_decrypt callback
     };
 
     aws_cryptosdk_keyring_base_init(this, &kms_keyring_vt);
 }
 
-Aws::KMS::Model::EncryptRequest KmsKeyring::CreateEncryptRequest(const Aws::String &key_id,
-                                                                 const Aws::Vector<Aws::String> &grant_tokens,
-                                                                 const Utils::ByteBuffer &plaintext,
-                                                                 const Aws::Map<Aws::String,
-                                                                                Aws::String> &encryption_context) const {
+Aws::KMS::Model::EncryptRequest Private::KmsKeyringImpl::CreateEncryptRequest(const Aws::String &key_id,
+                                                                              const Aws::Vector<Aws::String> &grant_tokens,
+                                                                              const Utils::ByteBuffer &plaintext,
+                                                                              const Aws::Map<Aws::String,
+                                                                              Aws::String> &encryption_context) const {
     KMS::Model::EncryptRequest encryption_request;
     encryption_request.SetKeyId(key_id);
     encryption_request.SetPlaintext(plaintext);
@@ -296,10 +296,10 @@ Aws::KMS::Model::EncryptRequest KmsKeyring::CreateEncryptRequest(const Aws::Stri
     return encryption_request;
 }
 
-Aws::KMS::Model::DecryptRequest KmsKeyring::CreateDecryptRequest(const Aws::Vector<Aws::String> &grant_tokens,
-                                                                 const Utils::ByteBuffer &ciphertext,
-                                                                 const Aws::Map<Aws::String,
-                                                                                Aws::String> &encryption_context) const {
+Aws::KMS::Model::DecryptRequest Private::KmsKeyringImpl::CreateDecryptRequest(const Aws::Vector<Aws::String> &grant_tokens,
+                                                                              const Utils::ByteBuffer &ciphertext,
+                                                                              const Aws::Map<Aws::String,
+                                                                              Aws::String> &encryption_context) const {
     KMS::Model::DecryptRequest request;
     request.SetCiphertextBlob(ciphertext);
 
@@ -309,7 +309,7 @@ Aws::KMS::Model::DecryptRequest KmsKeyring::CreateDecryptRequest(const Aws::Vect
     return request;
 }
 
-Aws::KMS::Model::GenerateDataKeyRequest KmsKeyring::CreateGenerateDataKeyRequest(
+Aws::KMS::Model::GenerateDataKeyRequest Private::KmsKeyringImpl::CreateGenerateDataKeyRequest(
     const Aws::String &key_id,
     const Aws::Vector<Aws::String> &grant_tokens,
     int number_of_bytes,
@@ -346,7 +346,7 @@ std::shared_ptr<KMS::KMSClient> KmsKeyring::SingleClientSupplier::GetClient(cons
 }
 
 std::shared_ptr<KmsKeyring::CachingClientSupplier> KmsKeyring::CachingClientSupplier::Create() {
-    return Aws::MakeShared<CachingClientSupplier>(AWS_CRYPTO_SDK_KMS_CLASS_TAG);
+    return Aws::MakeShared<KmsKeyring::CachingClientSupplier>(AWS_CRYPTO_SDK_KMS_CLASS_TAG);
 }
 
 std::shared_ptr<KMS::KMSClient> KmsKeyring::CachingClientSupplier::GetClient(const Aws::String &region, std::function<void()> &report_success) {
@@ -418,16 +418,16 @@ bool KmsKeyring::Builder::ValidParameters(const Aws::Vector<Aws::String> &key_id
  * would allow creation of a KmsKeyring without the builder. The solution was to make a nested
  * class in the builder which is just the KmsKeyring with a public constructor.
  */
-class KmsKeyringWithPublicConstructor : public KmsKeyring {
+class KmsKeyringWithPublicConstructor : public Private::KmsKeyringImpl {
 public:
     KmsKeyringWithPublicConstructor(const Aws::Vector<Aws::String> &key_ids,
                                     const String &default_region,
                                     const Aws::Vector<Aws::String> &grant_tokens,
-                                    std::shared_ptr<ClientSupplier> client_supplier) :
-        KmsKeyring(key_ids,
-                   default_region,
-                   grant_tokens,
-                   client_supplier) {}
+                                    std::shared_ptr<Aws::Cryptosdk::KmsKeyring::ClientSupplier> client_supplier) :
+        KmsKeyringImpl(key_ids,
+                       default_region,
+                       grant_tokens,
+                       client_supplier) {}
 };
 
 aws_cryptosdk_keyring *KmsKeyring::Builder::Build(const Aws::Vector<Aws::String> &key_ids) const {
@@ -467,7 +467,7 @@ KmsKeyring::Builder &KmsKeyring::Builder::WithGrantToken(const Aws::String &gran
     return *this;
 }
 
-KmsKeyring::Builder &KmsKeyring::Builder::WithClientSupplier(const std::shared_ptr<ClientSupplier> &client_supplier) {
+KmsKeyring::Builder &KmsKeyring::Builder::WithClientSupplier(const std::shared_ptr<KmsKeyring::ClientSupplier> &client_supplier) {
     this->client_supplier = client_supplier;
     return *this;
 }

--- a/aws-encryption-sdk-cpp/tests/unit/t_kms_keyring.cpp
+++ b/aws-encryption-sdk-cpp/tests/unit/t_kms_keyring.cpp
@@ -14,7 +14,7 @@
  */
 
 #include <aws/cryptosdk/enc_context.h>
-#include <aws/cryptosdk/kms_keyring.h>
+#include <aws/cryptosdk/private/kms_keyring.h>
 #include <aws/cryptosdk/private/cpputils.h>
 
 #include <aws/common/array_list.h>
@@ -35,7 +35,7 @@ const char *CLASS_TAG = "KMS_MASTER_KEY_CTAG";
 /**
  * Changes access control for some protected members from KmsCMasterKey for testing purposes
  */
-struct KmsKeyringExposer : Aws::Cryptosdk::KmsKeyring {
+struct KmsKeyringExposer : Aws::Cryptosdk::Private::KmsKeyringImpl {
   protected:
     KmsKeyringExposer(std::shared_ptr<Aws::KMS::KMSClient> kms,
                         const Aws::String &key_id)
@@ -45,17 +45,17 @@ struct KmsKeyringExposer : Aws::Cryptosdk::KmsKeyring {
                         const Aws::Vector<Aws::String> &key_ids,
                         const Aws::Vector<Aws::String> &grant_tokens = { }
                         )
-        : KmsKeyring(key_ids,
-                     "default_region",
-                     grant_tokens,
-                     Aws::MakeShared<SingleClientSupplier>("KMS_EXPOSER", kms)) {
+        : KmsKeyringImpl(key_ids,
+                         "default_region",
+                         grant_tokens,
+                         Aws::MakeShared<Aws::Cryptosdk::KmsKeyring::SingleClientSupplier>("KMS_EXPOSER", kms)) {
     }
   public:
-    using KmsKeyring::OnEncrypt;
-    using KmsKeyring::OnDecrypt;
-    using KmsKeyring::CreateEncryptRequest;
-    using KmsKeyring::CreateDecryptRequest;
-    using KmsKeyring::CreateGenerateDataKeyRequest;
+    using KmsKeyringImpl::OnEncrypt;
+    using KmsKeyringImpl::OnDecrypt;
+    using KmsKeyringImpl::CreateEncryptRequest;
+    using KmsKeyringImpl::CreateDecryptRequest;
+    using KmsKeyringImpl::CreateGenerateDataKeyRequest;
 
     template<typename T, typename ...ArgTypes>
     friend T *Aws::New(const char *allocationTag, ArgTypes &&... args);


### PR DESCRIPTION
    Aws::Cryptosdk::KmsKeyring is now a namespace including only client supplier and builder

    No functional or API changes at all in this commit, as evidenced by the fact that
    integration tests are unchanged. Unit tests had to be changed only to access the private
    implementation in the new namespace.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
