### PR TITLE
Removed absolute paths from documentation for struct generated from line

### DIFF
--- a/doxygen/doxygen.config.in
+++ b/doxygen/doxygen.config.in
@@ -27,7 +27,7 @@ ABBREVIATE_BRIEF       = "The $name class" \
                          the
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 STRIP_FROM_PATH        = 
 STRIP_FROM_INC_PATH    = 
 SHORT_NAMES            = NO


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
 For example: 

The documentation for this struct was generated from the following file:
`keyring_trace.h`

instead of: 

The documentation for this struct was generated from the following file:
  `  /workspace/github/aws-encryption-sdk-c/include/aws/cryptosdk/keyring_trace.h`



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
