### PR TITLE
Added guards to catch error values in cipher_openssl.c

### DIFF
--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -527,7 +527,11 @@ int aws_cryptosdk_sig_sign_start(
         goto out;
     }
 
-    EC_KEY_set_group(keypair, group);
+    if (!EC_KEY_set_group(keypair, group)) {
+        aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);
+        EC_GROUP_free(group);
+        goto out;
+    }
     EC_GROUP_free(group);
     EC_KEY_set_conv_form(keypair, POINT_CONVERSION_COMPRESSED);
 
@@ -543,7 +547,7 @@ int aws_cryptosdk_sig_sign_start(
     field = aws_byte_cursor_advance(&cursor, privkey_len);
     bufp  = field.ptr;
 
-    if (!d2i_ASN1_INTEGER(&priv_key_asn1, &bufp, field.len) || bufp != field.ptr + field.len) {
+    if (!field.ptr || !d2i_ASN1_INTEGER(&priv_key_asn1, &bufp, field.len) || bufp != field.ptr + field.len) {
         ASN1_STRING_clear_free(priv_key_asn1);
         aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);
         goto out;
@@ -620,7 +624,7 @@ static int load_pubkey(
     }
     // We must set the group before decoding, to allow openssl to decompress the point
     if (!EC_KEY_set_group(*key, group)) {
-        // raise an error?
+        result = AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN;
         goto out;
     }
     EC_KEY_set_conv_form(*key, POINT_CONVERSION_COMPRESSED);

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -614,8 +614,15 @@ static int load_pubkey(
     }
 
     *key = EC_KEY_new();
+    if (*key == NULL) {
+        result = AWS_ERROR_OOM;
+        goto out;
+    }
     // We must set the group before decoding, to allow openssl to decompress the point
-    EC_KEY_set_group(*key, group);
+    if (!EC_KEY_set_group(*key, group)) {
+        // raise an error?
+        goto out;
+    }
     EC_KEY_set_conv_form(*key, POINT_CONVERSION_COMPRESSED);
 
     const unsigned char *pBuf = b64_decode_buf.buffer;


### PR DESCRIPTION
*Description of changes:*

Added guards in functions load_pubkey and aws_cryptosdk_sign_start of file cipher_openssl.c for catching error values:

1. NULL pointer in the return of EC_KEY_new()
2. NULL pointer after advancing byte cursor
3. Error code in the return of EC_KEY_set_group

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
