### PR TITLE
Get rid of protected constructor/public constructor hack in builder

### DIFF
--- a/aws-encryption-sdk-cpp/include/aws/cryptosdk/kms_keyring.h
+++ b/aws-encryption-sdk-cpp/include/aws/cryptosdk/kms_keyring.h
@@ -33,7 +33,7 @@ namespace Aws {
 namespace Cryptosdk {
 namespace KmsKeyring {
     class ClientSupplier;
-    
+
     /**
      * Helper class for building a new KmsKeyring object. You cannot construct a KmsKeyring directly
      * and must use this class instead. This class is the only API you need to interact with KmsKeyrings.

--- a/aws-encryption-sdk-cpp/include/aws/cryptosdk/private/kms_keyring.h
+++ b/aws-encryption-sdk-cpp/include/aws/cryptosdk/private/kms_keyring.h
@@ -28,7 +28,6 @@ class KmsKeyringImpl : public aws_cryptosdk_keyring {
     KmsKeyringImpl(const KmsKeyringImpl &) = delete;
     KmsKeyringImpl &operator=(const KmsKeyringImpl &) = delete;
 
-  protected:
     /**
      * Constructor of KmsKeyring for internal use only. Use KmsKeyring::Builder to make a new KmsKeyring.
      *
@@ -43,6 +42,7 @@ class KmsKeyringImpl : public aws_cryptosdk_keyring {
         const Aws::Vector<Aws::String> &grant_tokens,
         std::shared_ptr<Aws::Cryptosdk::KmsKeyring::ClientSupplier> supplier);
 
+  protected:
     /**
      * This is the function that will be called virtually by calling aws_cryptosdk_keyring_on_decrypt
      * on the KmsKeyring pointer. See aws_cryptosdk_keyring_on_decrypt in

--- a/aws-encryption-sdk-cpp/source/kms_keyring.cpp
+++ b/aws-encryption-sdk-cpp/source/kms_keyring.cpp
@@ -406,50 +406,26 @@ bool KmsKeyring::Builder::ValidParameters(const Aws::Vector<Aws::String> &key_id
     return true;
 }
 
-/**
- * FIXME: No longer a nested class, but we don't necessarily need this once we take the entire
- * implementation of the KmsKeyring class out of the public header file. Update this comment
- * after reorganization.
- *
- * We want to allow construction of a KmsKeyring object only through the builder, which is why
- * KmsKeyring has a protected constructor. Doing this allows us to guarantee that it is always
- * allocated with Aws::New. However, Aws::New only allocates memory for classes that have public
- * constructors or for which Aws::New is a friend function. Making Aws::New a friend function
- * would allow creation of a KmsKeyring without the builder. The solution was to make a nested
- * class in the builder which is just the KmsKeyring with a public constructor.
- */
-class KmsKeyringWithPublicConstructor : public Private::KmsKeyringImpl {
-public:
-    KmsKeyringWithPublicConstructor(const Aws::Vector<Aws::String> &key_ids,
-                                    const String &default_region,
-                                    const Aws::Vector<Aws::String> &grant_tokens,
-                                    std::shared_ptr<Aws::Cryptosdk::KmsKeyring::ClientSupplier> client_supplier) :
-        KmsKeyringImpl(key_ids,
-                       default_region,
-                       grant_tokens,
-                       client_supplier) {}
-};
-
 aws_cryptosdk_keyring *KmsKeyring::Builder::Build(const Aws::Vector<Aws::String> &key_ids) const {
     if (!ValidParameters(key_ids)) {
         aws_raise_error(AWS_CRYPTOSDK_ERR_KMS_FAILURE);
         return NULL;
     }
 
-    return Aws::New<KmsKeyringWithPublicConstructor>(AWS_CRYPTO_SDK_KMS_CLASS_TAG,
-                                                     key_ids,
-                                                     default_region,
-                                                     grant_tokens,
-                                                     BuildClientSupplier(key_ids));
+    return Aws::New<Private::KmsKeyringImpl>(AWS_CRYPTO_SDK_KMS_CLASS_TAG,
+                                             key_ids,
+                                             default_region,
+                                             grant_tokens,
+                                             BuildClientSupplier(key_ids));
 }
 
 aws_cryptosdk_keyring *KmsKeyring::Builder::BuildDiscovery() const {
     Aws::Vector<Aws::String> empty_key_ids_list;
-    return Aws::New<KmsKeyringWithPublicConstructor>(AWS_CRYPTO_SDK_KMS_CLASS_TAG,
-                                                     empty_key_ids_list,
-                                                     default_region,
-                                                     grant_tokens,
-                                                     BuildClientSupplier(empty_key_ids_list));
+    return Aws::New<Private::KmsKeyringImpl>(AWS_CRYPTO_SDK_KMS_CLASS_TAG,
+                                             empty_key_ids_list,
+                                             default_region,
+                                             grant_tokens,
+                                             BuildClientSupplier(empty_key_ids_list));
 }
     
 KmsKeyring::Builder &KmsKeyring::Builder::WithDefaultRegion(const String &default_region) {


### PR DESCRIPTION
Not needed anymore since KMS keyring class is no longer in public header

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
