### PR TITLE
Abstract model for OpenSSL err.h module

### DIFF
--- a/.cbmc-batch/source/openssl/err_override.c
+++ b/.cbmc-batch/source/openssl/err_override.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/err.h>
+
+void ERR_print_errors_fp(FILE *fp) {
+    assert(fp == stderr);
+}


### PR DESCRIPTION
*Description of changes:*

Created stubs for OpenSSL functions in the `err.h` module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
