### PR TITLE
SAW: Adapt to use of aws_byte_cursor for input

### DIFF
--- a/saw/helper_functions.cry
+++ b/saw/helper_functions.cry
@@ -77,11 +77,13 @@ incrementFrameSeqno session_old = {
 
 //Helper function to changed only the session of the state_t to a new state.        
 advanceSessionByStateOnly : state_t -> state_size_t -> state_t
-advanceSessionByStateOnly state_old new_state = {
-                                                sess = advanceStateOnly state_old.sess new_state,
-                                                output_buffer = state_old.output_buffer, 
-                                                input_buffer = state_old.input_buffer
-                                                }
+advanceSessionByStateOnly state_old new_state =
+  { state_old | sess = advanceStateOnly state_old.sess new_state }
 
+advanceByteBuf : aws_byte_buf_c_t -> size_bits_t -> aws_byte_buf_c_t
+advanceByteBuf buf l =
+  { buf | len -> len + l }
 
-                                                    
+advanceByteCursor : aws_byte_cursor_c_t -> size_bits_t -> aws_byte_cursor_c_t
+advanceByteCursor cursor l =
+  { cursor | ptr -> ptr + l, len -> len - l }

--- a/saw/state_machine.cry
+++ b/saw/state_machine.cry
@@ -47,10 +47,10 @@ processState state_old =
 
 // Has the state changed after a call of processState (line 242 of session.c)
 hasStateorPtrsChanged : state_t -> state_t -> Bit
-hasStateorPtrsChanged state_new state_old = 
+hasStateorPtrsChanged state_new state_old =
     if state_new.sess.state != state_old.sess.state then True
-    else if state_new.output_buffer.ptr != state_old.output_buffer.ptr then True 
-    else if state_new.input_buffer.ptr != state_old.input_buffer.ptr then True
+    else if state_new.output_buffer.len != state_old.output_buffer.len then True
+    else if state_new.input_cursor.ptr != state_old.input_cursor.ptr then True
     else False 
 
 
@@ -58,8 +58,8 @@ hasStateorPtrsChanged state_new state_old =
 // Are larger output or input buffers needed. 
 isBufferUpdateNeeded : state_t -> Bit 
 isBufferUpdateNeeded state_new = 
-    if state_new.sess.output_size_estimate > state_new.output_buffer.len then True 
-    else if state_new.sess.input_size_estimate > state_new.input_buffer.len then True 
+    if state_new.sess.output_size_estimate > state_new.output_buffer.len then True
+    else if state_new.sess.input_size_estimate > state_new.input_cursor.len then True
     else False
 
 
@@ -81,18 +81,11 @@ getNewBufferSize old_size estimate_size =
     else old_size
 
 updateBuffers : state_t -> state_t
-updateBuffers old_state = {
-                            sess = old_state.sess,
-                            output_buffer = { 
-                                            ptr = old_state.output_buffer.ptr, 
-                                            len = getNewBufferSize 
-                                                old_state.output_buffer.len 
-                                                old_state.sess.output_size_estimate
-                                              },
-                           input_buffer = {
-                                            ptr = old_state.input_buffer.ptr,
-                                            len = getNewBufferSize 
-                                                old_state.input_buffer.len 
-                                                old_state.sess.input_size_estimate 
-                                            }
-                           }
+updateBuffers old_state = { old_state |
+                            output_buffer.len -> getNewBufferSize
+                                                 len
+                                                 old_state.sess.output_size_estimate,
+                            input_cursor.len -> getNewBufferSize
+                                                len
+                                                old_state.sess.input_size_estimate
+                          }

--- a/saw/transition_functions.cry
+++ b/saw/transition_functions.cry
@@ -31,7 +31,6 @@ import helper_functions
 // Success case : state is updated
 //                output size estimate is the size of the header
 //                output buffer len has decreased by header size
-//                output buffer ptr has increased by header size 
 
 // Failure case : output size estimate is the size of the header 
 
@@ -40,24 +39,20 @@ tryWriteHeaderModel : state_t -> state_t
 tryWriteHeaderModel state_old = 
     if state_old.output_buffer.len >= state_old.sess.header_size then 
         {
-        sess = ( updateOutputInputEstimates 
-                    ( advanceStateOnly state_old.sess ST_ENCRYPT_BODY ) 
-                    state_old.sess.header_size
-                    state_old.sess.input_size_estimate ), 
-        output_buffer = {
-                        ptr = state_old.output_buffer.ptr + state_old.sess.header_size,
-                        len = state_old.output_buffer.len - state_old.sess.header_size
-                        },  
-        input_buffer = state_old.input_buffer
+        state_old |
+        sess -> ( updateOutputInputEstimates
+                     ( advanceStateOnly sess ST_ENCRYPT_BODY )
+                     sess.header_size
+                     sess.input_size_estimate ),
+        output_buffer -> advanceByteBuf output_buffer state_old.sess.header_size
         }
     else 
         {
-        sess = updateOutputInputEstimates 
-            state_old.sess 
-            state_old.sess.header_size 
-            state_old.sess.input_size_estimate,
-        output_buffer = state_old.output_buffer,
-        input_buffer = state_old.input_buffer
+        state_old |
+        sess -> updateOutputInputEstimates
+            sess
+            sess.header_size
+            sess.input_size_estimate
         }
 
 
@@ -81,32 +76,28 @@ getHeaderSize state_old =
 
 updateInputBuffer : state_t -> size_bits_t
 updateInputBuffer state_old = 
-    if ( state_old.sess.input_size_estimate < state_old.input_buffer.len ) then 
-        if ( (state_old.input_buffer.len + DEFAULT_SIZE_INCREMENT) < state_old.input_buffer.len ) then 
+    if ( state_old.sess.input_size_estimate < state_old.input_cursor.len ) then
+        if ( (state_old.input_cursor.len + DEFAULT_SIZE_INCREMENT) < state_old.input_cursor.len ) then
              ( SIZE_T_MAX - 1 )
-        else  (state_old.input_buffer.len + DEFAULT_SIZE_INCREMENT)
+        else  (state_old.input_cursor.len + DEFAULT_SIZE_INCREMENT)
     else state_old.sess.input_size_estimate
 
 tryParseHeaderModel : state_t -> state_t 
 tryParseHeaderModel state_old = 
-    if (state_old.input_buffer.len < ( getHeaderSize state_old ) ) then 
+    if (state_old.input_cursor.len < ( getHeaderSize state_old ) ) then
         {
+        state_old |
         sess = updateOutputInputEstimates 
                 state_old.sess 
                 0 
-                ( updateInputBuffer state_old ),
-        output_buffer = state_old.output_buffer, //UNCHANGED
-        input_buffer = state_old.input_buffer    //UNCHANGED 
+                ( updateInputBuffer state_old )
         }
 
     else 
         {
-        sess = advanceStateOnly state_old.sess ST_UNWRAP_KEY,
-        output_buffer = state_old.output_buffer, //UNCHANGED 
-        input_buffer = { 
-                        ptr = state_old.input_buffer.ptr + ( getHeaderSize state_old ), 
-                        len = state_old.output_buffer.ptr - ( getHeaderSize state_old )
-                        }
+        state_old |
+        sess -> advanceStateOnly sess ST_UNWRAP_KEY,
+        input_cursor -> advanceByteCursor input_cursor ( getHeaderSize state_old )
         }
     
 
@@ -135,23 +126,17 @@ tryParseHeaderModel state_old =
 //                                                      output size estimate is 0
 encryptHelper : state_t -> size_bits_t -> size_bits_t -> state_size_t -> state_t 
 encryptHelper state_old size_in size_out new_state = 
-    if ( state_old.input_buffer.len < size_in ) || ( state_old.output_buffer.len < size_out ) then 
+    if ( state_old.input_cursor.len < size_in ) || ( state_old.output_buffer.len < size_out ) then
         { 
-        sess = updateOutputInputEstimates state_old.sess size_out size_in,
-        output_buffer = state_old.output_buffer, //UNCHANGED 
-        input_buffer = state_old.input_buffer    //UNCHANGED 
+        state_old |
+        sess -> updateOutputInputEstimates sess size_out size_in
         }
     else 
-        { 
-        sess = updateOutputInputEstimates (advanceStateOnly (incrementFrameSeqno state_old.sess) new_state) size_out size_in,
-                output_buffer = { 
-                                ptr = state_old.output_buffer.ptr + size_out,
-                                len = state_old.output_buffer.len - size_out
-                                },
-                input_buffer = { 
-                                ptr = state_old.input_buffer.ptr + size_in,
-                                len = state_old.input_buffer.len - size_in
-                                }       
+        {
+        state_old |
+        sess -> updateOutputInputEstimates (advanceStateOnly (incrementFrameSeqno sess) new_state) size_out size_in,
+                output_buffer -> advanceByteBuf output_buffer size_out,
+                input_cursor -> advanceByteCursor input_cursor size_in
         }
 
 encryptBodyFramed : state_t -> state_t
@@ -179,9 +164,8 @@ encryptBodyUnframed state_old =
             (state_old.sess.alg_prop.iv_len + FRAME_FIELD_OVERHEAD_UNFRAMED + state_old.sess.precise_size + state_old.sess.alg_prop.tag_len) 
             ST_WRITE_TRAILER
     else { 
-        sess = updateOutputInputEstimates state_old.sess 0 0,
-        output_buffer = state_old.output_buffer,
-        input_buffer = state_old.input_buffer 
+        state_old |
+        sess -> updateOutputInputEstimates sess 0 0
         }
 
 
@@ -194,32 +178,26 @@ tryEncryptBodyModel state_old =
 // Partial Cryptol translation of function try_decrypt_body in session_decrypt.c (line 193 - 252)
 decryptHelper : state_t -> size_bits_t -> size_bits_t -> state_size_t -> state_t
 decryptHelper state_old size_in size_out new_state = 
-    if ( state_old.input_buffer.len < size_in ) || ( state_old.output_buffer.len < size_out ) then 
+    if ( state_old.input_cursor.len < size_in ) || ( state_old.output_buffer.len < size_out ) then
         { 
-        sess = updateOutputInputEstimates state_old.sess size_out size_in, 
-        output_buffer = state_old.output_buffer,
-        input_buffer = state_old.input_buffer
+        state_old |
+        sess -> updateOutputInputEstimates sess size_out size_in
         }
     else 
-        { 
-        sess = updateOutputInputEstimates (advanceStateOnly state_old.sess new_state) size_out size_in,
-        output_buffer = { 
-                        ptr = state_old.output_buffer.ptr + size_out,
-                        len = state_old.output_buffer.len - size_out
-                        },
-        input_buffer = { 
-                        ptr = state_old.input_buffer.ptr + size_in,
-                        len = state_old.input_buffer.len - size_in
-                        }       
+        {
+        state_old |
+        sess -> updateOutputInputEstimates (advanceStateOnly sess new_state) size_out size_in,
+        output_buffer -> advanceByteBuf output_buffer size_out,
+        input_cursor -> advanceByteCursor input_cursor size_in
         }
 
-//TODO: Size of the unframed data is stored in the ciphertext (input_buffer). What is the best way to model this?
+//TODO: Size of the unframed data is stored in the ciphertext (input_cursor). What is the best way to model this?
 //TODO: Should not be using state_old.sess.precise_size. This is only temporary. 
 decryptBodyUnframed : state_t -> state_t 
 decryptBodyUnframed state_old = decryptHelper state_old ( state_old.sess.alg_prop.iv_len + 8 + 
 state_old.sess.precise_size + state_old.sess.alg_prop.tag_len)   state_old.sess.precise_size ST_CHECK_TRAILER
 
-//TODO: Whether the frame is final as well as the size of the final frame is stored in the ciphertext (input_buffer). 
+//TODO: Whether the frame is final as well as the size of the final frame is stored in the ciphertext (input_cursor).
 decryptBodyFramed : state_t -> state_t 
 decryptBodyFramed state_old = state_old 
 

--- a/saw/type_def.cry
+++ b/saw/type_def.cry
@@ -27,8 +27,8 @@ module type_def where
 // function of session.c has made progress (line 242)
 type state_t = {
                     sess : session_c_t, 
-                    output_buffer : aws_byte_cursor_c_t, 
-                    input_buffer : aws_byte_cursor_c_t
+                    output_buffer : aws_byte_buf_c_t,
+                    input_cursor : aws_byte_cursor_c_t
                     }
 
 
@@ -54,6 +54,16 @@ type aws_byte_cursor_c_t = {
     ptr : size_bits_t, //TODO: actual size in the c code is [8]. Figure out casting
     len : size_bits_t
     }
+
+
+// See <aws/common/byte_buf.h>
+// NOTE: Incomplete implementation - only has the fields necessary for current proofs.
+type aws_byte_buf_c_t = {
+    len : size_bits_t,
+    buffer : size_bits_t, //TODO: actual size in the c code is [8]. Figure out casting
+    capacity : size_bits_t
+}
+
 
 // <aws/cryptosdk/cipher.h>> : 28 - 41
 // NOTE: Incomplete implementation - only has the fields necessary for current proofs. 


### PR DESCRIPTION
The Cryptol specs were written at a time when aws_byte_buf was being
used for both input and output; nowadays input happens through
aws_byte_cursor instead (for instance,
`aws_cryptosdk_priv_try_parse_header` takes an `aws_byte_cursor *`).

*Description of changes:*

A new type `aws_byte_buf_c_t` is created to wrap the `aws_byte_buf` structure, and several fields and arguments have their types changed from `aws_byte_cursor_c_t` to `aws_byte_buf_c_t`.  Also, Cryptol's new record-update syntax simplifies a number of expressions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
