### PR TITLE
Fix KMS builder API inconsistency

### DIFF
--- a/aws-encryption-sdk-cpp/include/aws/cryptosdk/kms_keyring.h
+++ b/aws-encryption-sdk-cpp/include/aws/cryptosdk/kms_keyring.h
@@ -78,7 +78,7 @@ namespace KmsKeyring {
          * KmsKeyring will use only this KMS Client. Note that this is only suitable if all
          * KMS keys are in one region. If this is set then the client supplier parameter is ignored.
          */
-        Builder &WithKmsClient(std::shared_ptr<KMS::KMSClient> kms_client);
+        Builder &WithKmsClient(const std::shared_ptr<KMS::KMSClient> &kms_client);
 
         /**
          * Creates a new KmsKeyring object or returns NULL if parameters are invalid.

--- a/aws-encryption-sdk-cpp/source/kms_keyring.cpp
+++ b/aws-encryption-sdk-cpp/source/kms_keyring.cpp
@@ -430,7 +430,7 @@ KmsKeyring::Builder &KmsKeyring::Builder::WithClientSupplier(const std::shared_p
     return *this;
 }
 
-KmsKeyring::Builder &KmsKeyring::Builder::WithKmsClient(std::shared_ptr<KMS::KMSClient> kms_client) {
+KmsKeyring::Builder &KmsKeyring::Builder::WithKmsClient(const std::shared_ptr<KMS::KMSClient> &kms_client) {
     this->kms_client = kms_client;
     return *this;
 }


### PR DESCRIPTION
https://github.com/awslabs/aws-encryption-sdk-c/issues/219



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
