### PR TITLE
Added proof harness for aws_cryptosdk_deserialize_frame in framefmt.c

### DIFF
--- a/.cbmc-batch/.gitignore
+++ b/.cbmc-batch/.gitignore
@@ -1,0 +1,2 @@
+jobs/*/link-farm
+jobs/*/html

--- a/.cbmc-batch/cipher_proofs.c
+++ b/.cbmc-batch/cipher_proofs.c
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-#include "proof_helpers.h"
 #include <aws/cryptosdk/private/cipher.h>
 #include <openssl/evp.h>
+#include "proof_helpers.h"
 
 #define MSG_ID_LEN 16
 
@@ -35,12 +35,10 @@ void aws_cryptosdk_derive_key_verify(void) {
     ASSUME_VALID_MEMORY(props);
     props->impl = malloc(sizeof(&nondet_EVP_MD_ptr) + sizeof(&nondet_EVP_CIPHER_ptr));
 
-    props->impl->md_ctor = NULL;
+    props->impl->md_ctor     = NULL;
     props->impl->cipher_ctor = NULL;
-    if (nondet_int())
-        props->impl->md_ctor = &nondet_EVP_MD_ptr;
-    if (nondet_int())
-        props->impl->cipher_ctor = &nondet_EVP_CIPHER_ptr;
+    if (nondet_int()) props->impl->md_ctor = &nondet_EVP_MD_ptr;
+    if (nondet_int()) props->impl->cipher_ctor = &nondet_EVP_CIPHER_ptr;
 
     __CPROVER_assume(props->data_key_len <= MAX_DATA_KEY_SIZE);
 

--- a/.cbmc-batch/hdr_zeroize.c
+++ b/.cbmc-batch/hdr_zeroize.c
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#include<stdlib.h>
-#include<../source/header.c>
+#include <stdlib.h>
+#include <../source/header.c>
 
 static inline void hdr_zeroize_verify(struct aws_cryptosdk_hdr *hdr) {
     // Assume hdr is allocated
@@ -40,7 +40,7 @@ static inline void hdr_zeroize_verify(struct aws_cryptosdk_hdr *hdr) {
     size_t index = nondet_size_t();
     __CPROVER_assume(index < MESSAGE_ID_LEN);
     // Check message id is zero at the index
-    assert(hdr->message_id[index]==0);
+    assert(hdr->message_id[index] == 0);
     assert(!hdr->aad_tbl);
     assert(!hdr->edk_tbl);
     assert(hdr->auth_len == 0);

--- a/.cbmc-batch/header_proofs.c
+++ b/.cbmc-batch/header_proofs.c
@@ -14,16 +14,16 @@
  */
 
 #include <aws/common/byte_buf.h>
-#include <stdlib.h>
 #include <aws/cryptosdk/private/cipher.h>
 #include <aws/cryptosdk/private/header.h>
+#include <stdlib.h>
 #include "proof_helpers.h"
 #define MAX_AAD_COUNT 1
 #define MAX_EDK_COUNT 1
 #define MAX_BUFFER_LEN 1
 
-struct aws_cryptosdk_hdr * get_aws_cryptosdk_hdr_ptr(struct aws_allocator * allocator, bool full_init) {
-    struct aws_cryptosdk_hdr * hdr;
+struct aws_cryptosdk_hdr *get_aws_cryptosdk_hdr_ptr(struct aws_allocator *allocator, bool full_init) {
+    struct aws_cryptosdk_hdr *hdr;
     // Assume hdr is allocated
     ASSUME_VALID_MEMORY(hdr);
     hdr->aad_tbl = NULL;
@@ -34,9 +34,9 @@ struct aws_cryptosdk_hdr * get_aws_cryptosdk_hdr_ptr(struct aws_allocator * allo
         hdr->aad_tbl = aws_mem_acquire(allocator, hdr->aad_count * sizeof(*(hdr->aad_tbl)));
         for (int i = 0; i < hdr->aad_count; i++) {
             // For each entry in hdr->aad_tbl
-            struct aws_cryptosdk_hdr_aad * aad = hdr->aad_tbl + i;
-            size_t key_len = nondet_size_t();
-            size_t value_len = nondet_size_t();
+            struct aws_cryptosdk_hdr_aad *aad = hdr->aad_tbl + i;
+            size_t key_len                    = nondet_size_t();
+            size_t value_len                  = nondet_size_t();
             // Assume key_len is below bound on buffer length
             __CPROVER_assume(key_len < MAX_BUFFER_LEN);
             // Assume value_len is below bound on buffer length
@@ -65,10 +65,10 @@ struct aws_cryptosdk_hdr * get_aws_cryptosdk_hdr_ptr(struct aws_allocator * allo
         hdr->edk_tbl = aws_mem_acquire(allocator, hdr->edk_count * sizeof(*(hdr->edk_tbl)));
         for (int i = 0; i < hdr->edk_count; i++) {
             // For each entry in hdr->edk_tbl
-            struct aws_cryptosdk_edk * edk = hdr->edk_tbl + i;
-            size_t provider_id_len = nondet_size_t();
-            size_t provider_info_len = nondet_size_t();
-            size_t enc_data_key_len = nondet_size_t();
+            struct aws_cryptosdk_edk *edk = hdr->edk_tbl + i;
+            size_t provider_id_len        = nondet_size_t();
+            size_t provider_info_len      = nondet_size_t();
+            size_t enc_data_key_len       = nondet_size_t();
             // Assume provider_id_len is below bound on buffer length
             __CPROVER_assume(provider_id_len < MAX_BUFFER_LEN);
             // Assume provider_info_len is below bound on buffer length
@@ -114,35 +114,35 @@ struct aws_cryptosdk_hdr * get_aws_cryptosdk_hdr_ptr(struct aws_allocator * allo
 }
 
 void aws_cryptosdk_hdr_clean_up_verify(void) {
-    struct aws_allocator * allocator;
+    struct aws_allocator *allocator;
     // Use default allocator
     ASSUME_DEFAULT_ALLOCATOR(allocator);
-    struct aws_cryptosdk_hdr * hdr = get_aws_cryptosdk_hdr_ptr(allocator, nondet_int());
+    struct aws_cryptosdk_hdr *hdr = get_aws_cryptosdk_hdr_ptr(allocator, nondet_int());
     aws_cryptosdk_hdr_clean_up(allocator, hdr);
     free(hdr);
 }
 
 void aws_cryptosdk_hdr_write_verify(void) {
-    struct aws_allocator * allocator;
+    struct aws_allocator *allocator;
     // Use default allocator
     ASSUME_DEFAULT_ALLOCATOR(allocator);
-    struct aws_cryptosdk_hdr * hdr = get_aws_cryptosdk_hdr_ptr(allocator, true);
+    struct aws_cryptosdk_hdr *hdr = get_aws_cryptosdk_hdr_ptr(allocator, true);
 
-    size_t * bytes_written;
+    size_t *bytes_written;
     ASSUME_VALID_MEMORY(bytes_written);
     size_t outlen = nondet_size_t();
     __CPROVER_assume(outlen < __CPROVER_constant_infinity_uint - 1);
-    uint8_t * outbuf;
+    uint8_t *outbuf;
     ASSUME_VALID_MEMORY_COUNT(outbuf, outlen);
 
     aws_cryptosdk_hdr_write(hdr, bytes_written, outbuf, outlen);
 }
 
 void aws_cryptosdk_hdr_size_verify(void) {
-    struct aws_allocator * allocator;
+    struct aws_allocator *allocator;
     // Use default allocator
     ASSUME_DEFAULT_ALLOCATOR(allocator);
-    struct aws_cryptosdk_hdr * hdr = get_aws_cryptosdk_hdr_ptr(allocator, true);
+    struct aws_cryptosdk_hdr *hdr = get_aws_cryptosdk_hdr_ptr(allocator, true);
 
-    aws_cryptosdk_hdr_size(hdr); 
+    aws_cryptosdk_hdr_size(hdr);
 }

--- a/.cbmc-batch/include/bn_utils.h
+++ b/.cbmc-batch/include/bn_utils.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef BN_UTILS_H
+#define BN_UTILS_H
+
+#include <openssl/bn.h>
+
+bool bignum_is_valid(BIGNUM *bn);
+BIGNUM *bignum_nondet_alloc();
+
+#endif

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -1,3 +1,6 @@
+#ifndef AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H
+#define AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H
+
 /*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -21,6 +24,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-/* This function creates a valid alg properties data structure by
- * calling the initializer in cipher.h */
+/**
+ * This function creates a valid alg properties data structure by
+ * calling the initializer in cipher.h. This is the only valid way to
+ * construct an alg_props structure, and that is why
+ * [aws_cryptosdk_alg_properties_is_valid] checks whether the pointer
+ * of alg_props is the same as the one returned after calling the
+ * [aws_cryptosdk_alg_props] initializer.
+ */
 void ensure_alg_properties_is_allocated(struct aws_cryptosdk_alg_properties **alg_props);
+
+#endif /* AWS_CRYPTOSDK_MAKE_COMMON_DATA_STRUCTURES_H */

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -21,4 +21,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props);
+/* This function creates a valid alg properties data structure by
+ * calling the initializer in cipher.h */
+void ensure_alg_properties_is_allocated(struct aws_cryptosdk_alg_properties **alg_props);

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/common.h>
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props);

--- a/.cbmc-batch/include/proof_allocators.h
+++ b/.cbmc-batch/include/proof_allocators.h
@@ -20,4 +20,4 @@
  * The standard allocator in CBMC cannot fail.  This one can, which allows us to
  * nondeterministically find more bugs
  */
-struct aws_allocator* can_fail_allocator();
+struct aws_allocator *can_fail_allocator();

--- a/.cbmc-batch/jobs/Makefile.cbmc_batch
+++ b/.cbmc-batch/jobs/Makefile.cbmc_batch
@@ -1,0 +1,93 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: batch-yaml ci-yaml
+
+################################################################
+# Launching cbmc on cbmc-batch
+BATCH ?= cbmc-batch
+
+BATCHFLAGS ?= \
+  --bucket $(BUCKET) \
+	--srcdir $(SRCDIR) \
+	--wsdir $(WS) \
+	--jobprefix $(ENTRY) \
+	--no-build \
+	--goto $(ENTRY).goto \
+	--cbmcflags $(call encode_options,$(CBMCFLAGS)) \
+	--property-memory $(PROPMEM) \
+	--coverage-memory $(COVMEM) \
+	--cbmcpkg $(CBMCPKG) \
+	--batchpkg $(BATCHPKG) \
+	--viewerpkg $(VIEWERPKG) \
+	--no-copysrc \
+	--blddir $(SRCDIR) \
+
+BATCHPKG ?= cbmc-batch.tar.gz
+BUCKET ?= cbmc
+CBMCPKG ?= cbmc.tar.gz
+COVMEM ?= 64000
+
+define encode_options
+       '=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
+endef
+
+PROPMEM ?= 64000
+VIEWERPKG ?= cbmc-viewer.tar.gz
+WS ?= ws
+
+define yaml_encode_options
+       "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
+endef
+
+$(ENTRY).yaml: $(ENTRY).goto Makefile
+	echo 'jobos: ubuntu16' > $@
+	echo 'cbmcpkg: $(CBMCPKG)' >> $@
+	echo 'batchpkg: $(BATCHPKG)' >> $@
+	echo 'viewerpkg: $(VIEWERPKG)' >> $@
+	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'build: true' >> $@
+	echo 'cbmcflags: $(call yaml_encode_options,$(CBMCFLAGS))' >> $@
+	echo 'property_memory: $(PROPMEM)' >> $@
+	echo 'coverage_memory: $(COVMEM)' >> $@
+	echo 'expected: "SUCCESSFUL"' >> $@
+
+batch-yaml: $(ENTRY).yaml
+
+cbmc-batch.yaml: $(ENTRY).goto Makefile
+	echo 'jobos: ubuntu16' > $@
+	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
+	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'expected: "SUCCESSFUL"' >> $@
+
+ci-yaml: cbmc-batch.yaml
+
+launch: $(ENTRY).goto Makefile
+	mkdir -p $(WS)
+	cp $(ENTRY).goto $(WS)
+	$(BATCH) $(BATCHFLAGS)
+
+launch-clean:
+	for d in $(ENTRY)*; do \
+	  if [ -d $$d ]; then \
+	    for f in $$d.json $$d.yaml Makefile-$$d; do \
+	      if [ -f $$f ]; then mv $$f $$d; fi \
+	    done\
+	  fi \
+	done
+	$(RM) Makefile-$(ENTRY)-[0-7]*-[0-7]*
+	$(RM) $(ENTRY)-[0-7]*-[0-7]*.json $(ENTRY)-[0-7]*-[0-7]*.yaml
+	$(RM) -r $(WS)
+
+launch-veryclean: launch-clean
+	$(RM) -r $(ENTRY)-[0-7]*-[0-7]*

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -15,28 +15,31 @@ SHELL=/bin/bash
 
 default: report
 
-################################################################
-# Helper-inc must go first, so it can override other includes.
-INC += -I$(SRCDIR)/helper-inc
-INC += -I$(SRCDIR)/c-enc-sdk-inc
-INC += -I$(SRCDIR)/c-common-inc
-INC += -I$(SRCDIR)/c-common-helper-inc
-INC += -I/usr/local/opt/openssl@1.1/include/
-
-CBMC_OBJECT_BITS ?= 8
-CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
-DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
-DEFINES += -DCBMC=1
-
-OPT +=
-
-CFLAGS += $(CFLAGS2) $(DEFINES) $(OPT)
-
-LINKFARM = $(abspath ./link-farm)
-
-HARNESS_NAME ?= $(ENTRY)_harness.c
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude Makefile.local
 
 ################################################################
+# Define some constants that are hard to reference otherwise
+SPACE :=$() $()
+COMMA :=,
+
+################################################################
+# Setup paths to binaries
+# By default, use the version on your path; this can be overriden to select particular
+# versions of the tools. /usr/bin/goto-analyzer or ${HOME}/sw/goto-analyzer etc
+GOTO_ANALYZER ?= goto-analyzer
+GOTO_CC ?= goto-cc
+GOTO_INSTRUMENT ?= goto-instrument
+VIEWER ?= cbmc-viewer
+
+################################################################
+# Define locations and binaries
+ABSTRACTIONS ?= ""
+HARNESS_NAME ?= $(ENTRY).c
+
+################################################################
+# Default CBMC flags
+CBMC_VERBOSITY ?= ""
 CBMCFLAGS += --bounds-check
 CBMCFLAGS += --div-by-zero-check
 CBMCFLAGS += --float-overflow-check
@@ -49,12 +52,75 @@ CBMCFLAGS += --unsigned-overflow-check
 CBMCFLAGS += --unwind 1
 CBMCFLAGS += --unwinding-assertions
 
+################################################################
+# Preprocess the unwindset
+ifneq ($(UNWINDSET),)
+CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+endif
+CBMCFLAGS += $(CBMC_UNWINDSET)
 
-UNWIND ?= 0
+################################################################
+# Set C compiler defines
+CBMC_OBJECT_BITS ?= 8
+CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
+DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
+DEFINES += -DCBMC=1
+
+################################################################
+# Setup directory aliases
+BASEDIR ?= $(abspath ../../../..)
+SRCDIR ?= $(abspath ./link-farm)
+SDKDIR ?= $(abspath ../../..)
+HELPERDIR ?= $(SDKDIR)/.cbmc-batch
+LINKFARM = $(abspath ./link-farm)
+COMMON_REPO_NAME ?= aws-c-common-for-cryptosdk-proofs
+COMMONDIR ?= $(BASEDIR)/$(COMMON_REPO_NAME)
+COMMON_HELPERDIR ?= $(COMMONDIR)/.cbmc-batch
+
+################################################################
+# Setup include directory order
+# Helper-inc must go first, so it can override other includes.
+INC += -I$(SRCDIR)/helper-inc
+INC += -I$(SRCDIR)/c-enc-sdk-inc
+INC += -I$(SRCDIR)/c-common-inc
+INC += -I$(SRCDIR)/c-common-helper-inc
+INC += -I/usr/local/opt/openssl@1.1/include/
+
+################################################################
+# Temporarily disable UNWIND_GOTO, SIMPLIFY until the feature is
+# stable
+UNWIND_GOTO ?= 0
 SIMPLIFY ?= 0
 
-ABSTRACTIONS ?=
+################################################################
+# Enables costly checks (e.g. ones that contain loops)
+# Don't execute deep checks by default
+AWS_DEEP_CHECKS ?= 0
+DEFINES += -DAWS_DEEP_CHECKS=$(AWS_DEEP_CHECKS)
 
+################################################################
+# We always override allocator functions with our own allocator
+# Removing the function from the goto program helps CBMC's
+# function pointer analysis.
+REMOVE_FUNCTION_BODY += --remove-function-body aws_default_allocator
+REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_allocate
+REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_copy_description
+REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_deallocate
+REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_preferred_size
+REMOVE_FUNCTION_BODY += --remove-function-body s_cf_allocator_reallocate
+REMOVE_FUNCTION_BODY += --remove-function-body s_default_calloc
+REMOVE_FUNCTION_BODY += --remove-function-body s_default_free
+REMOVE_FUNCTION_BODY += --remove-function-body s_default_malloc
+REMOVE_FUNCTION_BODY += --remove-function-body s_default_realloc
+
+################################################################
+# We override abort() to be assert(0), as it is not caught by
+# CBMC as a violation. This is in the link-farm c-common
+ABSTRACTIONS += $(LINKFARM)/c-common-helper-stubs/abort_override_assert_false.c
+REMOVE_FUNCTION_BODY += --remove-function-body abort
+################################################################
+
+REMOVE_FUNCTION_BODY += $(ADDITIONAL_REMOVE_FUNCTION_BODY)
 DEPENDENT_GOTOS = $(patsubst %.c,%.goto,$(DEPENDENCIES))
 
 ################################################################
@@ -104,53 +170,98 @@ helper-symlinks: linkfarm-dir
 
 fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks common-helper-symlinks helper-symlinks
 
-$(ENTRY)1.goto: fill-linkfarm $(DEPENDENT_GOTOS)
-	$(GOTO_CC) --function harness -o $@ $(DEPENDENT_GOTOS)
+################################################################
+# Other libraries that use this Makefile template may wish to do
+# actual work here
+setup_dependencies: fill-linkfarm
+	echo "Setting up dependencies"
 
-$(ENTRY)3.goto: $(ENTRY)1.goto
-	 $(GOTO_INSTRUMENT) $(ABSTRACTIONS) --add-library $< $@ \
-		2>&1 | tee $(ENTRY)3.log ; exit $${PIPESTATUS[0]}
+# Here, whenever there is a change in any of ANSI-C source
+# dependency files, make will take action. However, to make
+# sure changes in the headers files will also trigger make,
+# the user must run make clean first.
+$(ENTRY)0.goto: setup_dependencies $(ENTRY).c $(DEPENDENT_GOTOS)
+	$(GOTO_CC) $(ENTRY).c $(DEPENDENT_GOTOS) \
+	  --export-function-local-symbols $(CBMC_VERBOSITY) \
+	  --function $(ENTRY) $(DEPENDENT_GOTOS) $(INC) $(DEFINES) -o $@ \
+	  2>&1 | tee $(ENTRY)1.log ; exit $${PIPESTATUS[0]}
+
+# Removes specified function bodies. This allows us to replace
+# function definitions with ABSTRACTIONS.
+$(ENTRY)1.goto: $(ENTRY)0.goto
+ifeq ($(REMOVE_FUNCTION_BODY), "")
+	cp $< $@
+	echo "Not removing function bodies" | tee $(ENTRY)1.log ; exit $${PIPESTATUS[0]}
+else
+	$(GOTO_INSTRUMENT) $(REMOVE_FUNCTION_BODY) $< $@ \
+		2>&1 | tee $(ENTRY)2.log ; exit $${PIPESTATUS[0]}
+endif
+
+# ABSTRACTIONS is a list of function stubs to use. If a function body
+# is missing and is not abstracted, then it returnes a non
+# deterministic value.
+$(ENTRY)2.goto: $(ENTRY)1.goto
+ifeq ($(ABSTRACTIONS), "")
+	cp $< $@
+	echo "Not implementing abstractions" | tee $(ENTRY)2.log ; exit $${PIPESTATUS[0]}
+else
+	$(GOTO_CC) --function $(ENTRY) $(ABSTRACTIONS) $< $(INC) $(DEFINES) -o $@ \
+		2>&1 | tee $(ENTRY)2.log ; exit $${PIPESTATUS[0]}
+endif
+
+
+## Temporarily skipped steps
 
 # Simplify and constant propagation may benefit from unwinding first
-$(ENTRY)4.goto: $(ENTRY)3.goto
+$(ENTRY)3.goto: $(ENTRY)2.goto
 ifeq ($(UNWIND_GOTO), 1)
 	$(GOTO_INSTRUMENT) $(UNWINDING) $< $@ \
+		2>&1 | tee $(ENTRY)3.log ; exit $${PIPESTATUS[0]}
+else
+	cp $< $@
+	echo "Not unwinding goto program" | tee $(ENTRY)3.log ; exit $${PIPESTATUS[0]}
+endif
+
+# Skip simplify (and hence generate-function-body) until missing source locations debugged
+$(ENTRY)4.goto: $(ENTRY)3.goto
+ifeq ($(SIMPLIFY), 1)
+	$(GOTO_INSTRUMENT) --generate-function-body '.*' $< $@ \
 		2>&1 | tee $(ENTRY)4.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
+	echo "Not generating-function-bodies in goto program" | tee $(ENTRY)4.log ; exit $${PIPESTATUS[0]}
 endif
 
 # Skip simplify (and hence generate-function-body) until missing source locations debugged
 $(ENTRY)5.goto: $(ENTRY)4.goto
 ifeq ($(SIMPLIFY), 1)
-	$(GOTO_INSTRUMENT) --generate-function-body '.*' $< $@ \
+	$(GOTO_ANALYZER) --simplify $@ $< \
 		2>&1 | tee $(ENTRY)5.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
+	echo "Not simplfying goto program" | tee $(ENTRY)5.log ; exit $${PIPESTATUS[0]}
 endif
 
-# Skip simplify (and hence generate-function-body) until missing source locations debugged
+# Simplify the goto program by removing any unused function bodies
 $(ENTRY)6.goto: $(ENTRY)5.goto
-ifeq ($(SIMPLIFY), 1)
-	$(GOTO_ANALYZER) --simplify $@ $< \
-		2>&1 | tee $(ENTRY)6.log ; exit $${PIPESTATUS[0]}
-else
-	cp $< $@
-endif
-
-$(ENTRY)7.goto: $(ENTRY)6.goto
 	$(GOTO_INSTRUMENT) --drop-unused-functions $< $@ \
+		2>&1 | tee $(ENTRY)6.log ; exit $${PIPESTATUS[0]}
+
+# Simplify the goto program by slicing away initializations of unused
+# global variables
+$(ENTRY)7.goto: $(ENTRY)6.goto
+	$(GOTO_INSTRUMENT) --slice-global-inits $< $@ \
 		2>&1 | tee $(ENTRY)7.log ; exit $${PIPESTATUS[0]}
 
-$(ENTRY)8.goto: $(ENTRY)7.goto
-	$(GOTO_INSTRUMENT) --slice-global-inits $< $@ \
-		2>&1 | tee $(ENTRY)8.log ; exit $${PIPESTATUS[0]}
-
-$(ENTRY).goto: $(ENTRY)8.goto
+$(ENTRY).goto: $(ENTRY)7.goto
 	cp $< $@
 
-%.goto : %.c fill-linkfarm
-	$(GOTO_CC) -o $@ $(INC) $(CFLAGS) $<
+# Catch-all used for building goto-binaries of the individual
+# dependencies, which are then linked in the $(ENTRY)0.goto rule above
+%.goto: %.c
+	$(GOTO_CC) -c $< --export-function-local-symbols $(CBMC_VERBOSITY) \
+	  $(INC) $(DEFINES) -o $@ \
+	  2>&1 | tee $(dir $<)/$(notdir $<).log ; exit $${PIPESTATUS[0]}
 
 goto: $(ENTRY).goto
 
@@ -171,18 +282,18 @@ coverage: coverage.xml
 
 report: cbmc.log property.xml coverage.xml
 	$(VIEWER) \
+	--block coverage.xml \
 	--goto $(ENTRY).goto \
-	--srcdir $(SRCDIR) \
 	--htmldir html \
-	--srcexclude "(./verification|./tests|./tools|./lib/third_party)" \
-	--result cbmc.log \
 	--property property.xml \
-	--block coverage.xml
+	--result cbmc.log \
+	--srcdir $(SRCDIR) \
+	--srcexclude "(./verification|./tests|./tools|./lib/third_party)"
 
 clean:
-	$(RM) $(GOTOS)
-	$(RM) $(DEPENDENT_GOTOS) $(ENTRY).goto
-	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].log
+	$(RM) *.goto
+	$(RM) $(DEPENDENT_GOTOS)
+	$(RM) *.log
 	$(RM) cbmc.log property.xml coverage.xml TAGS
 	$(RM) *~ \#*
 
@@ -193,83 +304,8 @@ veryclean: clean
 gitclean: veryclean
 	$(RM) -r $(COMMONDIR)
 
-
 .PHONY: cbmc property coverage report clean veryclean common-symlinks common-git harness-symlink fill-linkfarm helper-symlinks ci-yaml
 
-################################################################
-# Launching cbmc on cbmc-batch
+.PHONY: setup_dependencies cbmc property coverage report clean veryclean
 
-BATCH ?= cbmc-batch
-WS ?= ws
-
-define encode_options
-       '=$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')='
-endef
-
-PROPMEM ?= 64000
-COVMEM ?= 64000
-CBMCPKG ?= cbmc-20180820
-BATCHPKG ?= cbmc-batch-20180913
-VIEWERPKG ?= cbmc-viewer-20180913
-
-BATCHFLAGS ?= \
-	--srcdir $(LINKFARM) \
-	--wsdir $(WS) \
-	--jobprefix $(ENTRY) \
-	--no-build \
-	--goto $(ENTRY).goto \
-	--cbmcflags $(call encode_options,$(CBMCFLAGS)) \
-	--property-memory $(PROPMEM) \
-	--coverage-memory $(COVMEM) \
-	--cbmcpkg $(CBMCPKG) \
-	--batchpkg $(BATCHPKG) \
-	--viewerpkg $(VIEWERPKG) \
-	--no-copysrc \
-	--srctarfile $(SRC_TARFILE) \
-	--blddir $(LINKFARM) \
-
-define yaml_encode_options
-       "$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
-endef
-
-$(ENTRY).yaml: $(ENTRY).goto Makefile
-	echo 'jobos: ubuntu14' > $@
-	echo 'cbmcpkg: $(CBMCPKG)' >> $@
-	echo 'batchpkg: $(BATCHPKG)' >> $@
-	echo 'viewerpkg: $(VIEWERPKG)' >> $@
-	echo 'goto: $(ENTRY).goto' >> $@
-	echo 'build: true' >> $@
-	echo 'cbmcflags: $(call yaml_encode_options,$(CBMCFLAGS))' >> $@
-	echo 'property_memory: $(PROPMEM)' >> $@
-	echo 'coverage_memory: $(COVMEM)' >> $@
-	echo 'expected: "SUCCESSFUL"' >> $@
-
-batch-yaml: $(ENTRY).yaml
-
-cbmc-batch.yaml: $(ENTRY).goto Makefile
-	echo 'jobos: ubuntu16' > $@
-	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
-	echo 'goto: $(ENTRY).goto' >> $@
-	echo 'expected: "SUCCESSFUL"' >> $@
-
-ci-yaml: cbmc-batch.yaml
-
-launch: $(ENTRY).goto Makefile
-	mkdir -p $(WS)
-	cp $(ENTRY).goto $(WS)
-	$(BATCH) $(BATCHFLAGS)
-
-launch-clean:
-	for d in $(ENTRY)*; do \
-	  if [ -d $$d ]; then \
-	    for f in $$d.json $$d.yaml Makefile-$$d; do \
-	      if [ -f $$f ]; then mv $$f $$d; fi \
-	    done\
-	  fi \
-	done
-	$(RM) Makefile-$(ENTRY)-[0-9]*-[0-9]*
-	$(RM) $(ENTRY)-[0-9]*-[0-9]*.json $(ENTRY)-[0-9]*-[0-9]*.yaml
-	$(RM) -r $(WS)
-
-launch-veryclean: launch-clean
-	$(RM) -r $(ENTRY)-[0-9]*-[0-9]*
+include $(HELPERDIR)/jobs/Makefile.cbmc_batch

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -191,7 +191,7 @@ gitclean: veryclean
 	$(RM) -r $(COMMONDIR)
 
 
-.PHONY: cbmc property coverage report clean veryclean common-symlinks common-git harness-symlink fill-linkfarm helper-symlinks
+.PHONY: cbmc property coverage report clean veryclean common-symlinks common-git harness-symlink fill-linkfarm helper-symlinks ci-yaml
 
 ################################################################
 # Launching cbmc on cbmc-batch
@@ -240,6 +240,16 @@ $(ENTRY).yaml: $(ENTRY).goto Makefile
 	echo 'property_memory: $(PROPMEM)' >> $@
 	echo 'coverage_memory: $(COVMEM)' >> $@
 	echo 'expected: "SUCCESSFUL"' >> $@
+
+batch-yaml: $(ENTRY).yaml
+
+cbmc-batch.yaml: $(ENTRY).goto Makefile
+	echo 'jobos: ubuntu16' > $@
+	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
+	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'expected: "SUCCESSFUL"' >> $@
+
+ci-yaml: cbmc-batch.yaml
 
 launch: $(ENTRY).goto Makefile
 	mkdir -p $(WS)

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -17,12 +17,15 @@ default: report
 
 ################################################################
 # Helper-inc must go first, so it can override other includes.
-INC += \
-	-I$(SRCDIR)/helper-inc \
-	-I$(SRCDIR)/c-enc-sdk-inc \
-	-I$(SRCDIR)/c-common-inc 
-	 
+INC += -I$(SRCDIR)/helper-inc
+INC += -I$(SRCDIR)/c-enc-sdk-inc
+INC += -I$(SRCDIR)/c-common-inc
+INC += -I$(SRCDIR)/c-common-helper-inc
+INC += -I/usr/local/opt/openssl@1.1/include/
 
+CBMC_OBJECT_BITS ?= 8
+CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
+DEF += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEF += -DCBMC=1
 
 OPT += 
@@ -31,15 +34,21 @@ CFLAGS += $(CFLAGS2) $(DEF) $(OPT)
 
 LINKFARM = $(abspath ./link-farm)
 
+HARNESS_NAME ?= $(ENTRY)_harness.c
+
 ################################################################
-CBMCFLAGS += \
-	--bounds-check \
-	--pointer-check \
-	--signed-overflow-check \
-	--unsigned-overflow-check \
-	--pointer-overflow-check \
-	--div-by-zero-check \
-	--unwinding-assertions
+CBMCFLAGS += --bounds-check
+CBMCFLAGS += --div-by-zero-check
+CBMCFLAGS += --float-overflow-check
+CBMCFLAGS += --nan-check
+CBMCFLAGS += --pointer-check
+CBMCFLAGS += --pointer-overflow-check
+CBMCFLAGS += --signed-overflow-check
+CBMCFLAGS += --undefined-shift-check
+CBMCFLAGS += --unsigned-overflow-check
+CBMCFLAGS += --unwind 1
+CBMCFLAGS += --unwinding-assertions
+
 
 UNWIND ?= 0
 SIMPLIFY ?= 0
@@ -74,6 +83,10 @@ common-symlinks: common-git linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(COMMONDIR)/include, c-common-inc)
 	$(call make_symlink, $(LINKFARM), $(COMMONDIR)/source, c-common-src)
 
+common-helper-symlinks: common-git linkfarm-dir
+	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/include, c-common-helper-inc)
+	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/source, c-common-helper-src)
+
 enc-sdk-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(SDKDIR)/include, c-enc-sdk-inc)
 	$(call make_symlink, $(LINKFARM), $(SDKDIR)/source, c-enc-sdk-src)
@@ -86,20 +99,20 @@ helper-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(HELPERDIR)/source, helper-src)
 
 
-fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks helper-symlinks
+fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks common-helper-symlinks helper-symlinks
 
 $(ENTRY)1.goto: fill-linkfarm $(OBJS)
 	$(GOTO_CC) --function harness -o $@ $(OBJS)
 
 $(ENTRY)3.goto: $(ENTRY)1.goto
 	 $(GOTO_INSTRUMENT) $(ABSTRACTIONS) --add-library $< $@ \
-		2>&1 | tee $(ENTRY)3.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)3.log ; exit $${PIPESTATUS[0]}
 
 # Simplify and constant propagation may benefit from unwinding first
 $(ENTRY)4.goto: $(ENTRY)3.goto
 ifeq ($(UNWIND_GOTO), 1)
 	$(GOTO_INSTRUMENT) $(UNWINDING) $< $@ \
-		2>&1 | tee $(ENTRY)4.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)4.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
@@ -108,7 +121,7 @@ endif
 $(ENTRY)5.goto: $(ENTRY)4.goto
 ifeq ($(SIMPLIFY), 1)
 	$(GOTO_INSTRUMENT) --generate-function-body '.*' $< $@ \
-		2>&1 | tee $(ENTRY)5.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)5.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
@@ -117,18 +130,18 @@ endif
 $(ENTRY)6.goto: $(ENTRY)5.goto
 ifeq ($(SIMPLIFY), 1)
 	$(GOTO_ANALYZER) --simplify $@ $< \
-		2>&1 | tee $(ENTRY)6.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)6.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
 
 $(ENTRY)7.goto: $(ENTRY)6.goto
 	$(GOTO_INSTRUMENT) --drop-unused-functions $< $@ \
-		2>&1 | tee $(ENTRY)7.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)7.log ; exit $${PIPESTATUS[0]}
 
 $(ENTRY)8.goto: $(ENTRY)7.goto
 	$(GOTO_INSTRUMENT) --slice-global-inits $< $@ \
-		2>&1 | tee $(ENTRY)8.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)8.log ; exit $${PIPESTATUS[0]}
 
 $(ENTRY).goto: $(ENTRY)8.goto
 	cp $< $@
@@ -138,7 +151,7 @@ $(ENTRY).goto: $(ENTRY)8.goto
 
 goto: $(ENTRY).goto 
 
-cbmc.txt: $(ENTRY).goto
+cbmc.log: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
 
 property.xml: $(ENTRY).goto
@@ -147,27 +160,27 @@ property.xml: $(ENTRY).goto
 coverage.xml: $(ENTRY).goto
 	cbmc $(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui $< 2>&1 > $@
 
-cbmc: cbmc.txt
+cbmc: cbmc.log
 
 property: property.xml
 
 coverage: coverage.xml
 
-report: cbmc.txt property.xml coverage.xml
+report: cbmc.log property.xml coverage.xml
 	$(VIEWER) \
 	--goto $(ENTRY).goto \
 	--srcdir $(SRCDIR) \
 	--htmldir html \
 	--srcexclude "(./verification|./tests|./tools|./lib/third_party)" \
-	--result cbmc.txt \
+	--result cbmc.log \
 	--property property.xml \
 	--block coverage.xml
 
 clean:
 	$(RM) $(GOTOS)
 	$(RM) $(OBJS) $(ENTRY).goto
-	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
-	$(RM) cbmc.txt property.xml coverage.xml TAGS
+	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].log
+	$(RM) cbmc.log property.xml coverage.xml TAGS
 	$(RM) *~ \#*
 
 veryclean: clean

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -25,12 +25,12 @@ INC += -I/usr/local/opt/openssl@1.1/include/
 
 CBMC_OBJECT_BITS ?= 8
 CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
-DEF += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
-DEF += -DCBMC=1
+DEFINES += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
+DEFINES += -DCBMC=1
 
-OPT += 
+OPT +=
 
-CFLAGS += $(CFLAGS2) $(DEF) $(OPT) 
+CFLAGS += $(CFLAGS2) $(DEFINES) $(OPT)
 
 LINKFARM = $(abspath ./link-farm)
 
@@ -54,6 +54,8 @@ UNWIND ?= 0
 SIMPLIFY ?= 0
 
 ABSTRACTIONS ?=
+
+DEPENDENT_GOTOS = $(patsubst %.c,%.goto,$(DEPENDENCIES))
 
 ################################################################
 # makes a symlink if one doesn't already exist
@@ -86,13 +88,14 @@ common-symlinks: common-git linkfarm-dir
 common-helper-symlinks: common-git linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/include, c-common-helper-inc)
 	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/source, c-common-helper-src)
+	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/stubs, c-common-helper-stubs)
 
 enc-sdk-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(SDKDIR)/include, c-enc-sdk-inc)
 	$(call make_symlink, $(LINKFARM), $(SDKDIR)/source, c-enc-sdk-src)
 
 harness-symlink: linkfarm-dir
-	$(call make_symlink, $(LINKFARM), ../$(HARNESS_NAME), $(HARNESS_NAME)); 
+	$(call make_symlink, $(LINKFARM), ../$(HARNESS_NAME), $(HARNESS_NAME));
 
 helper-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(HELPERDIR)/include, helper-inc)
@@ -101,8 +104,8 @@ helper-symlinks: linkfarm-dir
 
 fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks common-helper-symlinks helper-symlinks
 
-$(ENTRY)1.goto: fill-linkfarm $(OBJS)
-	$(GOTO_CC) --function harness -o $@ $(OBJS)
+$(ENTRY)1.goto: fill-linkfarm $(DEPENDENT_GOTOS)
+	$(GOTO_CC) --function harness -o $@ $(DEPENDENT_GOTOS)
 
 $(ENTRY)3.goto: $(ENTRY)1.goto
 	 $(GOTO_INSTRUMENT) $(ABSTRACTIONS) --add-library $< $@ \
@@ -149,7 +152,7 @@ $(ENTRY).goto: $(ENTRY)8.goto
 %.goto : %.c fill-linkfarm
 	$(GOTO_CC) -o $@ $(INC) $(CFLAGS) $<
 
-goto: $(ENTRY).goto 
+goto: $(ENTRY).goto
 
 cbmc.log: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
@@ -178,7 +181,7 @@ report: cbmc.log property.xml coverage.xml
 
 clean:
 	$(RM) $(GOTOS)
-	$(RM) $(OBJS) $(ENTRY).goto
+	$(RM) $(DEPENDENT_GOTOS) $(ENTRY).goto
 	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].log
 	$(RM) cbmc.log property.xml coverage.xml TAGS
 	$(RM) *~ \#*

--- a/.cbmc-batch/jobs/Makefile.local_default
+++ b/.cbmc-batch/jobs/Makefile.local_default
@@ -24,5 +24,6 @@ SRCDIR ?= $(abspath ./link-farm)
 BASEDIR ?= $(abspath ../../../..)
 COMMON_REPO_NAME ?= aws-c-common-for-cryptosdk-proofs
 COMMONDIR ?= $(BASEDIR)/$(COMMON_REPO_NAME)
+COMMON_HELPERDIR ?= $(COMMONDIR)/.cbmc-batch
 SDKDIR ?= $(abspath ../../..)
 HELPERDIR ?= $(SDKDIR)/.cbmc-batch

--- a/.cbmc-batch/jobs/aws_cryptosdk_deserialize_frame/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_deserialize_frame/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_deserialize_frame_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_deserialize_frame/aws_cryptosdk_deserialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_deserialize_frame/aws_cryptosdk_deserialize_frame_harness.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_deserialize_frame_harness() {
+    /* Data structures */
+    struct aws_cryptosdk_frame frame;
+    size_t ciphertext_size;
+    size_t plaintext_size;
+    struct aws_byte_cursor ciphertext_buf;
+    enum aws_cryptosdk_alg_id id;
+    struct aws_cryptosdk_alg_properties *alg_props = aws_cryptosdk_alg_props(id);
+    uint32_t max_frame_size;
+
+    /* Assumptions about the function inputs */
+    ensure_byte_cursor_has_allocated_buffer_member(&ciphertext_buf);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&ciphertext_buf));
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(alg_props));
+
+    /* Save the old state of the ciphertext cursor */
+    uint8_t *old_ciphertext_buffer      = ciphertext_buf.ptr;
+    size_t old_ciphertext_buffer_length = ciphertext_buf.len;
+
+    size_t number_of_bytes_read;
+
+    /* Operation being verified */
+    if (aws_cryptosdk_deserialize_frame(
+            &frame, &ciphertext_size, &plaintext_size, &ciphertext_buf, alg_props, max_frame_size) == AWS_OP_SUCCESS) {
+        assert(aws_cryptosdk_frame_is_valid(&frame));
+        if (max_frame_size == 0) {
+            // non-framed case
+            assert(frame.sequence_number == 1);
+            assert(frame.type == FRAME_TYPE_SINGLE);
+            // Reads: IV, encrypted content length (8 bytes), encrypted content, authentication tag
+            number_of_bytes_read = alg_props->iv_len + 8 + plaintext_size + alg_props->tag_len;
+        } else {
+            // framed case
+            if (frame.type == FRAME_TYPE_FRAME) {
+                assert(plaintext_size == max_frame_size);
+                // Reads: sequence number (4 bytes), IV, encrypted content, authentication tag
+                number_of_bytes_read = 4 + alg_props->iv_len + plaintext_size + alg_props->tag_len;
+            } else {
+                assert(frame.type == FRAME_TYPE_FINAL);
+                // Reads: sequence number end indicator (4 bytes), sequence number (4 bytes), IV, encrypted content
+                // length (4 bytes), encrypted content, authentication tag
+                number_of_bytes_read = 4 + 4 + alg_props->iv_len + 4 + plaintext_size + alg_props->tag_len;
+            }
+        }
+        assert(ciphertext_buf.ptr == old_ciphertext_buffer + number_of_bytes_read);
+        assert(ciphertext_buf.len == old_ciphertext_buffer_length - number_of_bytes_read);
+    }
+    assert(aws_byte_cursor_is_valid(&ciphertext_buf));
+    assert(aws_cryptosdk_alg_properties_is_valid(alg_props));
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_deserialize_frame/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_deserialize_frame/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_deserialize_frame_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
@@ -20,12 +20,10 @@ include ../Makefile.local_default
 
 ######### 
 ENTRY = MultiKeyringNew
-HARNESS_NAME = $(ENTRY)_harness.c
-OBJS = \
-	$(SRCDIR)/$(ENTRY)_harness.goto \
-	$(SRCDIR)/c-enc-sdk-src/multi_keyring.goto \
-	$(SRCDIR)/c-common-src/common.goto \
-	$(SRCDIR)/helper-src/proof_allocators.goto
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+OBJS += $(SRCDIR)/c-enc-sdk-src/multi_keyring.goto
+OBJS += $(SRCDIR)/c-common-src/common.goto
+OBJS += $(SRCDIR)/helper-src/proof_allocators.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
@@ -19,12 +19,11 @@ sinclude ../Makefile.local
 include ../Makefile.local_default
 
 #########
-ENTRY = MultiKeyringNew
+ENTRY = MultiKeyringNew_harness
 
-DEPENDENCIES += $(SRCDIR)/$(ENTRY)_harness.goto
-DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/multi_keyring.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/multi_keyring.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/helper-src/proof_allocators.c
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
@@ -13,17 +13,18 @@
 
 
 #########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
+# if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 
-######### 
+#########
 ENTRY = MultiKeyringNew
-OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
-OBJS += $(SRCDIR)/c-enc-sdk-src/multi_keyring.goto
-OBJS += $(SRCDIR)/c-common-src/common.goto
-OBJS += $(SRCDIR)/helper-src/proof_allocators.goto
+
+DEPENDENCIES += $(SRCDIR)/$(ENTRY)_harness.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/multi_keyring.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/proof_allocators.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/MultiKeyringNew_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/MultiKeyringNew_harness.c
@@ -19,7 +19,7 @@
 
 // This is a memory safety proof for aws_cryptosdk_multi_keyring() defined in
 // https://github.com/aws/aws-encryption-sdk-c/blob/master/source/multi_keyring.c
-void harness() {
+void MultiKeyringNew_harness() {
     struct aws_allocator *alloc = can_fail_allocator();
     struct aws_cryptosdk_keyring generator;
     aws_cryptosdk_keyring_base_init(&generator, NULL);

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/cbmc-batch.yaml
@@ -1,17 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
-# this file except in compliance with the License. A copy of the License is
-# located at
-#
-#     http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied. See the License for the specific language governing permissions and
-# limitations under the License.
-
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--pointer-check;--signed-overflow-check;--unsigned-overflow-check;--pointer-overflow-check;--div-by-zero-check;--unwinding-assertions"
-goto: MultiKeyringNew.goto
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: MultiKeyringNew_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+UNWINDSET += 
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_serialize_frame
+
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+
+OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/utils.goto
+OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
+OBJS +=	$(SRCDIR)/c-common-src/common.goto
+OBJS +=	$(SRCDIR)/c-common-src/error.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
+OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
@@ -12,29 +12,27 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
+# if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 
 ## At the moment this is not used in the Makefile.common of encryption-sdk
-UNWINDSET += 
+UNWINDSET +=
 
 CBMCFLAGS +=
 
-ENTRY = aws_cryptosdk_serialize_frame
+ENTRY = aws_cryptosdk_serialize_frame_harness
 
-OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
-
-OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
-OBJS +=	$(SRCDIR)/c-common-helper-src/utils.goto
-OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
-OBJS +=	$(SRCDIR)/c-common-src/common.goto
-OBJS +=	$(SRCDIR)/c-common-src/error.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
-OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void harness() {
+    /* data structure */
+    struct aws_cryptosdk_frame frame;
+    size_t ciphertext_size;
+    size_t plaintext_size;
+    struct aws_byte_buf ciphertext_buf;
+    struct aws_cryptosdk_alg_properties alg_props;
+
+    /* Assumptions about the function input */
+    ensure_byte_buf_has_allocated_buffer_member(&ciphertext_buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&ciphertext_buf));
+
+    ensure_alg_properties_has_allocated_names(&alg_props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(&alg_props));
+
+    /* Save the old state of the ciphertext buffer */
+    uint8_t *old_ciphertext_buffer   = ciphertext_buf.buffer;
+    size_t old_ciphertext_buffer_len = ciphertext_buf.len;
+
+    int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, &alg_props);
+    if (rval == AWS_OP_SUCCESS) {
+        assert(aws_cryptosdk_frame_is_valid(&frame));
+        assert(ciphertext_buf.buffer == old_ciphertext_buffer);
+        assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
+    } else {
+        // Assert that the ciphertext buffer is zeroed in case of failure
+        assert_all_zeroes(ciphertext_buf.buffer, ciphertext_buf.capacity);
+        assert(ciphertext_buf.len == 0);
+    }   
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -38,7 +38,7 @@ void harness() {
     size_t old_ciphertext_buffer_len = ciphertext_buf.len;
 
     /* Assume the preconditions */
-    __CPROVER_assume(aws_cryptosdk_frame_has_valid_type_seq(&frame));
+    __CPROVER_assume(aws_cryptosdk_frame_has_valid_type(&frame));
 
     int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, &alg_props);
     if (rval == AWS_OP_SUCCESS) {

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -18,7 +18,7 @@
 #include <make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void harness() {
+void aws_cryptosdk_serialize_frame_harness() {
     /* data structure */
     struct aws_cryptosdk_frame frame;  // Preconditions assume not null
     size_t ciphertext_size;

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--object-bits;8;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions"
+goto: aws_cryptosdk_serialize_frame.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--object-bits;8;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions"
-goto: aws_cryptosdk_serialize_frame.goto
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_serialize_frame_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/patches/memcpy.c
+++ b/.cbmc-batch/patches/memcpy.c
@@ -4,83 +4,62 @@
 /* FUNCTION: memcpy */
 
 #ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
+#    include <string.h>
+#    define __CPROVER_STRING_H_INCLUDED
 #endif
 
 #undef memcpy
 
-void *memcpy(void *dst, const void *src, size_t n)
-{
-  __CPROVER_HIDE:
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(src)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)>=n,
-                         "memcpy buffer overflow");
-  //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
-  if(__CPROVER_is_zero_string(src) &&
-     n > __CPROVER_zero_string_length(src))
-  {
-    __CPROVER_is_zero_string(dst)=1;
-    __CPROVER_zero_string_length(dst)=__CPROVER_zero_string_length(src);
-  }
-  else if(!(__CPROVER_is_zero_string(dst) &&
-            n <= __CPROVER_zero_string_length(dst)))
-    __CPROVER_is_zero_string(dst)=0;
-  #else
-  __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst)!=
-                         __CPROVER_POINTER_OBJECT(src),
-                         "memcpy src/dst overlap");
+void *memcpy(void *dst, const void *src, size_t n) {
+__CPROVER_HIDE:
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(src) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) >= n, "memcpy buffer overflow");
+    //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
+    if (__CPROVER_is_zero_string(src) && n > __CPROVER_zero_string_length(src)) {
+        __CPROVER_is_zero_string(dst)     = 1;
+        __CPROVER_zero_string_length(dst) = __CPROVER_zero_string_length(src);
+    } else if (!(__CPROVER_is_zero_string(dst) && n <= __CPROVER_zero_string_length(dst)))
+        __CPROVER_is_zero_string(dst) = 0;
+#else
+    __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst) != __CPROVER_POINTER_OBJECT(src), "memcpy src/dst overlap");
 
-  if(n > 0)
-  {
-    (void)*(char *)dst; // check that the memory is accessible
-    (void)*(const char *)src; // check that the memory is accessible
-    (void)*(((char *)dst) + n - 1);       // check that the memory is accessible
-    (void)*(((const char *)src) + n - 1); // check that the memory is accessible
-    for(__CPROVER_size_t i=0; i<n ; i++) ((char *)dst)[i]=((const char *)src)[i];
-  }
-  #endif
-  return dst;
+    if (n > 0) {
+        (void)*(char *)dst;                    // check that the memory is accessible
+        (void)*(const char *)src;              // check that the memory is accessible
+        (void)*(((char *)dst) + n - 1);        // check that the memory is accessible
+        (void)*(((const char *)src) + n - 1);  // check that the memory is accessible
+        for (__CPROVER_size_t i = 0; i < n; i++) ((char *)dst)[i] = ((const char *)src)[i];
+    }
+#endif
+    return dst;
 }
 
 /* FUNCTION: __builtin___memcpy_chk */
 
-void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __CPROVER_size_t size)
-{
-  __CPROVER_HIDE:
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(src)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)==s,
-                         "builtin object size");
-  //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
-  if(__CPROVER_is_zero_string(src) &&
-     n > __CPROVER_zero_string_length(src))
-  {
-    __CPROVER_is_zero_string(dst)=1;
-    __CPROVER_zero_string_length(dst)=__CPROVER_zero_string_length(src);
-  }
-  else if(!(__CPROVER_is_zero_string(dst) &&
-            n <= __CPROVER_zero_string_length(dst)))
-    __CPROVER_is_zero_string(dst)=0;
-  #else
-  __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst)!=
-                         __CPROVER_POINTER_OBJECT(src),
-                         "memcpy src/dst overlap");
-  (void)size;
+void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __CPROVER_size_t size) {
+__CPROVER_HIDE:
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(src) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) == s, "builtin object size");
+    //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
+    if (__CPROVER_is_zero_string(src) && n > __CPROVER_zero_string_length(src)) {
+        __CPROVER_is_zero_string(dst)     = 1;
+        __CPROVER_zero_string_length(dst) = __CPROVER_zero_string_length(src);
+    } else if (!(__CPROVER_is_zero_string(dst) && n <= __CPROVER_zero_string_length(dst)))
+        __CPROVER_is_zero_string(dst) = 0;
+#else
+    __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst) != __CPROVER_POINTER_OBJECT(src), "memcpy src/dst overlap");
+    (void)size;
 
-  if(n > 0)
-  {
-    (void)*(char *)dst; // check that the memory is accessible
-    (void)*(const char *)src; // check that the memory is accessible
-    (void)*(((char *)dst) + n - 1);       // check that the memory is accessible
-    (void)*(((const char *)src) + n - 1); // check that the memory is accessible
-    for(__CPROVER_size_t i=0; i<n ; i++) ((char *)dst)[i]=((const char *)src)[i];
-  }
-  #endif
-  return dst;
+    if (n > 0) {
+        (void)*(char *)dst;                    // check that the memory is accessible
+        (void)*(const char *)src;              // check that the memory is accessible
+        (void)*(((char *)dst) + n - 1);        // check that the memory is accessible
+        (void)*(((const char *)src) + n - 1);  // check that the memory is accessible
+        for (__CPROVER_size_t i = 0; i < n; i++) ((char *)dst)[i] = ((const char *)src)[i];
+    }
+#endif
+    return dst;
 }

--- a/.cbmc-batch/patches/memcpy_nocpy.c
+++ b/.cbmc-batch/patches/memcpy_nocpy.c
@@ -4,83 +4,62 @@
 /* FUNCTION: memcpy */
 
 #ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
+#    include <string.h>
+#    define __CPROVER_STRING_H_INCLUDED
 #endif
 
 #undef memcpy
 
-void *memcpy(void *dst, const void *src, size_t n)
-{
-  __CPROVER_HIDE:
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(src)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)>=n,
-                         "memcpy buffer overflow");
-  //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
-  if(__CPROVER_is_zero_string(src) &&
-     n > __CPROVER_zero_string_length(src))
-  {
-    __CPROVER_is_zero_string(dst)=1;
-    __CPROVER_zero_string_length(dst)=__CPROVER_zero_string_length(src);
-  }
-  else if(!(__CPROVER_is_zero_string(dst) &&
-            n <= __CPROVER_zero_string_length(dst)))
-    __CPROVER_is_zero_string(dst)=0;
-  #else
-  __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst)!=
-                         __CPROVER_POINTER_OBJECT(src),
-                         "memcpy src/dst overlap");
+void *memcpy(void *dst, const void *src, size_t n) {
+__CPROVER_HIDE:
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(src) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) >= n, "memcpy buffer overflow");
+    //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
+    if (__CPROVER_is_zero_string(src) && n > __CPROVER_zero_string_length(src)) {
+        __CPROVER_is_zero_string(dst)     = 1;
+        __CPROVER_zero_string_length(dst) = __CPROVER_zero_string_length(src);
+    } else if (!(__CPROVER_is_zero_string(dst) && n <= __CPROVER_zero_string_length(dst)))
+        __CPROVER_is_zero_string(dst) = 0;
+#else
+    __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst) != __CPROVER_POINTER_OBJECT(src), "memcpy src/dst overlap");
 
-  if(n > 0)
-  {
-    (void)*(char *)dst; // check that the memory is accessible
-    (void)*(const char *)src; // check that the memory is accessible
-    (void)*(((char *)dst) + n - 1);       // check that the memory is accessible
-    (void)*(((const char *)src) + n - 1); // check that the memory is accessible
-    // Don't actually copy because the values don't matter
-  }
-  #endif
-  return dst;
+    if (n > 0) {
+        (void)*(char *)dst;                    // check that the memory is accessible
+        (void)*(const char *)src;              // check that the memory is accessible
+        (void)*(((char *)dst) + n - 1);        // check that the memory is accessible
+        (void)*(((const char *)src) + n - 1);  // check that the memory is accessible
+                                               // Don't actually copy because the values don't matter
+    }
+#endif
+    return dst;
 }
 
 /* FUNCTION: __builtin___memcpy_chk */
 
-void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __CPROVER_size_t size)
-{
-  __CPROVER_HIDE:
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(src)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)==s,
-                         "builtin object size");
-  //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
-  if(__CPROVER_is_zero_string(src) &&
-     n > __CPROVER_zero_string_length(src))
-  {
-    __CPROVER_is_zero_string(dst)=1;
-    __CPROVER_zero_string_length(dst)=__CPROVER_zero_string_length(src);
-  }
-  else if(!(__CPROVER_is_zero_string(dst) &&
-            n <= __CPROVER_zero_string_length(dst)))
-    __CPROVER_is_zero_string(dst)=0;
-  #else
-  __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst)!=
-                         __CPROVER_POINTER_OBJECT(src),
-                         "memcpy src/dst overlap");
-  (void)size;
+void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __CPROVER_size_t size) {
+__CPROVER_HIDE:
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(src) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) == s, "builtin object size");
+    //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
+    if (__CPROVER_is_zero_string(src) && n > __CPROVER_zero_string_length(src)) {
+        __CPROVER_is_zero_string(dst)     = 1;
+        __CPROVER_zero_string_length(dst) = __CPROVER_zero_string_length(src);
+    } else if (!(__CPROVER_is_zero_string(dst) && n <= __CPROVER_zero_string_length(dst)))
+        __CPROVER_is_zero_string(dst) = 0;
+#else
+    __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst) != __CPROVER_POINTER_OBJECT(src), "memcpy src/dst overlap");
+    (void)size;
 
-  if(n > 0)
-  {
-    (void)*(char *)dst; // check that the memory is accessible
-    (void)*(const char *)src; // check that the memory is accessible
-    (void)*(((char *)dst) + n - 1);       // check that the memory is accessible
-    (void)*(((const char *)src) + n - 1); // check that the memory is accessible
-    // Don't actually copy because the values don't matter
-  }
-  #endif
-  return dst;
+    if (n > 0) {
+        (void)*(char *)dst;                    // check that the memory is accessible
+        (void)*(const char *)src;              // check that the memory is accessible
+        (void)*(((char *)dst) + n - 1);        // check that the memory is accessible
+        (void)*(((const char *)src) + n - 1);  // check that the memory is accessible
+                                               // Don't actually copy because the values don't matter
+    }
+#endif
+    return dst;
 }

--- a/.cbmc-batch/patches/memcpy_small.c
+++ b/.cbmc-batch/patches/memcpy_small.c
@@ -5,87 +5,66 @@
 /* FUNCTION: memcpy */
 
 #ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
+#    include <string.h>
+#    define __CPROVER_STRING_H_INCLUDED
 #endif
 
 #undef memcpy
 
 #define BOUND 5
 
-void *memcpy(void *dst, const void *src, size_t n)
-{
-  __CPROVER_HIDE:
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(src)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)>=n,
-                         "memcpy buffer overflow");
-  //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
-  if(__CPROVER_is_zero_string(src) &&
-     n > __CPROVER_zero_string_length(src))
-  {
-    __CPROVER_is_zero_string(dst)=1;
-    __CPROVER_zero_string_length(dst)=__CPROVER_zero_string_length(src);
-  }
-  else if(!(__CPROVER_is_zero_string(dst) &&
-            n <= __CPROVER_zero_string_length(dst)))
-    __CPROVER_is_zero_string(dst)=0;
-  #else
-  __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst)!=
-                         __CPROVER_POINTER_OBJECT(src),
-                         "memcpy src/dst overlap");
+void *memcpy(void *dst, const void *src, size_t n) {
+__CPROVER_HIDE:
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(src) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) >= n, "memcpy buffer overflow");
+    //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
+    if (__CPROVER_is_zero_string(src) && n > __CPROVER_zero_string_length(src)) {
+        __CPROVER_is_zero_string(dst)     = 1;
+        __CPROVER_zero_string_length(dst) = __CPROVER_zero_string_length(src);
+    } else if (!(__CPROVER_is_zero_string(dst) && n <= __CPROVER_zero_string_length(dst)))
+        __CPROVER_is_zero_string(dst) = 0;
+#else
+    __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst) != __CPROVER_POINTER_OBJECT(src), "memcpy src/dst overlap");
 
-  if(n > 0)
-  {
-    (void)*(char *)dst; // check that the memory is accessible
-    (void)*(const char *)src; // check that the memory is accessible
-    (void)*(((char *)dst) + n - 1);       // check that the memory is accessible
-    (void)*(((const char *)src) + n - 1); // check that the memory is accessible
-    if (n < BOUND)
-        for(__CPROVER_size_t i=0; i<n ; i++) ((char *)dst)[i]=((const char *)src)[i];
-  }
-  #endif
-  return dst;
+    if (n > 0) {
+        (void)*(char *)dst;                    // check that the memory is accessible
+        (void)*(const char *)src;              // check that the memory is accessible
+        (void)*(((char *)dst) + n - 1);        // check that the memory is accessible
+        (void)*(((const char *)src) + n - 1);  // check that the memory is accessible
+        if (n < BOUND)
+            for (__CPROVER_size_t i = 0; i < n; i++) ((char *)dst)[i] = ((const char *)src)[i];
+    }
+#endif
+    return dst;
 }
 
 /* FUNCTION: __builtin___memcpy_chk */
 
-void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __CPROVER_size_t size)
-{
-  __CPROVER_HIDE:
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(src)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)>=n,
-                         "memcpy buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(dst)==s,
-                         "builtin object size");
-  //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
-  if(__CPROVER_is_zero_string(src) &&
-     n > __CPROVER_zero_string_length(src))
-  {
-    __CPROVER_is_zero_string(dst)=1;
-    __CPROVER_zero_string_length(dst)=__CPROVER_zero_string_length(src);
-  }
-  else if(!(__CPROVER_is_zero_string(dst) &&
-            n <= __CPROVER_zero_string_length(dst)))
-    __CPROVER_is_zero_string(dst)=0;
-  #else
-  __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst)!=
-                         __CPROVER_POINTER_OBJECT(src),
-                         "memcpy src/dst overlap");
-  (void)size;
+void *__builtin___memcpy_chk(void *dst, const void *src, __CPROVER_size_t n, __CPROVER_size_t size) {
+__CPROVER_HIDE:
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(src) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) >= n, "memcpy buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(dst) == s, "builtin object size");
+    //  for(size_t i=0; i<n ; i++) dst[i]=src[i];
+    if (__CPROVER_is_zero_string(src) && n > __CPROVER_zero_string_length(src)) {
+        __CPROVER_is_zero_string(dst)     = 1;
+        __CPROVER_zero_string_length(dst) = __CPROVER_zero_string_length(src);
+    } else if (!(__CPROVER_is_zero_string(dst) && n <= __CPROVER_zero_string_length(dst)))
+        __CPROVER_is_zero_string(dst) = 0;
+#else
+    __CPROVER_precondition(__CPROVER_POINTER_OBJECT(dst) != __CPROVER_POINTER_OBJECT(src), "memcpy src/dst overlap");
+    (void)size;
 
-  if(n > 0)
-  {
-    (void)*(char *)dst; // check that the memory is accessible
-    (void)*(const char *)src; // check that the memory is accessible
-    (void)*(((char *)dst) + n - 1);       // check that the memory is accessible
-    (void)*(((const char *)src) + n - 1); // check that the memory is accessible
-    if (n < BOUND)
-        for(__CPROVER_size_t i=0; i<n ; i++) ((char *)dst)[i]=((const char *)src)[i];
-  }
-  #endif
-  return dst;
+    if (n > 0) {
+        (void)*(char *)dst;                    // check that the memory is accessible
+        (void)*(const char *)src;              // check that the memory is accessible
+        (void)*(((char *)dst) + n - 1);        // check that the memory is accessible
+        (void)*(((const char *)src) + n - 1);  // check that the memory is accessible
+        if (n < BOUND)
+            for (__CPROVER_size_t i = 0; i < n; i++) ((char *)dst)[i] = ((const char *)src)[i];
+    }
+#endif
+    return dst;
 }

--- a/.cbmc-batch/patches/memset.c
+++ b/.cbmc-batch/patches/memset.c
@@ -4,113 +4,87 @@
 /* FUNCTION: memset */
 
 #ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
+#    include <string.h>
+#    define __CPROVER_STRING_H_INCLUDED
 #endif
 
 #undef memset
 
-void *memset(void *s, int c, size_t n)
-{
-  __CPROVER_HIDE:;
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(s)>=n,
-                         "memset buffer overflow");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
-  if(__CPROVER_is_zero_string(s) &&
-     n > __CPROVER_zero_string_length(s))
-  {
-    __CPROVER_is_zero_string(s)=1;
-  }
-  else if(c==0)
-  {
-    __CPROVER_is_zero_string(s)=1;
-    __CPROVER_zero_string_length(s)=0;
-  }
-  else
-    __CPROVER_is_zero_string(s)=0;
-  #else
+void *memset(void *s, int c, size_t n) {
+__CPROVER_HIDE:;
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(s) >= n, "memset buffer overflow");
+    //  for(size_t i=0; i<n ; i++) s[i]=c;
+    if (__CPROVER_is_zero_string(s) && n > __CPROVER_zero_string_length(s)) {
+        __CPROVER_is_zero_string(s) = 1;
+    } else if (c == 0) {
+        __CPROVER_is_zero_string(s)     = 1;
+        __CPROVER_zero_string_length(s) = 0;
+    } else
+        __CPROVER_is_zero_string(s) = 0;
+#else
 
-  if(n > 0)
-  {
-    (void)*(char *)s; // check that the memory is accessible
-    (void)*(((char *)s) + n - 1); // check that the memory is accessible
-    char *sp=s;
-    for(__CPROVER_size_t i=0; i<n ; i++) sp[i]=c;
-  }
-  #endif
-  return s;
+    if (n > 0) {
+        (void)*(char *)s;              // check that the memory is accessible
+        (void)*(((char *)s) + n - 1);  // check that the memory is accessible
+        char *sp = s;
+        for (__CPROVER_size_t i = 0; i < n; i++) sp[i] = c;
+    }
+#endif
+    return s;
 }
 
 /* FUNCTION: __builtin_memset */
 
-void *__builtin_memset(void *s, int c, __CPROVER_size_t n)
-{
-  __CPROVER_HIDE:;
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(s)>=n,
-                         "memset buffer overflow");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
-  if(__CPROVER_is_zero_string(s) &&
-     n > __CPROVER_zero_string_length(s))
-  {
-    __CPROVER_is_zero_string(s)=1;
-  }
-  else if(c==0)
-  {
-    __CPROVER_is_zero_string(s)=1;
-    __CPROVER_zero_string_length(s)=0;
-  }
-  else
-  {
-    __CPROVER_is_zero_string(s)=0;
-  }
-  #else
+void *__builtin_memset(void *s, int c, __CPROVER_size_t n) {
+__CPROVER_HIDE:;
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(s) >= n, "memset buffer overflow");
+    //  for(size_t i=0; i<n ; i++) s[i]=c;
+    if (__CPROVER_is_zero_string(s) && n > __CPROVER_zero_string_length(s)) {
+        __CPROVER_is_zero_string(s) = 1;
+    } else if (c == 0) {
+        __CPROVER_is_zero_string(s)     = 1;
+        __CPROVER_zero_string_length(s) = 0;
+    } else {
+        __CPROVER_is_zero_string(s) = 0;
+    }
+#else
 
-  if(n > 0)
-  {
-    (void)*(char *)s; // check that the memory is accessible
-    (void)*(((char *)s) + n - 1); // check that the memory is accessible
-    char *sp=s;
-    for(__CPROVER_size_t i=0; i<n ; i++) sp[i]=c;
-  }
-  #endif
-  return s;
+    if (n > 0) {
+        (void)*(char *)s;              // check that the memory is accessible
+        (void)*(((char *)s) + n - 1);  // check that the memory is accessible
+        char *sp = s;
+        for (__CPROVER_size_t i = 0; i < n; i++) sp[i] = c;
+    }
+#endif
+    return s;
 }
 
 /* FUNCTION: __builtin___memset_chk */
 
-void *__builtin___memset_chk(void *s, int c, __CPROVER_size_t n, __CPROVER_size_t size)
-{
-  __CPROVER_HIDE:;
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(s)>=n,
-                         "memset buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(s)==size,
-                         "builtin object size");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
-  if(__CPROVER_is_zero_string(s) &&
-     n > __CPROVER_zero_string_length(s))
-  {
-    __CPROVER_is_zero_string(s)=1;
-  }
-  else if(c==0)
-  {
-    __CPROVER_is_zero_string(s)=1;
-    __CPROVER_zero_string_length(s)=0;
-  }
-  else
-    __CPROVER_is_zero_string(s)=0;
-  #else
-  (void)size;
+void *__builtin___memset_chk(void *s, int c, __CPROVER_size_t n, __CPROVER_size_t size) {
+__CPROVER_HIDE:;
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(s) >= n, "memset buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(s) == size, "builtin object size");
+    //  for(size_t i=0; i<n ; i++) s[i]=c;
+    if (__CPROVER_is_zero_string(s) && n > __CPROVER_zero_string_length(s)) {
+        __CPROVER_is_zero_string(s) = 1;
+    } else if (c == 0) {
+        __CPROVER_is_zero_string(s)     = 1;
+        __CPROVER_zero_string_length(s) = 0;
+    } else
+        __CPROVER_is_zero_string(s) = 0;
+#else
+    (void)size;
 
-  if(n > 0)
-  {
-    (void)*(char *)s; // check that the memory is accessible
-    (void)*(((char *)s) + n - 1); // check that the memory is accessible
-    char *sp=s;
-    for(__CPROVER_size_t i=0; i<n ; i++) sp[i]=c;
-  }
-  #endif
-  return s;
+    if (n > 0) {
+        (void)*(char *)s;              // check that the memory is accessible
+        (void)*(((char *)s) + n - 1);  // check that the memory is accessible
+        char *sp = s;
+        for (__CPROVER_size_t i = 0; i < n; i++) sp[i] = c;
+    }
+#endif
+    return s;
 }

--- a/.cbmc-batch/patches/memset_noset.c
+++ b/.cbmc-batch/patches/memset_noset.c
@@ -4,113 +4,87 @@
 /* FUNCTION: memset */
 
 #ifndef __CPROVER_STRING_H_INCLUDED
-#include <string.h>
-#define __CPROVER_STRING_H_INCLUDED
+#    include <string.h>
+#    define __CPROVER_STRING_H_INCLUDED
 #endif
 
 #undef memset
 
-void *memset(void *s, int c, size_t n)
-{
-  __CPROVER_HIDE:;
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(s)>=n,
-                         "memset buffer overflow");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
-  if(__CPROVER_is_zero_string(s) &&
-     n > __CPROVER_zero_string_length(s))
-  {
-    __CPROVER_is_zero_string(s)=1;
-  }
-  else if(c==0)
-  {
-    __CPROVER_is_zero_string(s)=1;
-    __CPROVER_zero_string_length(s)=0;
-  }
-  else
-    __CPROVER_is_zero_string(s)=0;
-  #else
+void *memset(void *s, int c, size_t n) {
+__CPROVER_HIDE:;
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(s) >= n, "memset buffer overflow");
+    //  for(size_t i=0; i<n ; i++) s[i]=c;
+    if (__CPROVER_is_zero_string(s) && n > __CPROVER_zero_string_length(s)) {
+        __CPROVER_is_zero_string(s) = 1;
+    } else if (c == 0) {
+        __CPROVER_is_zero_string(s)     = 1;
+        __CPROVER_zero_string_length(s) = 0;
+    } else
+        __CPROVER_is_zero_string(s) = 0;
+#else
 
-  if(n > 0)
-  {
-    (void)*(char *)s; // check that the memory is accessible
-    (void)*(((char *)s) + n - 1); // check that the memory is accessible
-    char *sp=s;
-    // Don't actually do the memset, since the values aren't important
-  }
-  #endif
-  return s;
+    if (n > 0) {
+        (void)*(char *)s;              // check that the memory is accessible
+        (void)*(((char *)s) + n - 1);  // check that the memory is accessible
+        char *sp = s;
+        // Don't actually do the memset, since the values aren't important
+    }
+#endif
+    return s;
 }
 
 /* FUNCTION: __builtin_memset */
 
-void *__builtin_memset(void *s, int c, __CPROVER_size_t n)
-{
-  __CPROVER_HIDE:;
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(s)>=n,
-                         "memset buffer overflow");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
-  if(__CPROVER_is_zero_string(s) &&
-     n > __CPROVER_zero_string_length(s))
-  {
-    __CPROVER_is_zero_string(s)=1;
-  }
-  else if(c==0)
-  {
-    __CPROVER_is_zero_string(s)=1;
-    __CPROVER_zero_string_length(s)=0;
-  }
-  else
-  {
-    __CPROVER_is_zero_string(s)=0;
-  }
-  #else
+void *__builtin_memset(void *s, int c, __CPROVER_size_t n) {
+__CPROVER_HIDE:;
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(s) >= n, "memset buffer overflow");
+    //  for(size_t i=0; i<n ; i++) s[i]=c;
+    if (__CPROVER_is_zero_string(s) && n > __CPROVER_zero_string_length(s)) {
+        __CPROVER_is_zero_string(s) = 1;
+    } else if (c == 0) {
+        __CPROVER_is_zero_string(s)     = 1;
+        __CPROVER_zero_string_length(s) = 0;
+    } else {
+        __CPROVER_is_zero_string(s) = 0;
+    }
+#else
 
-  if(n > 0)
-  {
-    (void)*(char *)s; // check that the memory is accessible
-    (void)*(((char *)s) + n - 1); // check that the memory is accessible
-    char *sp=s;
-    // Don't actually do the memset, since te values aren't important
-  }
-  #endif
-  return s;
+    if (n > 0) {
+        (void)*(char *)s;              // check that the memory is accessible
+        (void)*(((char *)s) + n - 1);  // check that the memory is accessible
+        char *sp = s;
+        // Don't actually do the memset, since te values aren't important
+    }
+#endif
+    return s;
 }
 
 /* FUNCTION: __builtin___memset_chk */
 
-void *__builtin___memset_chk(void *s, int c, __CPROVER_size_t n, __CPROVER_size_t size)
-{
-  __CPROVER_HIDE:;
-  #ifdef __CPROVER_STRING_ABSTRACTION
-  __CPROVER_precondition(__CPROVER_buffer_size(s)>=n,
-                         "memset buffer overflow");
-  __CPROVER_precondition(__CPROVER_buffer_size(s)==size,
-                         "builtin object size");
-  //  for(size_t i=0; i<n ; i++) s[i]=c;
-  if(__CPROVER_is_zero_string(s) &&
-     n > __CPROVER_zero_string_length(s))
-  {
-    __CPROVER_is_zero_string(s)=1;
-  }
-  else if(c==0)
-  {
-    __CPROVER_is_zero_string(s)=1;
-    __CPROVER_zero_string_length(s)=0;
-  }
-  else
-    __CPROVER_is_zero_string(s)=0;
-  #else
-  (void)size;
+void *__builtin___memset_chk(void *s, int c, __CPROVER_size_t n, __CPROVER_size_t size) {
+__CPROVER_HIDE:;
+#ifdef __CPROVER_STRING_ABSTRACTION
+    __CPROVER_precondition(__CPROVER_buffer_size(s) >= n, "memset buffer overflow");
+    __CPROVER_precondition(__CPROVER_buffer_size(s) == size, "builtin object size");
+    //  for(size_t i=0; i<n ; i++) s[i]=c;
+    if (__CPROVER_is_zero_string(s) && n > __CPROVER_zero_string_length(s)) {
+        __CPROVER_is_zero_string(s) = 1;
+    } else if (c == 0) {
+        __CPROVER_is_zero_string(s)     = 1;
+        __CPROVER_zero_string_length(s) = 0;
+    } else
+        __CPROVER_is_zero_string(s) = 0;
+#else
+    (void)size;
 
-  if(n > 0)
-  {
-    (void)*(char *)s; // check that the memory is accessible
-    (void)*(((char *)s) + n - 1); // check that the memory is accessible
-    char *sp=s;
-    // Don't actually do the memset, since te values aren't important
-  }
-  #endif
-  return s;
+    if (n > 0) {
+        (void)*(char *)s;              // check that the memory is accessible
+        (void)*(((char *)s) + n - 1);  // check that the memory is accessible
+        char *sp = s;
+        // Don't actually do the memset, since te values aren't important
+    }
+#endif
+    return s;
 }

--- a/.cbmc-batch/proof_helpers.h
+++ b/.cbmc-batch/proof_helpers.h
@@ -1,4 +1,4 @@
-#include<stdlib.h>
+#include <stdlib.h>
 
 #define ASSUME_VALID_MEMORY(ptr) ptr = malloc(sizeof(*(ptr)))
 #define ASSUME_VALID_MEMORY_COUNT(ptr, count) ptr = malloc(sizeof(*(ptr)) * (count))

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -15,11 +15,6 @@
 
 #include <make_common_data_structures.h>
 
-void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props) {
-    size_t md_name_size;
-    alg_props->md_name = can_fail_malloc(md_name_size);
-    size_t cipher_name_size;
-    alg_props->cipher_name = can_fail_malloc(cipher_name_size);
-    size_t alg_name_size;
-    alg_props->alg_name = can_fail_malloc(alg_name_size);
+void ensure_alg_properties_is_allocated(struct aws_cryptosdk_alg_properties **alg_props) {
+    *alg_props = aws_cryptosdk_alg_props(nondet_int());
 }

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <make_common_data_structures.h>
+
+void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props) {
+    size_t md_name_size;
+    alg_props->md_name = can_fail_malloc(md_name_size);
+    size_t cipher_name_size;
+    alg_props->cipher_name = can_fail_malloc(cipher_name_size);
+    size_t alg_name_size;
+    alg_props->alg_name = can_fail_malloc(alg_name_size);
+}

--- a/.cbmc-batch/source/openssl/bn_override.c
+++ b/.cbmc-batch/source/openssl/bn_override.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/bn.h>
+
+#include <stdbool.h>
+
+#include <proof_helpers/proof_allocators.h>
+
+#include <bn_utils.h>
+
+/* Abstraction of the BIGNUM struct */
+struct bignum_st {
+    bool is_initialized;
+};
+
+/*
+ * Description: BN_new() allocates and initializes a BIGNUM structure.
+ * Return values: BN_new() and BN_secure_new() return a pointer to the BIGNUM initialised to the value 0. If the
+ * allocation fails, they return NULL and set an error code that can be obtained by ERR_get_error(3).
+ */
+BIGNUM *BN_new(void) {
+    BIGNUM *rv = can_fail_malloc(sizeof(BIGNUM));
+    if (rv) {
+        rv->is_initialized = true;
+    }
+
+    // Assuming error codes can be safely ignored
+
+    return rv;
+}
+
+/*
+ * Description: BN_dup() creates a new BIGNUM containing the value from.
+ * Return values: BN_dup() returns the new BIGNUM, and NULL on error.
+ */
+BIGNUM *BN_dup(const BIGNUM *from) {
+    assert(bignum_is_valid(from));
+
+    // WARNING: somehow CBMC doesn't catch the NULL-ptr deref?
+    // *dup = *from;
+
+    return BN_new();  // Guarantees that return value will be either NULL or initialized
+}
+
+/*
+ * Description: BN_sub() subtracts b from a and places the result in r (r=a-b). r may be the same BIGNUM as a or b.
+ * Return values: For all functions, 1 is returned for success, 0 on error. The return value should always be checked
+ * (e.g., if (!BN_add(r,a,b)) goto err;).
+ */
+int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b) {
+    assert(bignum_is_valid(r));
+    assert(bignum_is_valid(a));
+    assert(bignum_is_valid(b));
+
+    r->is_initialized = nondet_bool();
+
+    return r->is_initialized;
+}
+
+/*
+ * Description: BN_free() frees the components of the BIGNUM, and if it was created by BN_new(), also the structure
+ * itself.
+ */
+void BN_free(BIGNUM *a) {
+    free(a);  // Assuming BIGNUMs are always allocated dynamically
+}
+
+/*
+ * Description: BN_clear_free() additionally overwrites the data before the memory is returned to the system. If a is
+ * NULL, nothing is done.
+ */
+void BN_clear_free(BIGNUM *a) {
+    // No way currently to model or check that the data is cleared
+    free(a);
+}
+
+/* CBMC helper functions */
+
+bool bignum_is_valid(BIGNUM *a) {
+    return a && a->is_initialized;
+}
+
+BIGNUM *bignum_nondet_alloc() {
+    return can_fail_malloc(sizeof(BIGNUM));
+}

--- a/.cbmc-batch/source/openssl/objects_override.c
+++ b/.cbmc-batch/source/openssl/objects_override.c
@@ -22,14 +22,14 @@
  * numerical representation of an object. Return values: OBJ_txt2nid() returns a NID or NID_undef on error.
  */
 int OBJ_txt2nid(const char *s) {
-  // Currently these are the only values used in the ESDK
+    // Currently these are the only values used in the ESDK
     assert(!s || strcmp(s, "prime256v1") == 0 || strcmp(s, "secp384r1") == 0);
 
     if (!s) {
-      return NID_undef;
+        return NID_undef;
     } else if (strcmp(s, "prime256v1") == 0) {
         return NID_X9_62_prime256v1;
-    } else { // s is "secp384r1"
+    } else {  // s is "secp384r1"
         return NID_secp384r1;
     }
 }

--- a/.cbmc-batch/source/openssl/objects_override.c
+++ b/.cbmc-batch/source/openssl/objects_override.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/objects.h>
+
+#include <proof_helpers/nondet.h>
+
+/*
+ * Description: OBJ_txt2nid() returns NID corresponding to text string <s>. s can be a long name, a short name or the
+ * numerical representation of an object. Return values: OBJ_txt2nid() returns a NID or NID_undef on error.
+ */
+int OBJ_txt2nid(const char *s) {
+  // Currently these are the only values used in the ESDK
+    assert(!s || strcmp(s, "prime256v1") == 0 || strcmp(s, "secp384r1") == 0);
+
+    if (!s) {
+      return NID_undef;
+    } else if (strcmp(s, "prime256v1") == 0) {
+        return NID_X9_62_prime256v1;
+    } else { // s is "secp384r1"
+        return NID_secp384r1;
+    }
+}

--- a/.cbmc-batch/source/proof_allocators.c
+++ b/.cbmc-batch/source/proof_allocators.c
@@ -16,14 +16,16 @@
 #include "proof_allocators.h"
 #include <stdlib.h>
 
-//Use the same functions as the standard default allocator, but nondeterministically have malloc
-//return null.  This is needed because the CBMC model of malloc cannot fail, so we cannot
-//test the null case otherwise.
+// Use the same functions as the standard default allocator, but nondeterministically have malloc
+// return null.  This is needed because the CBMC model of malloc cannot fail, so we cannot
+// test the null case otherwise.
 static void *can_fail_malloc(struct aws_allocator *allocator, size_t size) {
     (void)allocator;
     int nondet;
-    if (nondet) return NULL;
-    else return malloc(size);
+    if (nondet)
+        return NULL;
+    else
+        return malloc(size);
 }
 
 static void can_fail_free(struct aws_allocator *allocator, void *ptr) {
@@ -35,8 +37,10 @@ static void *can_fail_realloc(struct aws_allocator *allocator, void *ptr, size_t
     (void)allocator;
     (void)oldsize;
     int nondet;
-    if (nondet) return NULL;
-    else return realloc(ptr, newsize);
+    if (nondet)
+        return NULL;
+    else
+        return realloc(ptr, newsize);
 }
 
 static struct aws_allocator can_fail_allocator_static = {
@@ -45,7 +49,6 @@ static struct aws_allocator can_fail_allocator_static = {
     .mem_realloc = can_fail_realloc,
 };
 
-struct aws_allocator* can_fail_allocator()
-{
-  return &can_fail_allocator_static;
+struct aws_allocator *can_fail_allocator() {
+    return &can_fail_allocator_static;
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 *.[ch]-e
 .DS_Store
 *.goto
+*.log
+.cbmc-batch/jobs/*/link-farm
+.cbmc-batch/jobs/*/html

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ build
 .DS_Store
 *.goto
 *.log
-.cbmc-batch/jobs/*/link-farm
-.cbmc-batch/jobs/*/html

--- a/include/aws/cryptosdk/cipher.h
+++ b/include/aws/cryptosdk/cipher.h
@@ -102,6 +102,12 @@ AWS_CRYPTOSDK_API
 const struct aws_cryptosdk_alg_properties *aws_cryptosdk_alg_props(enum aws_cryptosdk_alg_id alg_id);
 
 /**
+ * Checks whether an aws_cryptosdk_alg_properties is valid and is supported by the SDK.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props);
+
+/**
  * An opaque structure representing an ongoing sign or verify operation
  */
 struct aws_cryptosdk_sig_ctx;

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -17,6 +17,7 @@
 #define AWS_CRYPTOSDK_PRIVATE_FRAMEFMT_H
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/cipher.h>
 
@@ -32,6 +33,20 @@ struct aws_cryptosdk_frame {
     /* A cursor to space for the AEAD tag in the ciphertext buffer */
     struct aws_byte_buf authtag;
 };
+
+// MAX_FRAME_SIZE = 2^32 - 1
+#define MAX_FRAME_SIZE 0xFFFFFFFF
+// MAX_FRAMES = 2^32 - 1
+#define MAX_FRAMES 0xFFFFFFFF
+// MAX_UNFRAMED_PLAINTEXT_SIZE = 2^36 - 32
+#define MAX_UNFRAMED_PLAINTEXT_SIZE 0xFFFFFFFE0ull
+
+/**
+ * Checks whether a frame struct is valid. At the moment this means
+ * that it checks the validity of the byte buffers and the fact that
+ * they should have NULL allocators.
+ */
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame);
 
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -61,9 +61,9 @@ bool aws_cryptosdk_frame_serialized(
     size_t plaintext_size);
 
 /**
- * Checks whether a frame has a valid frame type, and a valid sequence number.
+ * Checks whether a frame has a valid frame type.
  */
-bool aws_cryptosdk_frame_has_valid_type_seq(const struct aws_cryptosdk_frame *frame);
+bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame);
 
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -139,6 +139,6 @@ int aws_cryptosdk_deserialize_frame(
     /* in */
     struct aws_byte_cursor *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props,
-    uint64_t max_frame_size);
+    uint32_t max_frame_size);
 
 #endif

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -49,6 +49,23 @@ struct aws_cryptosdk_frame {
 bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame);
 
 /**
+ * Checks whether a frame struct is correctly serialized in relation
+ * to a specific algorithm.  More precisely, it checks that the
+ * buffers in [frame] have the same sizes as the sizes described in
+ * the [alg_props] algorithm properties and in the
+ * [plaintext_size]. It also checks that the two buffers are empty.
+ */
+bool aws_cryptosdk_frame_serialized(
+    const struct aws_cryptosdk_frame *frame,
+    const struct aws_cryptosdk_alg_properties *alg_props,
+    size_t plaintext_size);
+
+/**
+ * Checks whether a frame has a valid frame type, and a valid sequence number.
+ */
+bool aws_cryptosdk_frame_has_valid_type_seq(const struct aws_cryptosdk_frame *frame);
+
+/**
  * Performs frame-type-specific work prior to writing a frame; writes out all
  * fields except for the IV, ciphertext, and authtag - for those three fields,
  * this method will set the appropriate cursors in the frame structure instead;

--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -21,7 +21,6 @@
 #include <aws/cryptosdk/session.h>
 
 #define DEFAULT_FRAME_SIZE (256 * 1024)
-#define MAX_FRAME_SIZE 0xFFFFFFFF
 
 enum session_state {
     /*** Common states ***/

--- a/reformat.sh
+++ b/reformat.sh
@@ -15,4 +15,4 @@
 
 set -euxo pipefail
 
-find {.,aws-encryption-sdk-cpp}/{include,source,tests} examples -name '*.h' -or -name '*.c' -or -name '*.cpp' | xargs clang-format -i
+find {.,aws-encryption-sdk-cpp}/{include,source,tests} .cbmc-batch examples -name '*.h' -or -name '*.c' -or -name '*.cpp' | xargs clang-format -i

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -88,6 +88,32 @@ static enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk
     }
 }
 
+static bool alg_properties_equal(
+    const struct aws_cryptosdk_alg_properties alg_props1, const struct aws_cryptosdk_alg_properties alg_props2) {
+    /* Note: We are not checking whether the names (md/cipher/alg) are
+     * equal */
+
+    /* Note: We are not checking whether the underlying alg_impl
+     * structs are equal. */
+    return alg_props1.data_key_len == alg_props2.data_key_len &&
+           alg_props1.content_key_len == alg_props2.content_key_len && alg_props1.iv_len == alg_props2.iv_len &&
+           alg_props1.tag_len == alg_props2.tag_len && alg_props1.signature_len == alg_props2.signature_len &&
+           alg_props1.alg_id == alg_props2.alg_id;
+}
+
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props) {
+    if (alg_props == NULL) {
+        return false;
+    }
+    enum aws_cryptosdk_alg_id id                             = alg_props->alg_id;
+    const struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
+    if (std_alg_props == NULL) {
+        return false;
+    }
+    return alg_props->md_name && alg_props->cipher_name && alg_props->alg_name &&
+           alg_properties_equal(*alg_props, *std_alg_props);
+}
+
 int aws_cryptosdk_derive_key(
     const struct aws_cryptosdk_alg_properties *props,
     struct content_key *content_key,

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -88,30 +88,13 @@ static enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk
     }
 }
 
-static bool alg_properties_equal(
-    const struct aws_cryptosdk_alg_properties alg_props1, const struct aws_cryptosdk_alg_properties alg_props2) {
-    /* Note: We are not checking whether the names (md/cipher/alg) are
-     * equal */
-
-    /* Note: We are not checking whether the underlying alg_impl
-     * structs are equal. */
-    return alg_props1.data_key_len == alg_props2.data_key_len &&
-           alg_props1.content_key_len == alg_props2.content_key_len && alg_props1.iv_len == alg_props2.iv_len &&
-           alg_props1.tag_len == alg_props2.tag_len && alg_props1.signature_len == alg_props2.signature_len &&
-           alg_props1.alg_id == alg_props2.alg_id;
-}
-
 bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props) {
     if (alg_props == NULL) {
         return false;
     }
     enum aws_cryptosdk_alg_id id                             = alg_props->alg_id;
     const struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
-    if (std_alg_props == NULL) {
-        return false;
-    }
-    return alg_props->md_name && alg_props->cipher_name && alg_props->alg_name &&
-           alg_properties_equal(*alg_props, *std_alg_props);
+    return std_alg_props == alg_props;
 }
 
 int aws_cryptosdk_derive_key(

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -94,7 +94,7 @@ bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_proper
     }
     enum aws_cryptosdk_alg_id id                             = alg_props->alg_id;
     const struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
-    return std_alg_props == alg_props;
+    return (std_alg_props == alg_props);
 }
 
 int aws_cryptosdk_derive_key(

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <aws/common/common.h>
 #include <aws/common/error.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/private/framefmt.h>
@@ -213,6 +214,24 @@ static inline int serde_nonframed(
     return AWS_ERROR_SUCCESS;
 }
 
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame) {
+    bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
+    bool iv_byte_buf_static = frame->iv.allocator == NULL;
+
+    bool authtag_byte_buf_valid  = aws_byte_buf_is_valid(&frame->authtag);
+    bool authtag_byte_buf_static = frame->authtag.allocator == NULL;
+
+    bool ciphertext_byte_buf_valid = aws_byte_buf_is_valid(&frame->ciphertext);
+    /* This happens when input plaintext size is 0 */
+    bool ciphertext_valid_zero =
+        frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0;
+    bool ciphertext_valid  = ciphertext_byte_buf_valid || ciphertext_valid_zero;
+    bool ciphertext_static = frame->ciphertext.allocator == NULL;
+
+    return iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid && authtag_byte_buf_static &&
+           ciphertext_valid && ciphertext_static;
+}
+
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all
  * fields except for the IV, ciphertext, and authtag, and returns their
@@ -235,7 +254,17 @@ int aws_cryptosdk_serialize_frame(
     size_t plaintext_size,
     struct aws_byte_buf *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props) {
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
     struct aws_cryptosdk_framestate state;
+
+    // The plaintext_size should be bound to prevent arithmetic
+    // overflows due to addition
+    if ((frame->type == FRAME_TYPE_SINGLE && plaintext_size > MAX_UNFRAMED_PLAINTEXT_SIZE) ||
+        (frame->type != FRAME_TYPE_SINGLE && plaintext_size > MAX_FRAME_SIZE)) {
+        // Clear the ciphertext buffer
+        aws_byte_buf_secure_zero(ciphertext_buf);
+        return aws_raise_error(AWS_CRYPTOSDK_ERR_LIMIT_EXCEEDED);
+    }
 
     // We assume that the max frame size is equal to the plaintext size. This
     // lets us avoid having to pass in a redundant argument, avoids needing to
@@ -244,7 +273,7 @@ int aws_cryptosdk_serialize_frame(
     state.max_frame_size = plaintext_size;
     state.plaintext_size = plaintext_size;
     // Currently all supported algorithms have plaintext = ciphertext size
-    state.ciphertext_size = plaintext_size;
+    state.ciphertext_size = 0;
 
     state.alg_props = alg_props;
     state.u.buffer  = *ciphertext_buf;
@@ -271,6 +300,7 @@ int aws_cryptosdk_serialize_frame(
         return aws_raise_error(result);
     } else {
         *ciphertext_buf = state.u.buffer;
+        AWS_POSTCONDITION(aws_cryptosdk_frame_is_valid(frame));
         return AWS_OP_SUCCESS;
     }
 }

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -203,6 +203,12 @@ static inline int serde_nonframed(
     struct aws_cryptosdk_framestate *AWS_RESTRICT state, struct aws_cryptosdk_frame *AWS_RESTRICT frame) {
     field_sized(state, &frame->iv, state->alg_props->iv_len);
     field_be64(state, &state->plaintext_size);
+
+    // Check that plaintext_size is within bounds so we avoid an overflow later
+    if (state->plaintext_size >= MAX_PLAINTEXT_SIZE) {
+        return AWS_CRYPTOSDK_ERR_BAD_CIPHERTEXT;
+    }
+
     field_sized(state, &frame->ciphertext, state->plaintext_size);
     field_sized(state, &frame->authtag, state->alg_props->tag_len);
 

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -222,20 +222,21 @@ bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame)
     bool frame_type_valid = aws_cryptosdk_frame_has_valid_type(frame);
 
     bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
-    bool iv_byte_buf_static = frame->iv.allocator == NULL;
+    bool iv_byte_buf_static = (frame->iv.allocator == NULL);
 
     bool authtag_byte_buf_valid  = aws_byte_buf_is_valid(&frame->authtag);
-    bool authtag_byte_buf_static = frame->authtag.allocator == NULL;
+    bool authtag_byte_buf_static = (frame->authtag.allocator == NULL);
 
     bool ciphertext_byte_buf_valid = aws_byte_buf_is_valid(&frame->ciphertext);
     /* This happens when input plaintext size is 0 */
     bool ciphertext_valid_zero =
-        frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0;
-    bool ciphertext_valid  = ciphertext_byte_buf_valid || ciphertext_valid_zero;
-    bool ciphertext_static = frame->ciphertext.allocator == NULL;
+        (frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0);
+    bool ciphertext_valid  = (ciphertext_byte_buf_valid || ciphertext_valid_zero);
+    bool ciphertext_static = (frame->ciphertext.allocator == NULL);
 
-    return frame_type_valid && iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid &&
-           authtag_byte_buf_static && ciphertext_valid && ciphertext_static;
+    return (
+        frame_type_valid && iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid &&
+        authtag_byte_buf_static && ciphertext_valid && ciphertext_static);
 }
 
 bool aws_cryptosdk_frame_serialized(
@@ -247,19 +248,19 @@ bool aws_cryptosdk_frame_serialized(
     }
 
     // Check that both iv, authtag buffers contain the correct amount of bytes
-    bool iv_size_valid  = frame->iv.capacity == alg_props->iv_len;
-    bool tag_size_valid = frame->authtag.capacity == alg_props->tag_len;
+    bool iv_size_valid  = (frame->iv.capacity == alg_props->iv_len);
+    bool tag_size_valid = (frame->authtag.capacity == alg_props->tag_len);
 
     // Check that both iv, authtag buffers are empty and ready for writting
-    bool iv_empty  = frame->iv.len == 0;
-    bool tag_empty = frame->authtag.len == 0;
+    bool iv_empty  = (frame->iv.len == 0);
+    bool tag_empty = (frame->authtag.len == 0);
 
     // Check that the ciphertext buffer has the correct size
     bool ciphertext_size_valid = ((frame->type == FRAME_TYPE_SINGLE || frame->type == FRAME_TYPE_FRAME) &&
                                   frame->ciphertext.capacity == plaintext_size) ||
                                  (frame->type == FRAME_TYPE_FINAL && frame->ciphertext.capacity <= plaintext_size);
 
-    return iv_size_valid && tag_size_valid && iv_empty && tag_empty;
+    return (iv_size_valid && tag_size_valid && iv_empty && tag_empty);
 }
 
 bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame) {
@@ -268,7 +269,7 @@ bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame)
     }
 
     bool frame_enum_in_range =
-        frame->type == FRAME_TYPE_SINGLE || frame->type == FRAME_TYPE_FRAME || frame->type == FRAME_TYPE_FINAL;
+        (frame->type == FRAME_TYPE_SINGLE || frame->type == FRAME_TYPE_FRAME || frame->type == FRAME_TYPE_FINAL);
 
     return frame_enum_in_range;
 }

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -219,7 +219,7 @@ bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame)
         return false;
     }
 
-    bool frame_type_seq_valid = aws_cryptosdk_frame_has_valid_type_seq(frame);
+    bool frame_type_seq_valid = aws_cryptosdk_frame_has_valid_type(frame);
 
     bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
     bool iv_byte_buf_static = frame->iv.allocator == NULL;
@@ -262,17 +262,15 @@ bool aws_cryptosdk_frame_serialized(
     return iv_size_valid && tag_size_valid && iv_empty && tag_empty;
 }
 
-bool aws_cryptosdk_frame_has_valid_type_seq(const struct aws_cryptosdk_frame *frame) {
+bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame) {
     if (frame == NULL) {
         return false;
     }
 
-    bool seq_valid = frame->sequence_number > 0 && frame->sequence_number <= MAX_FRAMES;
-
     bool frame_enum_in_range =
         frame->type == FRAME_TYPE_SINGLE || frame->type == FRAME_TYPE_FRAME || frame->type == FRAME_TYPE_FINAL;
 
-    return seq_valid && frame_enum_in_range;
+    return frame_enum_in_range;
 }
 
 /**
@@ -297,7 +295,8 @@ int aws_cryptosdk_serialize_frame(
     size_t plaintext_size,
     struct aws_byte_buf *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props) {
-    AWS_PRECONDITION(aws_cryptosdk_frame_has_valid_type_seq(frame));
+    AWS_PRECONDITION(aws_cryptosdk_frame_has_valid_type(frame));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(ciphertext_buf));
     AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
     struct aws_cryptosdk_framestate state;
 

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -377,7 +377,7 @@ int aws_cryptosdk_deserialize_frame(
     /* in */
     struct aws_byte_cursor *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props,
-    uint64_t max_frame_size) {
+    uint32_t max_frame_size) {
     struct aws_cryptosdk_framestate state;
     state.max_frame_size  = max_frame_size;
     state.plaintext_size  = 0;

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -219,7 +219,7 @@ bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame)
         return false;
     }
 
-    bool frame_type_seq_valid = aws_cryptosdk_frame_has_valid_type(frame);
+    bool frame_type_valid = aws_cryptosdk_frame_has_valid_type(frame);
 
     bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
     bool iv_byte_buf_static = frame->iv.allocator == NULL;
@@ -234,7 +234,7 @@ bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame)
     bool ciphertext_valid  = ciphertext_byte_buf_valid || ciphertext_valid_zero;
     bool ciphertext_static = frame->ciphertext.allocator == NULL;
 
-    return frame_type_seq_valid && iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid &&
+    return frame_type_valid && iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid &&
            authtag_byte_buf_static && ciphertext_valid && ciphertext_static;
 }
 

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -413,6 +413,10 @@ int aws_cryptosdk_deserialize_frame(
         result = AWS_CRYPTOSDK_ERR_LIMIT_EXCEEDED;
     }
 
+    if (frame->sequence_number == 0) {
+        result = AWS_CRYPTOSDK_ERR_BAD_CIPHERTEXT;
+    }
+
     *plaintext_size  = state.plaintext_size;
     *ciphertext_size = state.ciphertext_size;
 

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -205,7 +205,7 @@ static inline int serde_nonframed(
     field_be64(state, &state->plaintext_size);
 
     // Check that plaintext_size is within bounds so we avoid an overflow later
-    if (state->plaintext_size >= MAX_PLAINTEXT_SIZE) {
+    if (state->plaintext_size >= MAX_UNFRAMED_PLAINTEXT_SIZE) {
         return AWS_CRYPTOSDK_ERR_BAD_CIPHERTEXT;
     }
 

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -378,6 +378,9 @@ int aws_cryptosdk_deserialize_frame(
     struct aws_byte_cursor *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props,
     uint32_t max_frame_size) {
+    AWS_PRECONDITION(frame);
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(ciphertext_buf));
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
     struct aws_cryptosdk_framestate state;
     state.max_frame_size  = max_frame_size;
     state.plaintext_size  = 0;
@@ -416,9 +419,14 @@ int aws_cryptosdk_deserialize_frame(
     if (result != AWS_ERROR_SUCCESS) {
         // Don't leak a partially-initialized structure
         aws_secure_zero(frame, sizeof(*frame));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(ciphertext_buf));
+        AWS_POSTCONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
         return aws_raise_error(result);
     } else {
         *ciphertext_buf = state.u.cursor;
+	AWS_POSTCONDITION(aws_cryptosdk_frame_is_valid(frame));
+        AWS_POSTCONDITION(aws_byte_cursor_is_valid(ciphertext_buf));
+        AWS_POSTCONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
         return AWS_OP_SUCCESS;
     }
 }

--- a/tests/unit/t_header.c
+++ b/tests/unit/t_header.c
@@ -153,12 +153,26 @@ void set_aad_tbl(struct aws_cryptosdk_hdr *hdr, struct aws_cryptosdk_hdr_aad *aa
 
 static struct aws_cryptosdk_hdr test_header_1_hdr() {
     struct aws_cryptosdk_hdr test_header_1_hdr = {
-        .alg_id    = ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
-        .frame_len = 0x1000,
-        .iv        = { .buffer = test_header_1_iv_arr, .len = sizeof(test_header_1_iv_arr) },
-        .auth_tag  = { .buffer = test_header_1_auth_tag_arr, .len = sizeof(test_header_1_auth_tag_arr) },
-        .message_id =
-            { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 },
+        .alg_id     = ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
+        .frame_len  = 0x1000,
+        .iv         = { .buffer = test_header_1_iv_arr, .len = sizeof(test_header_1_iv_arr) },
+        .auth_tag   = { .buffer = test_header_1_auth_tag_arr, .len = sizeof(test_header_1_auth_tag_arr) },
+        .message_id = { 0x11,
+                        0x22,
+                        0x33,
+                        0x44,
+                        0x55,
+                        0x66,
+                        0x77,
+                        0x88,
+                        0x11,
+                        0x22,
+                        0x33,
+                        0x44,
+                        0x55,
+                        0x66,
+                        0x77,
+                        0x88 },
         //        .aad_tbl = test_header_1_aad_tbl,
         //        .edk_tbl = test_header_1_edk_tbl,
         .auth_len = sizeof(test_header_1) - 29  // not used by aws_cryptosdk_hdr_size/write
@@ -287,12 +301,12 @@ static const uint8_t hdr_with_zero_edk_count[] = {
 };
 // clang-format on
 
-static const uint8_t *bad_headers[] = {
-    hdr_with_nonzero_reserve_bytes, hdr_with_zero_aad_count, hdr_with_zero_edk_count
-};
-static const size_t bad_headers_sz[] = {
-    sizeof(hdr_with_nonzero_reserve_bytes), sizeof(hdr_with_zero_aad_count), sizeof(hdr_with_zero_edk_count)
-};
+static const uint8_t *bad_headers[]  = { hdr_with_nonzero_reserve_bytes,
+                                        hdr_with_zero_aad_count,
+                                        hdr_with_zero_edk_count };
+static const size_t bad_headers_sz[] = { sizeof(hdr_with_nonzero_reserve_bytes),
+                                         sizeof(hdr_with_zero_aad_count),
+                                         sizeof(hdr_with_zero_edk_count) };
 
 struct aws_cryptosdk_hdr test_header_2_hdr() {
     // clang-format off

--- a/tests/unit/t_materials.c
+++ b/tests/unit/t_materials.c
@@ -283,13 +283,13 @@ static void track_destroy_keyring(struct aws_cryptosdk_keyring *keyring) {
     destroy_called = true;
 }
 
-static const struct aws_cryptosdk_cmm_vt track_destroy_cmm_vt = {
-    .vt_size = sizeof(track_destroy_cmm_vt), .name = "track_destroy_cmm_vt", .destroy = track_destroy_cmm
-};
+static const struct aws_cryptosdk_cmm_vt track_destroy_cmm_vt = { .vt_size = sizeof(track_destroy_cmm_vt),
+                                                                  .name    = "track_destroy_cmm_vt",
+                                                                  .destroy = track_destroy_cmm };
 
-static const struct aws_cryptosdk_keyring_vt track_destroy_keyring_vt = {
-    .vt_size = sizeof(track_destroy_keyring_vt), .name = "track_destroy_keyring_vt", .destroy = track_destroy_keyring
-};
+static const struct aws_cryptosdk_keyring_vt track_destroy_keyring_vt = { .vt_size = sizeof(track_destroy_keyring_vt),
+                                                                          .name    = "track_destroy_keyring_vt",
+                                                                          .destroy = track_destroy_keyring };
 
 static int refcount_keyring() {
     struct aws_cryptosdk_keyring keyring;

--- a/tests/unit/t_raw_aes_keyring_encrypt.c
+++ b/tests/unit/t_raw_aes_keyring_encrypt.c
@@ -64,12 +64,12 @@ static void tear_down_all_the_things() {
     aws_byte_buf_clean_up(&decrypted_data_key);
 }
 
-static enum aws_cryptosdk_aes_key_len raw_key_lens[] = {
-    AWS_CRYPTOSDK_AES128, AWS_CRYPTOSDK_AES192, AWS_CRYPTOSDK_AES256
-};
-static enum aws_cryptosdk_alg_id algs[] = {
-    ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256, ALG_AES192_GCM_IV12_TAG16_HKDF_SHA256, ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256
-};
+static enum aws_cryptosdk_aes_key_len raw_key_lens[] = { AWS_CRYPTOSDK_AES128,
+                                                         AWS_CRYPTOSDK_AES192,
+                                                         AWS_CRYPTOSDK_AES256 };
+static enum aws_cryptosdk_alg_id algs[]              = { ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256,
+                                            ALG_AES192_GCM_IV12_TAG16_HKDF_SHA256,
+                                            ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256 };
 
 static int encrypt_decrypt_data_key() {
     for (int fill_enc_ctx = 0; fill_enc_ctx < 2; ++fill_enc_ctx) {

--- a/tests/unit/t_raw_rsa_keyring_encrypt.c
+++ b/tests/unit/t_raw_rsa_keyring_encrypt.c
@@ -27,13 +27,13 @@ static struct aws_byte_buf unencrypted_data_key = { 0 };
 // same key, after it has been encrypted and then decrypted
 static struct aws_byte_buf decrypted_data_key = { 0 };
 
-static enum aws_cryptosdk_alg_id alg_ids[] = {
-    ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256, ALG_AES192_GCM_IV12_TAG16_HKDF_SHA256, ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256
-};
+static enum aws_cryptosdk_alg_id alg_ids[] = { ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256,
+                                               ALG_AES192_GCM_IV12_TAG16_HKDF_SHA256,
+                                               ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256 };
 
-static enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode[] = {
-    AWS_CRYPTOSDK_RSA_PKCS1, AWS_CRYPTOSDK_RSA_OAEP_SHA1_MGF1, AWS_CRYPTOSDK_RSA_OAEP_SHA256_MGF1
-};
+static enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode[] = { AWS_CRYPTOSDK_RSA_PKCS1,
+                                                                  AWS_CRYPTOSDK_RSA_OAEP_SHA1_MGF1,
+                                                                  AWS_CRYPTOSDK_RSA_OAEP_SHA256_MGF1 };
 
 static int set_up_encrypt_with_wrong_key(enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode) {
     alloc = aws_default_allocator();


### PR DESCRIPTION
*Description of changes:*

1. Added proof harness for `aws_cryptosdk_deserialize_frame` function in `framefmt.c`
2. Added check to `serde_nonframed` function in `framefmt.c` that the plaintext_size value read from the buffer is within bounds, in order to prevent arithmetic overflows
3. Changed `max_frame_size` argument in `aws_cryptosdk_deserialize_frame` from `uint64_t` to `uint32_t`

Depends on #378 and PR [#405](https://github.com/awslabs/aws-c-common/pull/405) of C-Common (for CBMC check in aws_hton64 of byte_order.h).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.