### PR TITLE
Replace OpenSSL headers needed for the proofs with local copies

### DIFF
--- a/.cbmc-batch/include/openssl/asn1.h
+++ b/.cbmc-batch/include/openssl/asn1.h
@@ -1,0 +1,28 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_ASN1_H
+#define HEADER_ASN1_H
+
+#include <openssl/ossl_typ.h>
+
+void ASN1_STRING_clear_free(ASN1_STRING *a);
+BIGNUM *ASN1_INTEGER_to_BN(const ASN1_INTEGER *ai, BIGNUM *bn);
+ASN1_INTEGER *BN_to_ASN1_INTEGER(const BIGNUM *bn, ASN1_INTEGER *ai);
+ASN1_INTEGER *d2i_ASN1_INTEGER(ASN1_INTEGER **a, unsigned char **ppin, long length);
+int i2d_ASN1_INTEGER(ASN1_INTEGER *a, unsigned char **ppout);
+
+#endif HEADER_ASN1_H

--- a/.cbmc-batch/include/openssl/bn.h
+++ b/.cbmc-batch/include/openssl/bn.h
@@ -1,0 +1,28 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_BN_H
+#define HEADER_BN_H
+
+#include <openssl/ossl_typ.h>
+
+BIGNUM *BN_new(void);
+BIGNUM *BN_dup(const BIGNUM *from);
+int BN_sub(BIGNUM *r, const BIGNUM *a, const BIGNUM *b);
+void BN_clear_free(BIGNUM *a);
+void BN_free(BIGNUM *a);
+
+#endif

--- a/.cbmc-batch/include/openssl/crypto.h
+++ b/.cbmc-batch/include/openssl/crypto.h
@@ -1,0 +1,17 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* Empty header. Necessary just because it is included in cipher_openssl.c */

--- a/.cbmc-batch/include/openssl/ec.h
+++ b/.cbmc-batch/include/openssl/ec.h
@@ -1,0 +1,67 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_EC_H
+#define HEADER_EC_H
+
+#include <openssl/asn1.h>
+#include <openssl/bn.h>
+#include <openssl/objects.h>
+#include <openssl/ossl_typ.h>
+
+/** Enum for the point conversion form as defined in X9.62 (ECDSA)
+ *  for the encoding of a elliptic curve point (x,y) */
+typedef enum {
+    /** the point is encoded as z||x, where the octet z specifies
+     *  which solution of the quadratic equation y is  */
+    POINT_CONVERSION_COMPRESSED = 2,
+    /** the point is encoded as z||x||y, where z is the octet 0x04  */
+    POINT_CONVERSION_UNCOMPRESSED = 4,
+    /** the point is encoded as z||x||y, where the octet z specifies
+     *  which solution of the quadratic equation y is  */
+    POINT_CONVERSION_HYBRID = 6
+} point_conversion_form_t;
+
+typedef struct ec_group_st EC_GROUP;
+
+EC_GROUP *EC_GROUP_new_by_curve_name(int nid);
+void EC_GROUP_set_point_conversion_form(EC_GROUP *group, point_conversion_form_t form);
+const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group);
+void EC_GROUP_free(EC_GROUP *group);
+
+typedef struct ECDSA_SIG_st ECDSA_SIG;
+
+EC_KEY *EC_KEY_new(void);
+int EC_KEY_set_group(EC_KEY *key, const EC_GROUP *group);
+void EC_KEY_set_conv_form(EC_KEY *eckey, point_conversion_form_t cform);
+int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *prv);
+int EC_KEY_generate_key(EC_KEY *key);
+int EC_KEY_up_ref(EC_KEY *r);
+const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key);
+const BIGNUM *EC_KEY_get0_private_key(const EC_KEY *key);
+int EC_KEY_generate_key(EC_KEY *key);
+void EC_KEY_free(EC_KEY *key);
+
+EC_KEY *o2i_ECPublicKey(EC_KEY **key, const unsigned char **in, long len);
+int i2o_ECPublicKey(EC_KEY *key, unsigned char **out);
+
+void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
+void ECDSA_SIG_free(ECDSA_SIG *sig);
+ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp, long len);
+int i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp);
+
+#endif

--- a/.cbmc-batch/include/openssl/ecdsa.h
+++ b/.cbmc-batch/include/openssl/ecdsa.h
@@ -1,0 +1,17 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* Empty header. Necessary just because it is included in cipher_openssl.c */

--- a/.cbmc-batch/include/openssl/err.h
+++ b/.cbmc-batch/include/openssl/err.h
@@ -1,0 +1,24 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_ERR_H
+#define HEADER_ERR_H
+
+#include <stdio.h>
+
+void ERR_print_errors_fp(FILE *fp);
+
+#endif

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -1,0 +1,80 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_EVP_H
+#define HEADER_EVP_H
+
+#include <stddef.h>
+
+#include <openssl/ec.h>
+#include <openssl/ossl_typ.h>
+
+#define EVP_MAX_MD_SIZE 64 /* longest known is SHA512 */
+
+EVP_PKEY *EVP_PKEY_new(void);
+EC_KEY *EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey);
+int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key);
+void EVP_PKEY_free(EVP_PKEY *pkey);
+EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
+int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen, const unsigned char *tbs, size_t tbslen);
+void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
+EVP_MD_CTX *EVP_MD_CTX_new(void);
+int EVP_MD_CTX_size(const EVP_MD_CTX *ctx);
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
+int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+int EVP_DigestFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
+int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen);
+
+#define EVP_MD_CTX_create() EVP_MD_CTX_new()
+#define EVP_MD_CTX_destroy(ctx) EVP_MD_CTX_free((ctx))
+
+const EVP_CIPHER *EVP_aes_128_gcm(void);
+const EVP_CIPHER *EVP_aes_192_gcm(void);
+const EVP_CIPHER *EVP_aes_256_gcm(void);
+const EVP_MD *EVP_sha256(void);
+const EVP_MD *EVP_sha384(void);
+const EVP_MD *EVP_sha512(void);
+
+#define EVP_CTRL_INIT 0x0
+#define EVP_CTRL_SET_KEY_LENGTH 0x1
+#define EVP_CTRL_GET_RC2_KEY_BITS 0x2
+#define EVP_CTRL_SET_RC2_KEY_BITS 0x3
+#define EVP_CTRL_GET_RC5_ROUNDS 0x4
+#define EVP_CTRL_SET_RC5_ROUNDS 0x5
+#define EVP_CTRL_RAND_KEY 0x6
+#define EVP_CTRL_PBE_PRF_NID 0x7
+#define EVP_CTRL_COPY 0x8
+#define EVP_CTRL_AEAD_SET_IVLEN 0x9
+#define EVP_CTRL_AEAD_GET_TAG 0x10
+#define EVP_CTRL_AEAD_SET_TAG 0x11
+#define EVP_CTRL_AEAD_SET_IV_FIXED 0x12
+#define EVP_CTRL_GCM_SET_IVLEN EVP_CTRL_AEAD_SET_IVLEN
+#define EVP_CTRL_GCM_GET_TAG EVP_CTRL_AEAD_GET_TAG
+#define EVP_CTRL_GCM_SET_TAG EVP_CTRL_AEAD_SET_TAG
+#define EVP_CTRL_GCM_SET_IV_FIXED EVP_CTRL_AEAD_SET_IV_FIXED
+#define EVP_CTRL_GCM_IV_GEN 0x13
+#define EVP_CTRL_CCM_SET_IVLEN EVP_CTRL_AEAD_SET_IVLEN
+#define EVP_CTRL_CCM_GET_TAG EVP_CTRL_AEAD_GET_TAG
+#define EVP_CTRL_CCM_SET_TAG EVP_CTRL_AEAD_SET_TAG
+#define EVP_CTRL_CCM_SET_IV_FIXED EVP_CTRL_AEAD_SET_IV_FIXED
+#define EVP_CTRL_CCM_SET_L 0x14
+#define EVP_CTRL_CCM_SET_MSGLEN 0x15
+
+#endif

--- a/.cbmc-batch/include/openssl/objects.h
+++ b/.cbmc-batch/include/openssl/objects.h
@@ -1,0 +1,26 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_OBJECTS_H
+#define HEADER_OBJECTS_H
+
+#define NID_undef 0
+#define NID_X9_62_prime256v1 415
+#define NID_secp384r1 715
+
+int OBJ_txt2nid(const char *s);
+
+#endif

--- a/.cbmc-batch/include/openssl/opensslv.h
+++ b/.cbmc-batch/include/openssl/opensslv.h
@@ -1,0 +1,22 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_OPENSSLV_H
+#define HEADER_OPENSSLV_H
+
+#define OPENSSL_VERSION_NUMBER 0X111000000
+
+#endif

--- a/.cbmc-batch/include/openssl/ossl_typ.h
+++ b/.cbmc-batch/include/openssl/ossl_typ.h
@@ -1,0 +1,45 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef HEADER_OPENSSL_TYPES_H
+#define HEADER_OPENSSL_TYPES_H
+
+#ifdef NO_ASN1_TYPEDEFS
+#    define ASN1_INTEGER ASN1_STRING
+#else
+typedef struct asn1_string_st ASN1_INTEGER;
+typedef struct asn1_string_st ASN1_STRING;
+#endif
+
+#ifdef BIGNUM
+#    undef BIGNUM
+#endif
+typedef struct bio_st BIO;
+typedef struct bignum_st BIGNUM;
+
+typedef struct ec_key_st EC_KEY;
+
+typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
+
+typedef struct evp_cipher_st EVP_CIPHER;
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
+typedef struct evp_md_st EVP_MD;
+typedef struct evp_md_ctx_st EVP_MD_CTX;
+typedef struct evp_pkey_st EVP_PKEY;
+
+typedef struct engine_st ENGINE;
+
+#endif

--- a/.cbmc-batch/include/openssl/pem.h
+++ b/.cbmc-batch/include/openssl/pem.h
@@ -1,0 +1,17 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* Empty header. Necessary just because it is included in cipher.c */

--- a/.cbmc-batch/include/openssl/rand.h
+++ b/.cbmc-batch/include/openssl/rand.h
@@ -1,0 +1,17 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* Empty header. Necessary just because it is included in cipher.c */

--- a/.cbmc-batch/include/openssl/rsa.h
+++ b/.cbmc-batch/include/openssl/rsa.h
@@ -1,0 +1,23 @@
+/*
+ * Changes to OpenSSL version 1.1.1. copyright 2019 Amazon.com, Inc. All Rights Reserved.
+ * Copyright 1995-2017 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#define RSA_PKCS1_PADDING 1
+#define RSA_SSLV23_PADDING 2
+#define RSA_NO_PADDING 3
+#define RSA_PKCS1_OAEP_PADDING 4
+#define RSA_X931_PADDING 5
+/* EVP_PKEY_ only */
+#define RSA_PKCS1_PSS_PADDING 6

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -84,7 +84,6 @@ INC += -I$(SRCDIR)/helper-inc
 INC += -I$(SRCDIR)/c-enc-sdk-inc
 INC += -I$(SRCDIR)/c-common-inc
 INC += -I$(SRCDIR)/c-common-helper-inc
-INC += -I/usr/local/opt/openssl@1.1/include/
 
 ################################################################
 # Temporarily disable UNWIND_GOTO, SIMPLIFY until the feature is

--- a/.cbmc-batch/source/openssl/objects_override.c
+++ b/.cbmc-batch/source/openssl/objects_override.c
@@ -22,14 +22,14 @@
  * numerical representation of an object. Return values: OBJ_txt2nid() returns a NID or NID_undef on error.
  */
 int OBJ_txt2nid(const char *s) {
-  // Currently these are the only values used in the ESDK
+    // Currently these are the only values used in the ESDK
     assert(!s || strcmp(s, "prime256v1") == 0 || strcmp(s, "secp384r1") == 0);
 
     if (!s) {
-      return NID_undef;
+        return NID_undef;
     } else if (strcmp(s, "prime256v1") == 0) {
         return NID_X9_62_prime256v1;
-    } else { // s is "secp384r1"
+    } else {  // s is "secp384r1"
         return NID_secp384r1;
     }
 }


### PR DESCRIPTION
*Description of changes:*

1. Created copies of the crypto.h, ec.h, ends.h, err.h, evp.h, openssl.h, ossl_typ.h, pem.h, rand.h and rsa.h OpenSSL headers inside the .cbmc-batch folder, with only the declarations and definitions that we need so far.
2. Changed Makefile.common to not add the OpenSSL path to the includes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.