### PR TITLE
Proof harnesses for aws_cryptosdk_sig_{abort, update}

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/Makefile
@@ -1,0 +1,44 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += 
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_abort_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/Makefile
@@ -24,20 +24,20 @@ CBMCFLAGS += --memory-leak-check
 
 ENTRY = aws_cryptosdk_sig_abort_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/framefmt.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/aws_cryptosdk_sig_abort_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/aws_cryptosdk_sig_abort_harness.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_abort_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx = can_fail_malloc(sizeof(struct aws_cryptosdk_sig_ctx));
+
+    /* assumptions */
+    if (ctx) {
+        ensure_sig_ctx_has_allocated_members(ctx);
+        __CPROVER_assume(ctx->alloc);
+        __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+    }
+
+    /* saving previous state */
+    EC_KEY *keypair                 = ctx ? ctx->keypair : NULL;
+    int old_keypair_reference_count = ec_key_get_reference_count(keypair);
+    bool keypair_needs_clean_up     = old_keypair_reference_count > 2;
+    EVP_PKEY *pkey                  = ctx ? ctx->pkey : NULL;
+    int old_pkey_reference_count    = evp_pkey_get_reference_count(pkey);
+    int min_pkey_reference_count    = !ctx ? 0 : (ctx->is_sign ? 1 : 2);
+    bool pkey_needs_clean_up        = old_pkey_reference_count > min_pkey_reference_count;
+
+    /* operation under verification */
+    aws_cryptosdk_sig_abort(ctx);
+
+    if (pkey_needs_clean_up) {
+        // assertions
+        assert(evp_pkey_get_reference_count(pkey) == old_pkey_reference_count - min_pkey_reference_count);
+        assert(ec_key_get_reference_count(keypair) == old_keypair_reference_count - 1);
+        // clean up (necessary because we are checking for memory leaks)
+        evp_pkey_unconditional_free(pkey);
+        // pkey holds a reference to keypair, have to free that too
+        ec_key_unconditional_free(keypair);
+    } else if (keypair_needs_clean_up) {
+        // pkey was freed, but keypair was not
+
+        // assertions
+        assert(ec_key_get_reference_count(keypair) == old_keypair_reference_count - 2);
+        // clean up (necessary because we are checking for memory leaks)
+        ec_key_unconditional_free(keypair);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/aws_cryptosdk_sig_abort_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/aws_cryptosdk_sig_abort_harness.c
@@ -30,7 +30,6 @@ void aws_cryptosdk_sig_abort_harness() {
     /* assumptions */
     if (ctx) {
         ensure_sig_ctx_has_allocated_members(ctx);
-        __CPROVER_assume(ctx->alloc);
         __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
     }
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_abort/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_sig_abort_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_update/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_update/Makefile
@@ -24,20 +24,19 @@ CBMCFLAGS += --memory-leak-check
 
 ENTRY = aws_cryptosdk_sig_update_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
-DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
-DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_update/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_update/Makefile
@@ -1,0 +1,44 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += 
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_update_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_update/aws_cryptosdk_sig_update_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_update/aws_cryptosdk_sig_update_harness.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_update_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx = can_fail_malloc(sizeof(struct aws_cryptosdk_sig_ctx));
+    struct aws_byte_cursor buf;
+
+    /* assumptions */
+    __CPROVER_assume(ctx);
+    ensure_sig_ctx_has_allocated_members(ctx);
+    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+    ensure_byte_cursor_has_allocated_buffer_member(&buf);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&buf));
+    __CPROVER_assume(buf.len > 0);
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_update(ctx, buf) == AWS_OP_SUCCESS) {
+        /* assertions */
+        assert(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+    }
+
+    /* assertions */
+    assert(aws_byte_cursor_is_valid(&buf));
+
+    /* clean up (necessary because we are checking for memory leaks) */
+    free(buf.ptr);
+    ec_key_unconditional_free(ctx->keypair);
+    evp_pkey_unconditional_free(ctx->pkey);
+    evp_md_ctx_shallow_free(ctx->ctx);
+    free(ctx);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_update/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_update/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_sig_update_harness.goto
+expected: "SUCCESSFUL"

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -471,6 +471,8 @@ rethrow:
 }
 
 void aws_cryptosdk_sig_abort(struct aws_cryptosdk_sig_ctx *ctx) {
+    AWS_PRECONDITION(!ctx || (aws_cryptosdk_sig_ctx_is_valid(ctx) && ctx->alloc));
+
     if (!ctx) {
         return;
     }
@@ -724,10 +726,15 @@ rethrow:
 }
 
 int aws_cryptosdk_sig_update(struct aws_cryptosdk_sig_ctx *ctx, const struct aws_byte_cursor cursor) {
+    AWS_PRECONDITION(aws_cryptosdk_sig_ctx_is_valid(ctx));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&cursor));
+    AWS_PRECONDITION(cursor.len > 0);
     if (EVP_DigestUpdate(ctx->ctx, cursor.ptr, cursor.len) != 1) {
         return aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);
     }
 
+    AWS_POSTCONDITION(aws_cryptosdk_sig_ctx_is_valid(ctx));
+    AWS_POSTCONDITION(aws_byte_cursor_is_valid(&cursor));
     return AWS_OP_SUCCESS;
 }
 

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -471,7 +471,7 @@ rethrow:
 }
 
 void aws_cryptosdk_sig_abort(struct aws_cryptosdk_sig_ctx *ctx) {
-    AWS_PRECONDITION(!ctx || (aws_cryptosdk_sig_ctx_is_valid(ctx) && ctx->alloc));
+    AWS_PRECONDITION(!ctx || (aws_cryptosdk_sig_ctx_is_valid(ctx) && AWS_OBJECT_PTR_IS_READABLE(ctx->alloc)));
 
     if (!ctx) {
         return;


### PR DESCRIPTION
*Description of changes:*

Created proof harnesses for functions `aws_cryptosdk_sig_{abort, update}`.

Depends on #396.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
