### PR TITLE
define the cache.h guard

### DIFF
--- a/include/aws/cryptosdk/cache.h
+++ b/include/aws/cryptosdk/cache.h
@@ -16,11 +16,11 @@
 #ifndef AWS_CRYPTOSDK_CACHE_H
 #define AWS_CRYPTOSDK_CACHE_H
 
-#    include <aws/common/clock.h>
+#include <aws/common/clock.h>
 
-#    include <aws/cryptosdk/exports.h>
-#    include <aws/cryptosdk/materials.h>
-#    include <aws/cryptosdk/vtable.h>
+#include <aws/cryptosdk/exports.h>
+#include <aws/cryptosdk/materials.h>
+#include <aws/cryptosdk/vtable.h>
 
 /**
  * @defgroup caching Caching APIs
@@ -50,21 +50,21 @@
  * @{
  */
 
-#    define AWS_CRYPTOSDK_CACHE_MAX_LIMIT_MESSAGES ((uint64_t)1 << 32)
+#define AWS_CRYPTOSDK_CACHE_MAX_LIMIT_MESSAGES ((uint64_t)1 << 32)
 
 /**
  * The backing materials cache that stores the cached materials for one or more caching CMMs.
  */
-#    ifdef AWS_CRYPTOSDK_DOXYGEN
+#ifdef AWS_CRYPTOSDK_DOXYGEN
 struct aws_cryptosdk_mat_cache;
-#    else
+#else
 struct aws_cryptosdk_mat_cache {
     struct aws_atomic_var refcount;
     const struct aws_cryptosdk_mat_cache_vt *vt;
 };
-#    endif
+#endif
 
-#    ifndef AWS_CRYPTOSDK_DOXYGEN
+#ifndef AWS_CRYPTOSDK_DOXYGEN
 /**
  * NOTE: The extension API for defining new materials cache is currently considered unstable and
  * may change in the future.
@@ -436,7 +436,7 @@ void aws_cryptosdk_mat_cache_entry_ttl_hint(
     }
 }
 
-#    endif  // AWS_CRYPTOSDK_DOXYGEN (unstable APIs excluded from docs)
+#endif  // AWS_CRYPTOSDK_DOXYGEN (unstable APIs excluded from docs)
 
 /**
  * Creates a new instance of the built-in local materials cache. This cache is thread safe, and uses a simple


### PR DESCRIPTION
The cache.h is currently missing an include guard.  Adding one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
