### PR TITLE
Implement a harness for serialize in framefmt.c

### DIFF
--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -1,6 +1,3 @@
-#ifndef AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H
-#define AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H
-
 /*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -15,6 +12,8 @@
  * implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#pragma once
 
 #include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
@@ -39,6 +38,3 @@ void ensure_sig_ctx_has_allocated_members(struct aws_cryptosdk_sig_ctx *ctx);
  * [aws_cryptosdk_alg_props] initializer.
  */
 void ensure_alg_properties_is_allocated(struct aws_cryptosdk_alg_properties **alg_props);
-
-#endif /* AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H */
-

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -1,3 +1,6 @@
+#ifndef AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H
+#define AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H
+
 /*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -15,6 +18,7 @@
 
 #include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/framefmt.h>
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 #include <stdint.h>
@@ -25,3 +29,16 @@ void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ct
 
 /* Allocates the members of the context and ensures that internal pointers are pointing to the correct objects. */
 void ensure_sig_ctx_has_allocated_members(struct aws_cryptosdk_sig_ctx *ctx);
+
+/**
+ * This function creates a valid alg properties data structure by
+ * calling the initializer in cipher.h. This is the only valid way to
+ * construct an alg_props structure, and that is why
+ * [aws_cryptosdk_alg_properties_is_valid] checks whether the pointer
+ * of alg_props is the same as the one returned after calling the
+ * [aws_cryptosdk_alg_props] initializer.
+ */
+void ensure_alg_properties_is_allocated(struct aws_cryptosdk_alg_properties **alg_props);
+
+#endif /* AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H */
+

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
@@ -1,0 +1,39 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_serialize_frame_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
@@ -24,14 +24,14 @@ CBMCFLAGS +=
 
 ENTRY = aws_cryptosdk_serialize_frame_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/framefmt.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
 ###########

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -23,7 +23,7 @@ void aws_cryptosdk_serialize_frame_harness() {
     struct aws_cryptosdk_frame frame;  // Preconditions assume not null
     size_t ciphertext_size;
     size_t plaintext_size;
-    struct aws_byte_buf ciphertext_buf;
+    struct aws_byte_buf ciphertext_buf;  // Preconditions assume not null
     struct aws_cryptosdk_alg_properties *alg_props;
 
     /* Assumptions about the function input (based on the
@@ -37,16 +37,21 @@ void aws_cryptosdk_serialize_frame_harness() {
     __CPROVER_assume(aws_cryptosdk_frame_has_valid_type(&frame));
 
     /* Save the old state of the ciphertext buffer */
-    uint8_t *old_ciphertext_buffer   = ciphertext_buf.buffer;
-    size_t old_ciphertext_buffer_len = ciphertext_buf.len;
+    uint8_t *old_ciphertext_buf_ptr = ciphertext_buf.buffer;
+    size_t old_ciphertext_buf_len   = ciphertext_buf.len;
+    struct store_byte_from_buffer old_byte_from_ciphertext_buf;
+    save_byte_from_array(ciphertext_buf.buffer, ciphertext_buf.len, &old_byte_from_ciphertext_buf);
 
     int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, alg_props);
     if (rval == AWS_OP_SUCCESS) {
         assert(aws_cryptosdk_frame_is_valid(&frame));
         assert(aws_cryptosdk_alg_properties_is_valid(alg_props));
-        assert(aws_cryptosdk_frame_serialized(&frame, alg_props, plaintext_size));
-        assert(ciphertext_buf.buffer == old_ciphertext_buffer);
-        assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
+        assert(aws_cryptosdk_frame_is_valid_serialized(&frame, alg_props, plaintext_size));
+        assert(ciphertext_buf.buffer == old_ciphertext_buf_ptr);
+        assert(ciphertext_buf.len == old_ciphertext_buf_len + ciphertext_size);
+        if (old_ciphertext_buf_len > 0) {
+            assert_byte_from_buffer_matches((uint8_t *)ciphertext_buf.buffer, &old_byte_from_ciphertext_buf);
+        }
     } else {
         // Assert that the ciphertext buffer is zeroed in case of failure
         assert_all_zeroes(ciphertext_buf.buffer, ciphertext_buf.capacity);

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_serialize_frame_harness() {
+    /* data structure */
+    struct aws_cryptosdk_frame frame;  // Preconditions assume not null
+    size_t ciphertext_size;
+    size_t plaintext_size;
+    struct aws_byte_buf ciphertext_buf;
+    struct aws_cryptosdk_alg_properties *alg_props;
+
+    /* Assumptions about the function input (based on the
+     * preconditions) */
+    ensure_byte_buf_has_allocated_buffer_member(&ciphertext_buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&ciphertext_buf));
+
+    ensure_alg_properties_is_allocated(&alg_props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(alg_props));
+
+    __CPROVER_assume(aws_cryptosdk_frame_has_valid_type(&frame));
+
+    /* Save the old state of the ciphertext buffer */
+    uint8_t *old_ciphertext_buffer   = ciphertext_buf.buffer;
+    size_t old_ciphertext_buffer_len = ciphertext_buf.len;
+
+    int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, alg_props);
+    if (rval == AWS_OP_SUCCESS) {
+        assert(aws_cryptosdk_frame_is_valid(&frame));
+        assert(aws_cryptosdk_alg_properties_is_valid(alg_props));
+        assert(aws_cryptosdk_frame_serialized(&frame, alg_props, plaintext_size));
+        assert(ciphertext_buf.buffer == old_ciphertext_buffer);
+        assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
+    } else {
+        // Assert that the ciphertext buffer is zeroed in case of failure
+        assert_all_zeroes(ciphertext_buf.buffer, ciphertext_buf.capacity);
+        assert(ciphertext_buf.len == 0);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_serialize_frame_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -44,3 +44,7 @@ void ensure_sig_ctx_has_allocated_members(struct aws_cryptosdk_sig_ctx *ctx) {
         evp_md_ctx_set0_evp_pkey(ctx->ctx, ctx->pkey);
     }
 }
+
+void ensure_alg_properties_is_allocated(struct aws_cryptosdk_alg_properties **alg_props) {
+    *alg_props = aws_cryptosdk_alg_props(nondet_int());
+}

--- a/include/aws/cryptosdk/cipher.h
+++ b/include/aws/cryptosdk/cipher.h
@@ -102,6 +102,12 @@ AWS_CRYPTOSDK_API
 const struct aws_cryptosdk_alg_properties *aws_cryptosdk_alg_props(enum aws_cryptosdk_alg_id alg_id);
 
 /**
+ * Checks whether an aws_cryptosdk_alg_properties is valid and is supported by the SDK.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props);
+
+/**
  * An opaque structure representing an ongoing sign or verify operation
  */
 struct aws_cryptosdk_sig_ctx;

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -55,7 +55,7 @@ bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame)
  * the [alg_props] algorithm properties and in the
  * [plaintext_size]. It also checks that the two buffers are empty.
  */
-bool aws_cryptosdk_frame_serialized(
+bool aws_cryptosdk_frame_is_valid_serialized(
     const struct aws_cryptosdk_frame *frame,
     const struct aws_cryptosdk_alg_properties *alg_props,
     size_t plaintext_size);

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -17,6 +17,7 @@
 #define AWS_CRYPTOSDK_PRIVATE_FRAMEFMT_H
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/cipher.h>
 
@@ -32,6 +33,37 @@ struct aws_cryptosdk_frame {
     /* A cursor to space for the AEAD tag in the ciphertext buffer */
     struct aws_byte_buf authtag;
 };
+
+// MAX_FRAME_SIZE = 2^32 - 1
+#define MAX_FRAME_SIZE 0xFFFFFFFF
+// MAX_FRAMES = 2^32 - 1
+#define MAX_FRAMES 0xFFFFFFFF
+// MAX_UNFRAMED_PLAINTEXT_SIZE = 2^36 - 32
+#define MAX_UNFRAMED_PLAINTEXT_SIZE 0xFFFFFFFE0ull
+
+/**
+ * Checks whether a frame struct is valid. At the moment this means
+ * that it checks the validity of the byte buffers and the fact that
+ * they should have NULL allocators.
+ */
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame);
+
+/**
+ * Checks whether a frame struct is correctly serialized in relation
+ * to a specific algorithm.  More precisely, it checks that the
+ * buffers in [frame] have the same sizes as the sizes described in
+ * the [alg_props] algorithm properties and in the
+ * [plaintext_size]. It also checks that the two buffers are empty.
+ */
+bool aws_cryptosdk_frame_serialized(
+    const struct aws_cryptosdk_frame *frame,
+    const struct aws_cryptosdk_alg_properties *alg_props,
+    size_t plaintext_size);
+
+/**
+ * Checks whether a frame has a valid frame type.
+ */
+bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame);
 
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all

--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -21,7 +21,6 @@
 #include <aws/cryptosdk/session.h>
 
 #define DEFAULT_FRAME_SIZE (256 * 1024)
-#define MAX_FRAME_SIZE 0xFFFFFFFF
 
 enum session_state {
     /*** Common states ***/

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -88,6 +88,15 @@ static enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk
     }
 }
 
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props) {
+    if (alg_props == NULL) {
+        return false;
+    }
+    enum aws_cryptosdk_alg_id id                             = alg_props->alg_id;
+    const struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
+    return (std_alg_props == alg_props);
+}
+
 int aws_cryptosdk_derive_key(
     const struct aws_cryptosdk_alg_properties *props,
     struct content_key *content_key,

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -215,7 +215,7 @@ static inline int serde_nonframed(
 }
 
 bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame) {
-    if (frame == NULL) {
+    if (!AWS_OBJECT_PTR_IS_READABLE(frame)) {
         return false;
     }
 
@@ -239,11 +239,11 @@ bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame)
         authtag_byte_buf_static && ciphertext_valid && ciphertext_static);
 }
 
-bool aws_cryptosdk_frame_serialized(
+bool aws_cryptosdk_frame_is_valid_serialized(
     const struct aws_cryptosdk_frame *frame,
     const struct aws_cryptosdk_alg_properties *alg_props,
     size_t plaintext_size) {
-    if (frame == NULL || alg_props == NULL) {
+    if (!AWS_OBJECT_PTR_IS_READABLE(frame) || !AWS_OBJECT_PTR_IS_READABLE(alg_props)) {
         return false;
     }
 
@@ -264,7 +264,7 @@ bool aws_cryptosdk_frame_serialized(
 }
 
 bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame) {
-    if (frame == NULL) {
+    if (!AWS_OBJECT_PTR_IS_READABLE(frame)) {
         return false;
     }
 
@@ -346,7 +346,7 @@ int aws_cryptosdk_serialize_frame(
         *ciphertext_buf = state.u.buffer;
         AWS_POSTCONDITION(aws_cryptosdk_frame_is_valid(frame));
         AWS_POSTCONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
-        AWS_POSTCONDITION(aws_cryptosdk_frame_serialized(frame, alg_props, plaintext_size));
+        AWS_POSTCONDITION(aws_cryptosdk_frame_is_valid_serialized(frame, alg_props, plaintext_size));
         return AWS_OP_SUCCESS;
     }
 }

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <aws/common/common.h>
 #include <aws/common/error.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/private/framefmt.h>
@@ -213,6 +214,66 @@ static inline int serde_nonframed(
     return AWS_ERROR_SUCCESS;
 }
 
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame) {
+    if (frame == NULL) {
+        return false;
+    }
+
+    bool frame_type_valid = aws_cryptosdk_frame_has_valid_type(frame);
+
+    bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
+    bool iv_byte_buf_static = (frame->iv.allocator == NULL);
+
+    bool authtag_byte_buf_valid  = aws_byte_buf_is_valid(&frame->authtag);
+    bool authtag_byte_buf_static = (frame->authtag.allocator == NULL);
+
+    bool ciphertext_byte_buf_valid = aws_byte_buf_is_valid(&frame->ciphertext);
+    /* This happens when input plaintext size is 0 */
+    bool ciphertext_valid_zero =
+        (frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0);
+    bool ciphertext_valid  = (ciphertext_byte_buf_valid || ciphertext_valid_zero);
+    bool ciphertext_static = (frame->ciphertext.allocator == NULL);
+
+    return (
+        frame_type_valid && iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid &&
+        authtag_byte_buf_static && ciphertext_valid && ciphertext_static);
+}
+
+bool aws_cryptosdk_frame_serialized(
+    const struct aws_cryptosdk_frame *frame,
+    const struct aws_cryptosdk_alg_properties *alg_props,
+    size_t plaintext_size) {
+    if (frame == NULL || alg_props == NULL) {
+        return false;
+    }
+
+    // Check that both iv, authtag buffers contain the correct amount of bytes
+    bool iv_size_valid  = (frame->iv.capacity == alg_props->iv_len);
+    bool tag_size_valid = (frame->authtag.capacity == alg_props->tag_len);
+
+    // Check that both iv, authtag buffers are empty and ready for writting
+    bool iv_empty  = (frame->iv.len == 0);
+    bool tag_empty = (frame->authtag.len == 0);
+
+    // Check that the ciphertext buffer has the correct size
+    bool ciphertext_size_valid = ((frame->type == FRAME_TYPE_SINGLE || frame->type == FRAME_TYPE_FRAME) &&
+                                  frame->ciphertext.capacity == plaintext_size) ||
+                                 (frame->type == FRAME_TYPE_FINAL && frame->ciphertext.capacity <= plaintext_size);
+
+    return (iv_size_valid && tag_size_valid && iv_empty && tag_empty);
+}
+
+bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame) {
+    if (frame == NULL) {
+        return false;
+    }
+
+    bool frame_enum_in_range =
+        (frame->type == FRAME_TYPE_SINGLE || frame->type == FRAME_TYPE_FRAME || frame->type == FRAME_TYPE_FINAL);
+
+    return frame_enum_in_range;
+}
+
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all
  * fields except for the IV, ciphertext, and authtag, and returns their
@@ -235,7 +296,19 @@ int aws_cryptosdk_serialize_frame(
     size_t plaintext_size,
     struct aws_byte_buf *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props) {
+    AWS_PRECONDITION(aws_cryptosdk_frame_has_valid_type(frame));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(ciphertext_buf));
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
     struct aws_cryptosdk_framestate state;
+
+    // The plaintext_size should be bound to prevent arithmetic
+    // overflows due to addition
+    if ((frame->type == FRAME_TYPE_SINGLE && plaintext_size > MAX_UNFRAMED_PLAINTEXT_SIZE) ||
+        (frame->type != FRAME_TYPE_SINGLE && plaintext_size > MAX_FRAME_SIZE)) {
+        // Clear the ciphertext buffer
+        aws_byte_buf_secure_zero(ciphertext_buf);
+        return aws_raise_error(AWS_CRYPTOSDK_ERR_LIMIT_EXCEEDED);
+    }
 
     // We assume that the max frame size is equal to the plaintext size. This
     // lets us avoid having to pass in a redundant argument, avoids needing to
@@ -244,7 +317,7 @@ int aws_cryptosdk_serialize_frame(
     state.max_frame_size = plaintext_size;
     state.plaintext_size = plaintext_size;
     // Currently all supported algorithms have plaintext = ciphertext size
-    state.ciphertext_size = plaintext_size;
+    state.ciphertext_size = 0;
 
     state.alg_props = alg_props;
     state.u.buffer  = *ciphertext_buf;
@@ -271,6 +344,9 @@ int aws_cryptosdk_serialize_frame(
         return aws_raise_error(result);
     } else {
         *ciphertext_buf = state.u.buffer;
+        AWS_POSTCONDITION(aws_cryptosdk_frame_is_valid(frame));
+        AWS_POSTCONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
+        AWS_POSTCONDITION(aws_cryptosdk_frame_serialized(frame, alg_props, plaintext_size));
         return AWS_OP_SUCCESS;
     }
 }


### PR DESCRIPTION
Implement a harness for `aws_cryptosdk_serialize_frame` function in `framefmt.c`. 

Add validity functions for `alg_cryptosdk_alg_properties` and `aws_cryptosdk_frame`, as well as preconditions and postconditions in `aws_cryptosdk_serialize_frame`

Depends on #377 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
