### PR TITLE
Changes to Makefile.common for CBMC proofs

### DIFF
--- a/.cbmc-batch/include/ec_utils.h
+++ b/.cbmc-batch/include/ec_utils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef EC_UTILS_H
+#define EC_UTILS_H
+
+#include <stdbool.h>
+
+#include <openssl/ec.h>
+
+bool ec_key_is_valid(EC_KEY *key);
+
+EC_KEY *ec_key_nondet_alloc();
+
+int ec_key_get_reference_count(EC_KEY *key);
+
+void ec_key_unconditional_free(EC_KEY *key);
+
+#endif

--- a/.cbmc-batch/include/evp_utils.h
+++ b/.cbmc-batch/include/evp_utils.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifndef EVP_UTILS_H
+#define EVP_UTILS_H
+
+#include <openssl/evp.h>
+
+bool evp_pkey_is_valid(EVP_PKEY *pkey);
+
+EVP_PKEY *evp_pkey_nondet_alloc();
+
+int evp_pkey_get_reference_count(EVP_PKEY *pkey);
+
+void evp_pkey_set0_ec_key(EVP_PKEY *pkey, EC_KEY *ec);
+
+void evp_pkey_unconditional_free(EVP_PKEY *pkey);
+
+bool evp_md_ctx_is_valid(EVP_MD_CTX *ctx);
+
+EVP_MD_CTX *evp_md_ctx_nondet_alloc();
+
+bool evp_md_ctx_is_initialized(EVP_MD_CTX *ctx);
+
+size_t evp_md_ctx_get_digest_size(EVP_MD_CTX *ctx);
+
+EVP_PKEY *evp_md_ctx_get0_evp_pkey(EVP_MD_CTX *ctx);
+
+void evp_md_ctx_set0_evp_pkey(EVP_MD_CTX *ctx, EVP_PKEY *pkey);
+
+void evp_md_ctx_shallow_free(EVP_MD_CTX *ctx);
+
+#endif

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/common.h>
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props);

--- a/.cbmc-batch/include/openssl/crypto.h
+++ b/.cbmc-batch/include/openssl/crypto.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+

--- a/.cbmc-batch/include/openssl/ec.h
+++ b/.cbmc-batch/include/openssl/ec.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/objects.h>
+#include <openssl/ossl_typ.h>
+
+/** Enum for the point conversion form as defined in X9.62 (ECDSA)
+ *  for the encoding of a elliptic curve point (x,y) */
+typedef enum {
+    /** the point is encoded as z||x, where the octet z specifies
+     *  which solution of the quadratic equation y is  */
+    POINT_CONVERSION_COMPRESSED = 2,
+    /** the point is encoded as z||x||y, where z is the octet 0x04  */
+    POINT_CONVERSION_UNCOMPRESSED = 4,
+    /** the point is encoded as z||x||y, where the octet z specifies
+     *  which solution of the quadratic equation y is  */
+    POINT_CONVERSION_HYBRID = 6
+} point_conversion_form_t;
+
+typedef struct ec_group_st EC_GROUP;
+
+EC_GROUP *EC_GROUP_new_by_curve_name(int nid);
+void EC_GROUP_set_point_conversion_form(EC_GROUP *group, point_conversion_form_t form);
+void EC_GROUP_free(EC_GROUP *group);
+
+typedef struct ECDSA_SIG_st ECDSA_SIG;
+
+EC_KEY *EC_KEY_new(void);
+int EC_KEY_set_group(EC_KEY *key, const EC_GROUP *group);
+void EC_KEY_set_conv_form(EC_KEY *eckey, point_conversion_form_t cform);
+int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *prv);
+int EC_KEY_up_ref(EC_KEY *r);
+void EC_KEY_free(EC_KEY *key);
+
+EC_KEY *o2i_ECPublicKey(EC_KEY **key, const unsigned char **in, long len);
+int i2o_ECPublicKey(EC_KEY *key, unsigned char **out);

--- a/.cbmc-batch/include/openssl/ecdsa.h
+++ b/.cbmc-batch/include/openssl/ecdsa.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */

--- a/.cbmc-batch/include/openssl/err.h
+++ b/.cbmc-batch/include/openssl/err.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <stddef.h>
+
+#include <openssl/ec.h>
+#include <openssl/ossl_typ.h>
+
+#define EVP_MAX_MD_SIZE 64 /* longest known is SHA512 */
+
+EVP_PKEY *EVP_PKEY_new(void);
+EC_KEY *EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey);
+int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key);
+void EVP_PKEY_free(EVP_PKEY *pkey);
+EVP_MD_CTX *EVP_MD_CTX_new(void);
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl);
+int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
+int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
+int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
+int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen);
+
+#define EVP_MD_CTX_create() EVP_MD_CTX_new()
+#define EVP_MD_CTX_destroy(ctx) EVP_MD_CTX_free((ctx))
+
+const EVP_CIPHER *EVP_aes_128_gcm(void);
+const EVP_CIPHER *EVP_aes_192_gcm(void);
+const EVP_CIPHER *EVP_aes_256_gcm(void);
+const EVP_MD *EVP_sha256(void);
+const EVP_MD *EVP_sha384(void);
+const EVP_MD *EVP_sha512(void);
+
+#define EVP_CTRL_INIT 0x0
+#define EVP_CTRL_SET_KEY_LENGTH 0x1
+#define EVP_CTRL_GET_RC2_KEY_BITS 0x2
+#define EVP_CTRL_SET_RC2_KEY_BITS 0x3
+#define EVP_CTRL_GET_RC5_ROUNDS 0x4
+#define EVP_CTRL_SET_RC5_ROUNDS 0x5
+#define EVP_CTRL_RAND_KEY 0x6
+#define EVP_CTRL_PBE_PRF_NID 0x7
+#define EVP_CTRL_COPY 0x8
+#define EVP_CTRL_AEAD_SET_IVLEN 0x9
+#define EVP_CTRL_AEAD_GET_TAG 0x10
+#define EVP_CTRL_AEAD_SET_TAG 0x11
+#define EVP_CTRL_AEAD_SET_IV_FIXED 0x12
+#define EVP_CTRL_GCM_SET_IVLEN EVP_CTRL_AEAD_SET_IVLEN
+#define EVP_CTRL_GCM_GET_TAG EVP_CTRL_AEAD_GET_TAG
+#define EVP_CTRL_GCM_SET_TAG EVP_CTRL_AEAD_SET_TAG
+#define EVP_CTRL_GCM_SET_IV_FIXED EVP_CTRL_AEAD_SET_IV_FIXED
+#define EVP_CTRL_GCM_IV_GEN 0x13
+#define EVP_CTRL_CCM_SET_IVLEN EVP_CTRL_AEAD_SET_IVLEN
+#define EVP_CTRL_CCM_GET_TAG EVP_CTRL_AEAD_GET_TAG
+#define EVP_CTRL_CCM_SET_TAG EVP_CTRL_AEAD_SET_TAG
+#define EVP_CTRL_CCM_SET_IV_FIXED EVP_CTRL_AEAD_SET_IV_FIXED
+#define EVP_CTRL_CCM_SET_L 0x14
+#define EVP_CTRL_CCM_SET_MSGLEN 0x15

--- a/.cbmc-batch/include/openssl/objects.h
+++ b/.cbmc-batch/include/openssl/objects.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#define NID_undef 0
+#define NID_X9_62_prime256v1 415
+#define NID_secp384r1 715
+
+int OBJ_txt2nid(const char *s);

--- a/.cbmc-batch/include/openssl/opensslv.h
+++ b/.cbmc-batch/include/openssl/opensslv.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#define OPENSSL_VERSION_NUMBER 0X111000000

--- a/.cbmc-batch/include/openssl/ossl_typ.h
+++ b/.cbmc-batch/include/openssl/ossl_typ.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#ifdef NO_ASN1_TYPEDEFS
+#define ASN1_INTEGER            ASN1_STRING
+#else
+typedef struct asn1_string_st ASN1_INTEGER;
+#endif
+
+#ifdef BIGNUM
+#undef BIGNUM
+#endif
+typedef struct bio_st BIO;
+typedef struct bignum_st BIGNUM;
+
+typedef struct ec_key_st EC_KEY;
+
+typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
+
+typedef struct evp_cipher_st EVP_CIPHER;
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
+typedef struct evp_md_st EVP_MD;
+typedef struct evp_md_ctx_st EVP_MD_CTX;
+typedef struct evp_pkey_st EVP_PKEY;
+
+typedef struct engine_st ENGINE;

--- a/.cbmc-batch/include/openssl/pem.h
+++ b/.cbmc-batch/include/openssl/pem.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */

--- a/.cbmc-batch/include/openssl/rand.h
+++ b/.cbmc-batch/include/openssl/rand.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */

--- a/.cbmc-batch/include/openssl/rsa.h
+++ b/.cbmc-batch/include/openssl/rsa.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+# define RSA_PKCS1_PADDING       1
+# define RSA_SSLV23_PADDING      2
+# define RSA_NO_PADDING          3
+# define RSA_PKCS1_OAEP_PADDING  4
+# define RSA_X931_PADDING        5
+/* EVP_PKEY_ only */
+# define RSA_PKCS1_PSS_PADDING   6

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -21,7 +21,6 @@ INC += -I$(SRCDIR)/helper-inc
 INC += -I$(SRCDIR)/c-enc-sdk-inc
 INC += -I$(SRCDIR)/c-common-inc
 INC += -I$(SRCDIR)/c-common-helper-inc
-INC += -I/usr/local/opt/openssl@1.1/include/
 
 CBMC_OBJECT_BITS ?= 8
 CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
@@ -102,7 +101,7 @@ helper-symlinks: linkfarm-dir
 fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks common-helper-symlinks helper-symlinks
 
 $(ENTRY)1.goto: fill-linkfarm $(OBJS)
-	$(GOTO_CC) --function harness -o $@ $(OBJS)
+		$(GOTO_CC) --function harness -o $@ $(OBJS)
 
 $(ENTRY)3.goto: $(ENTRY)1.goto
 	 $(GOTO_INSTRUMENT) $(ABSTRACTIONS) --add-library $< $@ \
@@ -186,7 +185,6 @@ clean:
 veryclean: clean
 	$(RM) -r html
 	$(RM) -r link-farm
-
 gitclean: veryclean
 	$(RM) -r $(COMMONDIR)
 

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -16,6 +16,12 @@ SHELL=/bin/bash
 default: report
 
 ################################################################
+# Define some constants that are hard to reference otherwise
+SPACE :=$() $()
+COMMA :=,
+
+
+################################################################
 # Helper-inc must go first, so it can override other includes.
 INC += -I$(SRCDIR)/helper-inc
 INC += -I$(SRCDIR)/c-enc-sdk-inc
@@ -47,12 +53,20 @@ CBMCFLAGS += --undefined-shift-check
 CBMCFLAGS += --unsigned-overflow-check
 CBMCFLAGS += --unwind 1
 CBMCFLAGS += --unwinding-assertions
-
+CBMCFLAGS += $(CBMC_UNWINDSET)
 
 UNWIND ?= 0
 SIMPLIFY ?= 0
 
 ABSTRACTIONS ?=
+
+################################################################
+# Preprocess the unwindset
+
+ifneq ($(UNWINDSET),)
+CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+endif
+
 
 ################################################################
 # makes a symlink if one doesn't already exist

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -45,6 +45,7 @@ HARNESS_NAME ?= $(ENTRY)_harness.c
 CBMCFLAGS += --bounds-check
 CBMCFLAGS += --div-by-zero-check
 CBMCFLAGS += --float-overflow-check
+CBMCFLAGS += --memory-leak-check
 CBMCFLAGS += --nan-check
 CBMCFLAGS += --pointer-check
 CBMCFLAGS += --pointer-overflow-check

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -191,7 +191,7 @@ gitclean: veryclean
 	$(RM) -r $(COMMONDIR)
 
 
-.PHONY: cbmc property coverage report clean veryclean common-symlinks common-git harness-symlink fill-linkfarm helper-symlinks
+.PHONY: cbmc property coverage report clean veryclean common-symlinks common-git harness-symlink fill-linkfarm helper-symlinks ci-yaml
 
 ################################################################
 # Launching cbmc on cbmc-batch
@@ -240,6 +240,16 @@ $(ENTRY).yaml: $(ENTRY).goto Makefile
 	echo 'property_memory: $(PROPMEM)' >> $@
 	echo 'coverage_memory: $(COVMEM)' >> $@
 	echo 'expected: "SUCCESSFUL"' >> $@
+
+batch-yaml: $(ENTRY).yaml
+
+cbmc-batch.yaml: $(ENTRY).goto Makefile
+	echo 'jobos: ubuntu16' > $@
+	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
+	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'expected: "SUCCESSFUL"' >> $@
+
+ci-yaml: cbmc-batch.yaml
 
 launch: $(ENTRY).goto Makefile
 	mkdir -p $(WS)

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -17,12 +17,15 @@ default: report
 
 ################################################################
 # Helper-inc must go first, so it can override other includes.
-INC += \
-	-I$(SRCDIR)/helper-inc \
-	-I$(SRCDIR)/c-enc-sdk-inc \
-	-I$(SRCDIR)/c-common-inc 
-	 
+INC += -I$(SRCDIR)/helper-inc
+INC += -I$(SRCDIR)/c-enc-sdk-inc
+INC += -I$(SRCDIR)/c-common-inc
+INC += -I$(SRCDIR)/c-common-helper-inc
+INC += -I/usr/local/opt/openssl@1.1/include/
 
+CBMC_OBJECT_BITS ?= 8
+CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
+DEF += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEF += -DCBMC=1
 
 OPT += 
@@ -31,15 +34,21 @@ CFLAGS += $(CFLAGS2) $(DEF) $(OPT)
 
 LINKFARM = $(abspath ./link-farm)
 
+HARNESS_NAME ?= $(ENTRY)_harness.c
+
 ################################################################
-CBMCFLAGS += \
-	--bounds-check \
-	--pointer-check \
-	--signed-overflow-check \
-	--unsigned-overflow-check \
-	--pointer-overflow-check \
-	--div-by-zero-check \
-	--unwinding-assertions
+CBMCFLAGS += --bounds-check
+CBMCFLAGS += --div-by-zero-check
+CBMCFLAGS += --float-overflow-check
+CBMCFLAGS += --nan-check
+CBMCFLAGS += --pointer-check
+CBMCFLAGS += --pointer-overflow-check
+CBMCFLAGS += --signed-overflow-check
+CBMCFLAGS += --undefined-shift-check
+CBMCFLAGS += --unsigned-overflow-check
+CBMCFLAGS += --unwind 1
+CBMCFLAGS += --unwinding-assertions
+
 
 UNWIND ?= 0
 SIMPLIFY ?= 0
@@ -74,6 +83,10 @@ common-symlinks: common-git linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(COMMONDIR)/include, c-common-inc)
 	$(call make_symlink, $(LINKFARM), $(COMMONDIR)/source, c-common-src)
 
+common-helper-symlinks: common-git linkfarm-dir
+	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/include, c-common-helper-inc)
+	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/source, c-common-helper-src)
+
 enc-sdk-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(SDKDIR)/include, c-enc-sdk-inc)
 	$(call make_symlink, $(LINKFARM), $(SDKDIR)/source, c-enc-sdk-src)
@@ -86,20 +99,20 @@ helper-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(HELPERDIR)/source, helper-src)
 
 
-fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks helper-symlinks
+fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks common-helper-symlinks helper-symlinks
 
 $(ENTRY)1.goto: fill-linkfarm $(OBJS)
 	$(GOTO_CC) --function harness -o $@ $(OBJS)
 
 $(ENTRY)3.goto: $(ENTRY)1.goto
 	 $(GOTO_INSTRUMENT) $(ABSTRACTIONS) --add-library $< $@ \
-		2>&1 | tee $(ENTRY)3.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)3.log ; exit $${PIPESTATUS[0]}
 
 # Simplify and constant propagation may benefit from unwinding first
 $(ENTRY)4.goto: $(ENTRY)3.goto
 ifeq ($(UNWIND_GOTO), 1)
 	$(GOTO_INSTRUMENT) $(UNWINDING) $< $@ \
-		2>&1 | tee $(ENTRY)4.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)4.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
@@ -108,7 +121,7 @@ endif
 $(ENTRY)5.goto: $(ENTRY)4.goto
 ifeq ($(SIMPLIFY), 1)
 	$(GOTO_INSTRUMENT) --generate-function-body '.*' $< $@ \
-		2>&1 | tee $(ENTRY)5.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)5.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
@@ -117,18 +130,18 @@ endif
 $(ENTRY)6.goto: $(ENTRY)5.goto
 ifeq ($(SIMPLIFY), 1)
 	$(GOTO_ANALYZER) --simplify $@ $< \
-		2>&1 | tee $(ENTRY)6.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)6.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
 
 $(ENTRY)7.goto: $(ENTRY)6.goto
 	$(GOTO_INSTRUMENT) --drop-unused-functions $< $@ \
-		2>&1 | tee $(ENTRY)7.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)7.log ; exit $${PIPESTATUS[0]}
 
 $(ENTRY)8.goto: $(ENTRY)7.goto
 	$(GOTO_INSTRUMENT) --slice-global-inits $< $@ \
-		2>&1 | tee $(ENTRY)8.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)8.log ; exit $${PIPESTATUS[0]}
 
 $(ENTRY).goto: $(ENTRY)8.goto
 	cp $< $@
@@ -138,7 +151,7 @@ $(ENTRY).goto: $(ENTRY)8.goto
 
 goto: $(ENTRY).goto 
 
-cbmc.txt: $(ENTRY).goto
+cbmc.log: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
 
 property.xml: $(ENTRY).goto
@@ -147,27 +160,27 @@ property.xml: $(ENTRY).goto
 coverage.xml: $(ENTRY).goto
 	cbmc $(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui $< 2>&1 > $@
 
-cbmc: cbmc.txt
+cbmc: cbmc.log
 
 property: property.xml
 
 coverage: coverage.xml
 
-report: cbmc.txt property.xml coverage.xml
+report: cbmc.log property.xml coverage.xml
 	$(VIEWER) \
 	--goto $(ENTRY).goto \
 	--srcdir $(SRCDIR) \
 	--htmldir html \
 	--srcexclude "(./verification|./tests|./tools|./lib/third_party)" \
-	--result cbmc.txt \
+	--result cbmc.log \
 	--property property.xml \
 	--block coverage.xml
 
 clean:
 	$(RM) $(GOTOS)
 	$(RM) $(OBJS) $(ENTRY).goto
-	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
-	$(RM) cbmc.txt property.xml coverage.xml TAGS
+	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].log
+	$(RM) cbmc.log property.xml coverage.xml TAGS
 	$(RM) *~ \#*
 
 veryclean: clean

--- a/.cbmc-batch/jobs/Makefile.local_default
+++ b/.cbmc-batch/jobs/Makefile.local_default
@@ -24,5 +24,6 @@ SRCDIR ?= $(abspath ./link-farm)
 BASEDIR ?= $(abspath ../../../..)
 COMMON_REPO_NAME ?= aws-c-common-for-cryptosdk-proofs
 COMMONDIR ?= $(BASEDIR)/$(COMMON_REPO_NAME)
+COMMON_HELPERDIR ?= $(COMMONDIR)/.cbmc-batch
 SDKDIR ?= $(abspath ../../..)
 HELPERDIR ?= $(SDKDIR)/.cbmc-batch

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
@@ -20,12 +20,10 @@ include ../Makefile.local_default
 
 ######### 
 ENTRY = MultiKeyringNew
-HARNESS_NAME = $(ENTRY)_harness.c
-OBJS = \
-	$(SRCDIR)/$(ENTRY)_harness.goto \
-	$(SRCDIR)/c-enc-sdk-src/multi_keyring.goto \
-	$(SRCDIR)/c-common-src/common.goto \
-	$(SRCDIR)/helper-src/proof_allocators.goto
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+OBJS += $(SRCDIR)/c-enc-sdk-src/multi_keyring.goto
+OBJS += $(SRCDIR)/c-common-src/common.goto
+OBJS += $(SRCDIR)/helper-src/proof_allocators.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+UNWINDSET += 
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_serialize_frame
+
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+
+OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/utils.goto
+OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
+OBJS +=	$(SRCDIR)/c-common-src/common.goto
+OBJS +=	$(SRCDIR)/c-common-src/error.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
+OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void harness() {
+    /* data structure */
+    struct aws_cryptosdk_frame frame;
+    size_t ciphertext_size;
+    size_t plaintext_size;
+    struct aws_byte_buf ciphertext_buf;
+    struct aws_cryptosdk_alg_properties alg_props;
+
+    /* Assumptions about the function input */
+    ensure_byte_buf_has_allocated_buffer_member(&ciphertext_buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&ciphertext_buf));
+
+    ensure_alg_properties_has_allocated_names(&alg_props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(&alg_props));
+
+    /* Save the old state of the ciphertext buffer */
+    uint8_t *old_ciphertext_buffer   = ciphertext_buf.buffer;
+    size_t old_ciphertext_buffer_len = ciphertext_buf.len;
+
+    int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, &alg_props);
+    if (rval == AWS_OP_SUCCESS) {
+        assert(aws_cryptosdk_frame_is_valid(&frame));
+        assert(ciphertext_buf.buffer == old_ciphertext_buffer);
+        assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
+    } else {
+        // Assert that the ciphertext buffer is zeroed in case of failure
+        assert_all_zeroes(ciphertext_buf.buffer, ciphertext_buf.capacity);
+        assert(ciphertext_buf.len == 0);
+    }   
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -38,7 +38,7 @@ void harness() {
     size_t old_ciphertext_buffer_len = ciphertext_buf.len;
 
     /* Assume the preconditions */
-    __CPROVER_assume(aws_cryptosdk_frame_has_valid_type_seq(&frame));
+    __CPROVER_assume(aws_cryptosdk_frame_has_valid_type(&frame));
 
     int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, &alg_props);
     if (rval == AWS_OP_SUCCESS) {

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--object-bits;8;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions"
+goto: aws_cryptosdk_serialize_frame.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <make_common_data_structures.h>
+
+void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props) {
+    size_t md_name_size;
+    alg_props->md_name = can_fail_malloc(md_name_size);
+    size_t cipher_name_size;
+    alg_props->cipher_name = can_fail_malloc(cipher_name_size);
+    size_t alg_name_size;
+    alg_props->alg_name = can_fail_malloc(alg_name_size);
+}

--- a/.cbmc-batch/source/openssl/ec_override.c
+++ b/.cbmc-batch/source/openssl/ec_override.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <ec_utils.h>
+#include <openssl/ec.h>
+#include <openssl/objects.h>
+
+#include <proof_helpers/nondet.h>
+#include <proof_helpers/proof_allocators.h>
+
+/* Abstraction of the EC_GROUP struct */
+struct ec_group_st {
+    int curve_name;
+    point_conversion_form_t asn1_form;
+};
+
+/*
+ * Description: In order to construct a builtin curve use the function EC_GROUP_new_by_curve_name and provide the nid of
+ * the curve to be constructed. Return values: All EC_GROUP_new* functions return a pointer to the newly constructed
+ * group, or NULL on error.
+ */
+EC_GROUP *EC_GROUP_new_by_curve_name(int nid) {
+    assert(nid == NID_X9_62_prime256v1 || nid == NID_secp384r1);
+
+    EC_GROUP *group = can_fail_malloc(sizeof(EC_GROUP));
+
+    if (group) {
+        group->curve_name = nid;
+        group->asn1_form  = POINT_CONVERSION_UNCOMPRESSED;
+    }
+
+    return group;
+}
+
+/*
+ * Description: The functions EC_GROUP_set_point_conversion_form and EC_GROUP_get_point_conversion_form set and get the
+ * point_conversion_form for the curve respectively.
+ */
+void EC_GROUP_set_point_conversion_form(EC_GROUP *group, point_conversion_form_t form) {
+    assert(group);
+    group->asn1_form = form;
+}
+
+/*
+ * Description: EC_GROUP_free frees the memory associated with the EC_GROUP. If group is NULL nothing is done.
+ */
+void EC_GROUP_free(EC_GROUP *group) {
+    free(group);
+}
+
+struct ec_key_st {
+    int references;
+    EC_GROUP *group;
+    point_conversion_form_t conv_form;
+    bool pub_key_is_set;
+    bool priv_key_is_set;
+};
+
+/*
+ * Description: A new EC_KEY with no associated curve can be constructed by calling EC_KEY_new(). The reference count
+ * for the newly created EC_KEY is initially set to 1. Return value: EC_KEY_new(), EC_KEY_new_by_curve_name() and
+ * EC_KEY_dup() return a pointer to the newly created EC_KEY object, or NULL on error.
+ */
+EC_KEY *EC_KEY_new() {
+    EC_KEY *key = can_fail_malloc(sizeof(EC_KEY));
+
+    if (key) {
+        key->references     = 1;
+        key->group          = NULL;  // no associated curve
+        key->conv_form      = POINT_CONVERSION_UNCOMPRESSED;
+        key->pub_key_is_set = false;
+    }
+
+    return key;
+}
+
+/*
+ * Description: The function EC_KEY_set_group() sets the EC_GROUP object for the key.
+ * Return values: Returns 1 on success or 0 on error.
+ */
+int EC_KEY_set_group(EC_KEY *key, const EC_GROUP *group) {
+    assert(key);
+
+    if (!group || nondet_bool()) return 0;
+
+    EC_GROUP_free(key->group);
+    key->group = can_fail_malloc(sizeof(EC_GROUP));
+
+    if (!key->group) return 0;
+
+    *key->group = *group;
+
+    return 1;
+}
+
+/*
+ * Description: The functions EC_KEY_get_conv_form() and EC_KEY_set_conv_form() get and set the point_conversion_form
+ * for the key.
+ */
+void EC_KEY_set_conv_form(EC_KEY *key, point_conversion_form_t cform) {
+    assert(key);
+    key->conv_form = cform;
+    if (key->group != NULL) EC_GROUP_set_point_conversion_form(key->group, cform);
+}
+
+/*
+ * Description: The function EC_KEY_set_private_key() sets the private key for the key.
+ * Return values: Returns 1 on success or 0 on error.
+ */
+int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *prv) {
+    assert(key);
+    assert(prv);
+
+    if (key->group == NULL || nondet_bool()) {
+        return 0;
+    }
+
+    key->priv_key_is_set = true;
+    return 1;
+}
+
+/*
+ * Description: EC_KEY_up_ref() increments the reference count associated with the EC_KEY object.
+ * Return values: EC_KEY_up_ref() returns 1 on success or 0 on error.
+ */
+int EC_KEY_up_ref(EC_KEY *key) {
+    assert(key);
+
+    key->references += 1;
+    return 1;  // Can we assume that this never fails?
+}
+
+/*
+ * Description: Calling EC_KEY_free() decrements the reference count for the EC_KEY object, and if it has dropped to
+ * zero then frees the memory associated with it. If key is NULL nothing is done.
+ */
+void EC_KEY_free(EC_KEY *key) {
+    if (key) {
+        key->references -= 1;
+        if (key->references == 0) {
+            EC_GROUP_free(key->group);
+            free(key);
+        }
+    }
+}
+
+/** Decodes a ec public key from a octet string.
+ *  \param  key  a pointer to a EC_KEY object which should be used
+ *  \param  in   memory buffer with the encoded public key
+ *  \param  len  length of the encoded public key
+ *  \return EC_KEY object with decoded public key or NULL if an error
+ *          occurred.
+ */
+EC_KEY *o2i_ECPublicKey(EC_KEY **key, const unsigned char **in, long len) {
+    assert(in);
+    assert(*in);
+    assert(AWS_MEM_IS_READABLE(*in, len));
+
+    if (!key || !(*key) || !(*key)->group || nondet_bool()) {
+        return NULL;
+    }
+
+    (*key)->pub_key_is_set = true;
+
+    // o2i_ECPublicKey calls EC_KEY_oct2key, which in some cases sets the conversion form.
+    // Can we guarantee that this never happens in our use cases?
+    // Any other possible changes to the EC_KEY?
+
+    long offset;
+    __CPROVER_assume(0 <= offset && offset <= len);
+    *in += offset;
+    return *key;
+}
+
+/** Encodes a ec public key in an octet string.
+ *  \param  key  the EC_KEY object with the public key
+ *  \param  out  the buffer for the result (if NULL the function returns number
+ *               of bytes needed).
+ *  \return 1 on success and 0 if an error occurred
+ */
+int i2o_ECPublicKey(const EC_KEY *key, unsigned char **out) {
+    assert(out);           // Assuming that it's always called in ESDK with non-NULL out
+    assert(*out == NULL);  // Assuming that it's always called with NULL *out, so buffer needs to be allocated
+
+    if (!key) return 0;
+
+    int buf_len;
+    __CPROVER_assume(0 < buf_len);
+    *out = can_fail_malloc(buf_len);
+
+    if (*out == NULL) {
+        int error_code;
+        __CPROVER_assume(error_code <= 0);
+        return error_code;
+    }
+
+    return buf_len;
+}
+
+/* CBMC helper functions */
+
+bool ec_group_is_valid(EC_GROUP *group) {
+    return group && (group->curve_name != NID_undef) && (group->asn1_form == POINT_CONVERSION_COMPRESSED);
+}
+
+/* Helper function for CBMC proofs: check validity of an EC_KEY. */
+bool ec_key_is_valid(EC_KEY *key) {
+    return key && (0 < key->references) && ec_group_is_valid(key->group) && (key->group->asn1_form == key->conv_form) &&
+           key->pub_key_is_set && key->priv_key_is_set;
+}
+
+/* Helper function for CBMC proofs: allocates an EC_KEY nondeterministically. */
+EC_KEY *ec_key_nondet_alloc() {
+    EC_KEY *key = can_fail_malloc(sizeof(EC_KEY));
+
+    if (key) key->group = can_fail_malloc(sizeof(EC_GROUP));
+
+    return key;
+}
+
+/* Helper function for CBMC proofs: returns the reference count. */
+int ec_key_get_reference_count(EC_KEY *key) {
+    return key ? key->references : 0;
+}
+
+/* Helper function for CBMC proofs: returns the group. */
+int ec_key_get_group(EC_KEY *key) {
+    return key ? key->group : NULL;
+}
+
+/* Helper function for CBMC proofs: frees the memory regardless of the reference count. */
+void ec_key_unconditional_free(EC_KEY *key) {
+    free(key->group);
+    free(key);
+}

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/evp.h>
+
+#include <ec_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/nondet.h>
+
+/* Abstraction of the EVP_PKEY struct */
+struct evp_pkey_st {
+    int references;
+    EC_KEY *ec_key;
+};
+
+/*
+ * Description: The EVP_PKEY_new() function allocates an empty EVP_PKEY structure which is used by OpenSSL to store
+ * public and private keys. The reference count is set to 1. Return values: EVP_PKEY_new() returns either the newly
+ * allocated EVP_PKEY structure or NULL if an error occurred.
+ */
+EVP_PKEY *EVP_PKEY_new() {
+    EVP_PKEY *pkey = can_fail_malloc(sizeof(EVP_PKEY));
+
+    if (pkey) {
+        pkey->references = 1;
+        pkey->ec_key     = NULL;
+    }
+
+    return pkey;
+}
+
+/*
+ * Description: EVP_PKEY_get0_EC_KEY() also returns the referenced key in pkey or NULL if the key is not of the correct
+ * type but the reference count of the returned key is not incremented and so must not be freed up after use. Return
+ * value: EVP_PKEY_get0_EC_KEY() returns the referenced key or NULL if an error occurred.
+ */
+EC_KEY *EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey) {
+    assert(pkey);
+
+    // In our current model, the key is always of type EC
+    return pkey->ec_key;
+}
+
+/*
+ * Description: EVP_PKEY_set1_EC_KEY() sets the key referenced by pkey to key.
+ * Return values: EVP_PKEY_set1_EC_KEY() returns 1 for success or 0 for failure.
+ */
+int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key) {
+    if (pkey == NULL || key == NULL || nondet_bool()) {
+        return 0;
+    }
+
+    EC_KEY_up_ref(key);
+    pkey->ec_key = key;
+
+    return 1;
+}
+
+/*
+ * Description: EVP_PKEY_free() decrements the reference count of key and, if the reference count is zero, frees it up.
+ * If key is NULL, nothing is done.
+ */
+void EVP_PKEY_free(EVP_PKEY *pkey) {
+    if (pkey) {
+        pkey->references -= 1;
+        if (pkey->references == 0) {
+            EC_KEY_free(pkey->ec_key);
+            free(pkey);
+        }
+    }
+}
+
+enum evp_aes { EVP_AES_128_GCM, EVP_AES_192_GCM, EVP_AES_256_GCM };
+
+/* Abstraction of the EVP_CIPHER struct */
+struct evp_cipher_st {
+    enum evp_aes from;
+};
+
+/*
+ * Description: AES for 128, 192 and 256 bit keys in Galois Counter Mode (GCM). These ciphers require additional control
+ * operations to function correctly, see the "AEAD Interface" in EVP_EncryptInit(3) section for details. Return values:
+ * These functions return an EVP_CIPHER structure that contains the implementation of the symmetric cipher.
+ */
+const EVP_CIPHER *EVP_aes_128_gcm(void) {
+    static const EVP_CIPHER cipher = { EVP_AES_128_GCM };
+    return &cipher;
+}
+const EVP_CIPHER *EVP_aes_192_gcm(void) {
+    static const EVP_CIPHER cipher = { EVP_AES_192_GCM };
+    return &cipher;
+}
+const EVP_CIPHER *EVP_aes_256_gcm(void) {
+    static const EVP_CIPHER cipher = { EVP_AES_256_GCM };
+    return &cipher;
+}
+
+enum evp_sha { EVP_SHA256, EVP_SHA384, EVP_SHA512 };
+
+/* Abstraction of the EVP_MD struct */
+struct evp_md_st {
+    enum evp_sha from;
+    size_t size;
+};
+
+/*
+ * Description: The SHA-2 SHA-224, SHA-256, SHA-512/224, SHA512/256, SHA-384 and SHA-512 algorithms, which generate 224,
+ * 256, 224, 256, 384 and 512 bits respectively of output from a given input. Return values: These functions return a
+ * EVP_MD structure that contains the implementation of the symmetric cipher.
+ */
+const EVP_MD *EVP_sha256() {
+    static const EVP_MD md = { EVP_SHA256, 32 };
+    return &md;
+}
+const EVP_MD *EVP_sha384() {
+    static const EVP_MD md = { EVP_SHA384, 48 };
+    return &md;
+}
+const EVP_MD *EVP_sha512() {
+    static const EVP_MD md = { EVP_SHA512, 64 };
+    return &md;
+}
+
+/* Abstraction of the EVP_MD_CTX struct */
+struct evp_md_ctx_st {
+    bool is_initialized;
+    EVP_PKEY *pkey;
+    size_t digest_size;
+};
+
+/*
+ * Description: Allocates and returns a digest context.
+ */
+EVP_MD_CTX *EVP_MD_CTX_new() {
+    EVP_MD_CTX *ctx = can_fail_malloc(sizeof(EVP_MD_CTX));
+
+    if (ctx) {
+        ctx->is_initialized = false;
+        ctx->pkey           = NULL;
+        ctx->digest_size    = 0;
+    }
+
+    return ctx;
+}
+
+/*
+ * Description: Cleans up digest context ctx and frees up the space allocated to it.
+ */
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
+    if (ctx) {
+        EVP_PKEY_free(ctx->pkey);
+        free(ctx);
+    }
+}
+
+/*
+ * Description: Sets up digest context ctx to use a digest type from ENGINE impl. type will typically be supplied by
+ * a function such as EVP_sha1(). If impl is NULL then the default implementation of digest type is used. Return
+ * values: Returns 1 for success and 0 for failure.
+ */
+int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl) {
+    assert(ctx);
+    assert(!ctx->is_initialized);
+    assert(evp_md_is_valid(type));
+    assert(!impl);  // Assuming that this function is always called in ESDK with impl == NULL
+
+    if (nondet_bool()) return 0;
+
+    ctx->is_initialized = true;
+    ctx->digest_size    = type->size;
+
+    return ctx->is_initialized;
+}
+
+/*
+ * Description: Hashes cnt bytes of data at d into the digest context ctx. This function can be called several times
+ * on the same ctx to hash additional data. Return values: Returns 1 for success and 0 for failure.
+ */
+int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt) {
+    assert(evp_md_ctx_is_valid(ctx));
+    assert(d);
+    assert(AWS_MEM_IS_READABLE(d, cnt));
+
+    if (nondet_bool()) {
+        ctx->is_initialized = false;
+        return 0;
+    }
+
+    return 1;
+}
+
+/*
+ * Description: Retrieves the digest value from ctx and places it in md. If the s parameter is not NULL then the
+ * number of bytes of data written (i.e. the length of the digest) will be written to the integer at s, at most
+ * EVP_MAX_MD_SIZE bytes will be written. After calling EVP_DigestFinal_ex() no additional calls to
+ * EVP_DigestUpdate() can be made, but EVP_DigestInit_ex() can be called to initialize a new digest operation.
+ * Return values: Returns 1 for success and 0 for failure.
+ */
+int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s) {
+    assert(evp_md_ctx_is_valid(ctx));
+    assert(md);
+    assert(AWS_MEM_IS_WRITABLE(md, ctx->digest_size));
+    assert(s);  // Assuming that this function is always called in ESDK with s != NULL
+
+    if (nondet_bool()) {
+        ctx->is_initialized = false;
+        return 0;
+    }
+
+    unsigned char start;               // arbitrary first byte
+    __CPROVER_array_copy(md, &start);  // copies the first byte from start and assigns the rest arbitrarily
+    *s                  = ctx->digest_size;
+    ctx->is_initialized = false;
+    return 1;
+}
+
+/*
+ * Description: EVP_DigestVerifyInit() sets up verification context ctx to use digest type from ENGINE e and public key
+ * pkey. ctx must be created with EVP_MD_CTX_new() before calling this function. If pctx is not NULL, the EVP_PKEY_CTX
+ * of the verification operation will be written to *pctx: this can be used to set alternative verification options.
+ * Note that any existing value in *pctx is overwritten. The EVP_PKEY_CTX value returned must not be freed directly by
+ * the application if ctx is not assigned an EVP_PKEY_CTX value before being passed to EVP_DigestVerifyInit() (which
+ * means the EVP_PKEY_CTX is created inside EVP_DigestVerifyInit() and it will be freed automatically when the
+ * EVP_MD_CTX is freed).
+ * Return values: EVP_DigestVerifyInit() EVP_DigestVerifyUpdate() return 1 for success and 0 for
+ * failure.
+ */
+int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey) {
+    assert(ctx);
+    assert(!ctx->is_initialized);
+    assert(!pctx);  // Assuming that this function is always called in ESDK with pctx == NULL
+    assert(evp_md_is_valid(type));
+    assert(!e);  // Assuming that this function is always called in ESDK with e == NULL
+    assert(evp_pkey_is_valid(pkey));
+
+    if (nondet_bool()) return 0;
+
+    ctx->is_initialized = true;
+    ctx->pkey           = pkey;
+    pkey->references += 1;
+    ctx->digest_size = type->size;
+
+    return 1;
+}
+
+/*
+ * Description: EVP_DigestVerifyFinal() verifies the data in ctx against the signature in sig of length siglen.
+ * Return values: EVP_DigestVerifyFinal() and EVP_DigestVerify() return 1 for success; any other value indicates
+ * failure. A return value of zero indicates that the signature did not verify successfully (that is, tbs did not match
+ * the original data or the signature had an invalid form), while other values indicate a more serious error (and
+ * sometimes also indicate an invalid signature form).
+ */
+int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen) {
+    assert(evp_md_ctx_is_valid(ctx));
+    assert(sig);
+    assert(AWS_MEM_IS_READABLE(sig, siglen));
+
+    return nondet_int();
+}
+
+/* CBMC helper functions */
+
+/* Helper function for CBMC proofs: checks if EVP_PKEY is valid. */
+bool evp_pkey_is_valid(EVP_PKEY *pkey) {
+    return pkey && (pkey->references > 0) && ec_key_is_valid(pkey->ec_key);
+}
+
+/* Helper function for CBMC proofs: allocates EVP_PKEY nondeterministically. */
+EVP_PKEY *evp_pkey_nondet_alloc() {
+    EVP_PKEY *pkey = can_fail_malloc(sizeof(EVP_PKEY));
+    return pkey;
+}
+
+/* Helper function for CBMC proofs: returns the reference count. */
+int evp_pkey_get_reference_count(EVP_PKEY *pkey) {
+    return pkey ? pkey->references : 0;
+}
+
+/* Helper function for CBMC proofs: set EC_KEY without incrementing the reference count. */
+void evp_pkey_set0_ec_key(EVP_PKEY *pkey, EC_KEY *ec) {
+    if (pkey) pkey->ec_key = ec;
+}
+
+/* Helper function for CBMC proofs: frees the memory regardless of the reference count. */
+void evp_pkey_unconditional_free(EVP_PKEY *pkey) {
+    free(pkey);
+    // Does not free EC_KEY, since this is always done separately in our use cases
+}
+
+bool evp_cipher_is_valid(EVP_CIPHER *cipher) {
+    return cipher &&
+           (cipher->from == EVP_AES_128_GCM || cipher->from == EVP_AES_192_GCM || cipher->from == EVP_AES_256_GCM);
+}
+
+bool evp_md_is_valid(EVP_MD *md) {
+    return md && ((md->from == EVP_SHA256 && md->size == 32) || (md->from == EVP_SHA384 && md->size == 48) ||
+                  (md->from == EVP_SHA512 && md->size == 64));
+}
+
+/* Helper function for CBMC proofs: checks if EVP_MD_CTX is valid. */
+bool evp_md_ctx_is_valid(EVP_MD_CTX *ctx) {
+    return ctx && ctx->is_initialized && ctx->digest_size <= EVP_MAX_MD_SIZE &&
+           (ctx->pkey == NULL || evp_pkey_is_valid(ctx->pkey));
+}
+
+/* Helper function for CBMC proofs: allocates EVP_PKEY nondeterministically. */
+EVP_MD_CTX *evp_md_ctx_nondet_alloc() {
+    return can_fail_malloc(sizeof(EVP_MD_CTX));
+}
+
+/* Helper function for CBMC proofs: checks if EVP_MD_CTX is initialized. */
+bool evp_md_ctx_is_initialized(EVP_MD_CTX *ctx) {
+    return ctx->is_initialized;
+}
+
+/* Helper function for CBMC proofs: returns digest size. */
+size_t evp_md_ctx_get_digest_size(EVP_MD_CTX *ctx) {
+    return ctx->digest_size;
+}
+
+/* Helper function for CBMC proofs: get EVP_PKEY without incrementing the reference count. */
+EVP_PKEY *evp_md_ctx_get0_evp_pkey(EVP_MD_CTX *ctx) {
+    return ctx ? ctx->pkey : NULL;
+}
+
+/* Helper function for CBMC proofs: set EVP_PKEY without incrementing the reference count. */
+void evp_md_ctx_set0_evp_pkey(EVP_MD_CTX *ctx, EVP_PKEY *pkey) {
+    if (ctx) ctx->pkey = pkey;
+}
+
+/* Helper function for CBMC proofs: frees the memory of the ctx without freeing the EVP_PKEY. */
+void evp_md_ctx_shallow_free(EVP_MD_CTX *ctx) {
+    free(ctx);
+    // Does not free EVP_KEY, since this is always done separately in our use cases
+}

--- a/.cbmc-batch/source/openssl/objects_override.c
+++ b/.cbmc-batch/source/openssl/objects_override.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/objects.h>
+
+#include <proof_helpers/nondet.h>
+
+/*
+ * Description: OBJ_txt2nid() returns NID corresponding to text string <s>. s can be a long name, a short name or the
+ * numerical representation of an object. Return values: OBJ_txt2nid() returns a NID or NID_undef on error.
+ */
+int OBJ_txt2nid(const char *s) {
+    assert(!s || strcmp(s, "prime256v1") == 0 || strcmp(s, "secp384r1") == 0);
+
+    if (strcmp(s, "prime256v1") == 0) {
+        return NID_X9_62_prime256v1;
+    } else if (strcmp(s, "secp384r1") == 0) {
+        return NID_secp384r1;
+    } else {
+        return NID_undef;
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 *.[ch]-e
 .DS_Store
 *.goto
+*.log
+.cbmc-batch/jobs/*/link-farm
+.cbmc-batch/jobs/*/html

--- a/include/aws/cryptosdk/cipher.h
+++ b/include/aws/cryptosdk/cipher.h
@@ -102,6 +102,12 @@ AWS_CRYPTOSDK_API
 const struct aws_cryptosdk_alg_properties *aws_cryptosdk_alg_props(enum aws_cryptosdk_alg_id alg_id);
 
 /**
+ * Checks whether an aws_cryptosdk_alg_properties is valid and is supported by the SDK.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props);
+
+/**
  * An opaque structure representing an ongoing sign or verify operation
  */
 struct aws_cryptosdk_sig_ctx;

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -17,6 +17,7 @@
 #define AWS_CRYPTOSDK_PRIVATE_FRAMEFMT_H
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/cipher.h>
 
@@ -32,6 +33,20 @@ struct aws_cryptosdk_frame {
     /* A cursor to space for the AEAD tag in the ciphertext buffer */
     struct aws_byte_buf authtag;
 };
+
+// MAX_FRAME_SIZE = 2^32 - 1
+#define MAX_FRAME_SIZE 0xFFFFFFFF
+// MAX_FRAMES = 2^32 - 1
+#define MAX_FRAMES 0xFFFFFFFF
+// MAX_UNFRAMED_PLAINTEXT_SIZE = 2^36 - 32
+#define MAX_UNFRAMED_PLAINTEXT_SIZE 0xFFFFFFFE0ull
+
+/**
+ * Checks whether a frame struct is valid. At the moment this means
+ * that it checks the validity of the byte buffers and the fact that
+ * they should have NULL allocators.
+ */
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame);
 
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -61,9 +61,9 @@ bool aws_cryptosdk_frame_serialized(
     size_t plaintext_size);
 
 /**
- * Checks whether a frame has a valid frame type, and a valid sequence number.
+ * Checks whether a frame has a valid frame type.
  */
-bool aws_cryptosdk_frame_has_valid_type_seq(const struct aws_cryptosdk_frame *frame);
+bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame);
 
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -49,6 +49,23 @@ struct aws_cryptosdk_frame {
 bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame);
 
 /**
+ * Checks whether a frame struct is correctly serialized in relation
+ * to a specific algorithm.  More precisely, it checks that the
+ * buffers in [frame] have the same sizes as the sizes described in
+ * the [alg_props] algorithm properties and in the
+ * [plaintext_size]. It also checks that the two buffers are empty.
+ */
+bool aws_cryptosdk_frame_serialized(
+    const struct aws_cryptosdk_frame *frame,
+    const struct aws_cryptosdk_alg_properties *alg_props,
+    size_t plaintext_size);
+
+/**
+ * Checks whether a frame has a valid frame type, and a valid sequence number.
+ */
+bool aws_cryptosdk_frame_has_valid_type_seq(const struct aws_cryptosdk_frame *frame);
+
+/**
  * Performs frame-type-specific work prior to writing a frame; writes out all
  * fields except for the IV, ciphertext, and authtag - for those three fields,
  * this method will set the appropriate cursors in the frame structure instead;

--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -21,7 +21,6 @@
 #include <aws/cryptosdk/session.h>
 
 #define DEFAULT_FRAME_SIZE (256 * 1024)
-#define MAX_FRAME_SIZE 0xFFFFFFFF
 
 enum session_state {
     /*** Common states ***/

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -88,6 +88,32 @@ static enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk
     }
 }
 
+static bool alg_properties_equal(
+    const struct aws_cryptosdk_alg_properties alg_props1, const struct aws_cryptosdk_alg_properties alg_props2) {
+    /* Note: We are not checking whether the names (md/cipher/alg) are
+     * equal */
+
+    /* Note: We are not checking whether the underlying alg_impl
+     * structs are equal. */
+    return alg_props1.data_key_len == alg_props2.data_key_len &&
+           alg_props1.content_key_len == alg_props2.content_key_len && alg_props1.iv_len == alg_props2.iv_len &&
+           alg_props1.tag_len == alg_props2.tag_len && alg_props1.signature_len == alg_props2.signature_len &&
+           alg_props1.alg_id == alg_props2.alg_id;
+}
+
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props) {
+    if (alg_props == NULL) {
+        return false;
+    }
+    enum aws_cryptosdk_alg_id id                             = alg_props->alg_id;
+    const struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
+    if (std_alg_props == NULL) {
+        return false;
+    }
+    return alg_props->md_name && alg_props->cipher_name && alg_props->alg_name &&
+           alg_properties_equal(*alg_props, *std_alg_props);
+}
+
 int aws_cryptosdk_derive_key(
     const struct aws_cryptosdk_alg_properties *props,
     struct content_key *content_key,

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -614,8 +614,15 @@ static int load_pubkey(
     }
 
     *key = EC_KEY_new();
+    if (*key == NULL) {
+        result = AWS_ERROR_OOM;
+        goto out;
+    }
     // We must set the group before decoding, to allow openssl to decompress the point
-    EC_KEY_set_group(*key, group);
+    if (!EC_KEY_set_group(*key, group)) {
+        // raise an error?
+        goto out;
+    }
     EC_KEY_set_conv_form(*key, POINT_CONVERSION_COMPRESSED);
 
     const unsigned char *pBuf = b64_decode_buf.buffer;

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -528,7 +528,7 @@ int aws_cryptosdk_sig_sign_start(
     }
 
     if (!EC_KEY_set_group(keypair, group)) {
-        // raise an error?
+        aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);
         goto out;
     }
     EC_GROUP_free(group);
@@ -623,7 +623,7 @@ static int load_pubkey(
     }
     // We must set the group before decoding, to allow openssl to decompress the point
     if (!EC_KEY_set_group(*key, group)) {
-        // raise an error?
+        result = AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN;
         goto out;
     }
     EC_KEY_set_conv_form(*key, POINT_CONVERSION_COMPRESSED);

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -527,7 +527,10 @@ int aws_cryptosdk_sig_sign_start(
         goto out;
     }
 
-    EC_KEY_set_group(keypair, group);
+    if (!EC_KEY_set_group(keypair, group)) {
+        // raise an error?
+        goto out;
+    }
     EC_GROUP_free(group);
     EC_KEY_set_conv_form(keypair, POINT_CONVERSION_COMPRESSED);
 
@@ -543,7 +546,7 @@ int aws_cryptosdk_sig_sign_start(
     field = aws_byte_cursor_advance(&cursor, privkey_len);
     bufp  = field.ptr;
 
-    if (!d2i_ASN1_INTEGER(&priv_key_asn1, &bufp, field.len) || bufp != field.ptr + field.len) {
+    if (!field.ptr || !d2i_ASN1_INTEGER(&priv_key_asn1, &bufp, field.len) || bufp != field.ptr + field.len) {
         ASN1_STRING_clear_free(priv_key_asn1);
         aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);
         goto out;

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <aws/common/common.h>
 #include <aws/common/error.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/private/framefmt.h>
@@ -213,6 +214,24 @@ static inline int serde_nonframed(
     return AWS_ERROR_SUCCESS;
 }
 
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame) {
+    bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
+    bool iv_byte_buf_static = frame->iv.allocator == NULL;
+
+    bool authtag_byte_buf_valid  = aws_byte_buf_is_valid(&frame->authtag);
+    bool authtag_byte_buf_static = frame->authtag.allocator == NULL;
+
+    bool ciphertext_byte_buf_valid = aws_byte_buf_is_valid(&frame->ciphertext);
+    /* This happens when input plaintext size is 0 */
+    bool ciphertext_valid_zero =
+        frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0;
+    bool ciphertext_valid  = ciphertext_byte_buf_valid || ciphertext_valid_zero;
+    bool ciphertext_static = frame->ciphertext.allocator == NULL;
+
+    return iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid && authtag_byte_buf_static &&
+           ciphertext_valid && ciphertext_static;
+}
+
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all
  * fields except for the IV, ciphertext, and authtag, and returns their
@@ -235,7 +254,17 @@ int aws_cryptosdk_serialize_frame(
     size_t plaintext_size,
     struct aws_byte_buf *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props) {
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
     struct aws_cryptosdk_framestate state;
+
+    // The plaintext_size should be bound to prevent arithmetic
+    // overflows due to addition
+    if ((frame->type == FRAME_TYPE_SINGLE && plaintext_size > MAX_UNFRAMED_PLAINTEXT_SIZE) ||
+        (frame->type != FRAME_TYPE_SINGLE && plaintext_size > MAX_FRAME_SIZE)) {
+        // Clear the ciphertext buffer
+        aws_byte_buf_secure_zero(ciphertext_buf);
+        return aws_raise_error(AWS_CRYPTOSDK_ERR_LIMIT_EXCEEDED);
+    }
 
     // We assume that the max frame size is equal to the plaintext size. This
     // lets us avoid having to pass in a redundant argument, avoids needing to
@@ -244,7 +273,7 @@ int aws_cryptosdk_serialize_frame(
     state.max_frame_size = plaintext_size;
     state.plaintext_size = plaintext_size;
     // Currently all supported algorithms have plaintext = ciphertext size
-    state.ciphertext_size = plaintext_size;
+    state.ciphertext_size = 0;
 
     state.alg_props = alg_props;
     state.u.buffer  = *ciphertext_buf;
@@ -271,6 +300,7 @@ int aws_cryptosdk_serialize_frame(
         return aws_raise_error(result);
     } else {
         *ciphertext_buf = state.u.buffer;
+        AWS_POSTCONDITION(aws_cryptosdk_frame_is_valid(frame));
         return AWS_OP_SUCCESS;
     }
 }

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -219,7 +219,7 @@ bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame)
         return false;
     }
 
-    bool frame_type_seq_valid = aws_cryptosdk_frame_has_valid_type_seq(frame);
+    bool frame_type_seq_valid = aws_cryptosdk_frame_has_valid_type(frame);
 
     bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
     bool iv_byte_buf_static = frame->iv.allocator == NULL;
@@ -262,17 +262,15 @@ bool aws_cryptosdk_frame_serialized(
     return iv_size_valid && tag_size_valid && iv_empty && tag_empty;
 }
 
-bool aws_cryptosdk_frame_has_valid_type_seq(const struct aws_cryptosdk_frame *frame) {
+bool aws_cryptosdk_frame_has_valid_type(const struct aws_cryptosdk_frame *frame) {
     if (frame == NULL) {
         return false;
     }
 
-    bool seq_valid = frame->sequence_number > 0 && frame->sequence_number <= MAX_FRAMES;
-
     bool frame_enum_in_range =
         frame->type == FRAME_TYPE_SINGLE || frame->type == FRAME_TYPE_FRAME || frame->type == FRAME_TYPE_FINAL;
 
-    return seq_valid && frame_enum_in_range;
+    return frame_enum_in_range;
 }
 
 /**
@@ -297,7 +295,8 @@ int aws_cryptosdk_serialize_frame(
     size_t plaintext_size,
     struct aws_byte_buf *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props) {
-    AWS_PRECONDITION(aws_cryptosdk_frame_has_valid_type_seq(frame));
+    AWS_PRECONDITION(aws_cryptosdk_frame_has_valid_type(frame));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(ciphertext_buf));
     AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
     struct aws_cryptosdk_framestate state;
 


### PR DESCRIPTION
*Description of changes:*

1. Added support for loop unwinding.
2. Added check for memory leaks.

Depends on #394.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
