### PR TITLE
Make BuildClientSupplier static instead of class method

### DIFF
--- a/aws-encryption-sdk-cpp/include/aws/cryptosdk/cpp/kms_keyring.h
+++ b/aws-encryption-sdk-cpp/include/aws/cryptosdk/cpp/kms_keyring.h
@@ -144,9 +144,6 @@ class AWS_CRYPTOSDK_CPP_API Builder {
      */
     aws_cryptosdk_keyring *BuildDiscovery() const;
 
-   protected:
-    std::shared_ptr<ClientSupplier> BuildClientSupplier(const Aws::Vector<Aws::String> &key_ids) const;
-
    private:
     std::shared_ptr<KMS::KMSClient> kms_client;
     Aws::Vector<Aws::String> grant_tokens;

--- a/aws-encryption-sdk-cpp/tests/unit/t_kms_keyring.cpp
+++ b/aws-encryption-sdk-cpp/tests/unit/t_kms_keyring.cpp
@@ -677,29 +677,8 @@ int generateDataKey_kmsFails_returnFailure() {
     return 0;
 }
 
-// exposes protected members
-struct KmsKeyringBuilderExposer : KmsKeyring::Builder {
-   public:
-    using KmsKeyring::Builder::BuildClientSupplier;
-};
-
-int testBuilder_buildClientSupplier_buildsClient() {
-    KmsKeyringBuilderExposer a;
-    TEST_ASSERT(
-        dynamic_cast<KmsKeyring::CachingClientSupplier *>(
-            a.BuildClientSupplier({ "arn:aws:kms:region1:", "arn:aws:kms:region2:" }).get()) != NULL);
-
-    TestValues tv;
-    a.WithKmsClient(tv.kms_client_mock);
-    TEST_ASSERT(
-        dynamic_cast<KmsKeyring::SingleClientSupplier *>(a.BuildClientSupplier({ "arn:aws:kms:region:" }).get()) !=
-        NULL);
-
-    return 0;
-}
-
 int testBuilder_keyWithRegion_valid() {
-    KmsKeyringBuilderExposer a;
+    KmsKeyring::Builder a;
     aws_cryptosdk_keyring *k = a.Build("arn:aws:kms:region_extracted_from_key:");
     TEST_ASSERT_ADDR_NOT_NULL(k);
     aws_cryptosdk_keyring_release(k);
@@ -707,13 +686,13 @@ int testBuilder_keyWithRegion_valid() {
 }
 
 int testBuilder_keyWithoutRegion_invalid() {
-    KmsKeyringBuilderExposer a;
+    KmsKeyring::Builder a;
     TEST_ASSERT_ADDR_NULL(a.Build("alias/foobar"));
     return 0;
 }
 
 int testBuilder_emptyKey_invalid() {
-    KmsKeyringBuilderExposer a;
+    KmsKeyring::Builder a;
     TEST_ASSERT_ADDR_NULL(a.Build(""));
     return 0;
 }
@@ -753,7 +732,6 @@ int main() {
     RUN_TEST(generateDataKey_validInputs_returnSuccess());
     RUN_TEST(generateDataKey_validInputsWithGrantTokensAndEncContext_returnSuccess());
     RUN_TEST(generateDataKey_kmsFails_returnFailure());
-    RUN_TEST(testBuilder_buildClientSupplier_buildsClient());
     RUN_TEST(testBuilder_keyWithRegion_valid());
     RUN_TEST(testBuilder_keyWithoutRegion_invalid());
     RUN_TEST(testBuilder_emptyKey_invalid());


### PR DESCRIPTION
This is a private implementation detail that doesn't need to be part of public
interface of KMS keyring.

A now unnecessary test was taken out of the KMS keyring unit tests. Note that we still
have full code coverage of the static BuildClientSupplier method:

t_integration_kms_keyring.cpp:78 : build keyring using WithKmsClient
t_integration_kms_keyring.cpp:102 : build keyring with kms_client = NULL and one CMK
t_integration_kms_keyring.cpp:131 : build keyring with kms_client = NULL and multiple CMKs
t_integration_kms_keyring.cpp:441 : build keyring using WithClientSupplier


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
