### PR TITLE
Proof harnesses for aws_cryptosdk_sig_sign_start[_keygen]

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/Makefile
@@ -1,0 +1,48 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += strcmp.0:11, aws_base64_encode.0:22 # computed according to MAX_PUBKEY_SIZE and the implementation of aws_base64_encode
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_sign_start_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/asn1_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/Makefile
@@ -24,24 +24,24 @@ CBMCFLAGS += --memory-leak-check
 
 ENTRY = aws_cryptosdk_sig_sign_start_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
-DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/asn1_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/aws_cryptosdk_sig_sign_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/aws_cryptosdk_sig_sign_start_harness.c
@@ -1,0 +1,46 @@
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_sign_start_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_string *pub_key;
+    struct aws_string *priv_key = ensure_string_is_allocated_nondet_length();
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assumptions */
+    __CPROVER_assume(props);
+    assert(aws_string_is_valid(priv_key));
+
+    bool save_pub_key = nondet_bool();
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_sign_start(
+            &ctx, alloc, save_pub_key ? &pub_key : NULL, props, priv_key /* priv_key can't be NULL */) ==
+        AWS_OP_SUCCESS) {
+        /* assertion: on success, context is initialized unless no curve name was given */
+        assert((!props->impl->curve_name && !ctx) || (aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx) && ctx->is_sign));
+    }
+
+    /* assertions */
+    if (save_pub_key) assert(!pub_key || aws_string_is_valid(pub_key));
+    assert(aws_string_is_valid(priv_key));
+
+    /* clean up */
+    if (ctx) {
+        ec_key_unconditional_free(ctx->keypair);
+        evp_pkey_unconditional_free(ctx->pkey);
+        evp_md_ctx_shallow_free(ctx->ctx);
+    }
+    aws_mem_release(alloc, ctx);
+    if (save_pub_key) free(pub_key);
+    free(priv_key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/aws_cryptosdk_sig_sign_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/aws_cryptosdk_sig_sign_start_harness.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <aws/cryptosdk/cipher.h>
 #include <cbmc_invariants.h>
 #include <ec_utils.h>

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_encode.0:22;--object-bits;8"
+goto: aws_cryptosdk_sig_sign_start_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += strcmp.0:11, aws_base64_encode.0:22 # computed according to MAX_PUBKEY_SIZE and the implementation of aws_base64_encode
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_sign_start_keygen_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/Makefile
@@ -24,22 +24,22 @@ CBMCFLAGS += --memory-leak-check
 
 ENTRY = aws_cryptosdk_sig_sign_start_keygen_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
-DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/aws_cryptosdk_sig_sign_start_keygen_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/aws_cryptosdk_sig_sign_start_keygen_harness.c
@@ -1,0 +1,40 @@
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_sign_start_keygen_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *pctx;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_string *pub_key;
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assumptions */
+    __CPROVER_assume(props);
+
+    bool save_pub_key = nondet_bool();
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_sign_start_keygen(&pctx, alloc, save_pub_key ? &pub_key : NULL, props) == AWS_OP_SUCCESS) {
+        assert((!props->impl->curve_name && !pctx) || (aws_cryptosdk_sig_ctx_is_valid_cbmc(pctx) && pctx->is_sign));
+    }
+
+    /* assertions */
+    if (save_pub_key) assert(!pub_key || aws_string_is_valid(pub_key));
+
+    /* clean up */
+    if (pctx) {
+        ec_key_unconditional_free(pctx->keypair);
+        evp_pkey_unconditional_free(pctx->pkey);
+        evp_md_ctx_shallow_free(pctx->ctx);
+    }
+    aws_mem_release(alloc, pctx);
+    if (save_pub_key) free(pub_key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/aws_cryptosdk_sig_sign_start_keygen_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/aws_cryptosdk_sig_sign_start_keygen_harness.c
@@ -1,9 +1,23 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <aws/cryptosdk/cipher.h>
 #include <cbmc_invariants.h>
 #include <ec_utils.h>
 #include <evp_utils.h>
 #include <make_common_data_structures.h>
-#include <proof_allocators.h>
 #include <proof_helpers/proof_allocators.h>
 
 #include <cipher_openssl.h>
@@ -23,6 +37,7 @@ void aws_cryptosdk_sig_sign_start_keygen_harness() {
 
     /* operation under verification */
     if (aws_cryptosdk_sig_sign_start_keygen(&pctx, alloc, save_pub_key ? &pub_key : NULL, props) == AWS_OP_SUCCESS) {
+        /* assertion: on success, context is initialized unless no curve name was given */
         assert((!props->impl->curve_name && !pctx) || (aws_cryptosdk_sig_ctx_is_valid_cbmc(pctx) && pctx->is_sign));
     }
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_encode.0:22;--object-bits;8"
+goto: aws_cryptosdk_sig_sign_start_keygen_harness.goto
+expected: "SUCCESSFUL"

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -461,8 +461,10 @@ rethrow:
     aws_cryptosdk_sig_abort(*pctx);
     *pctx = NULL;
 
-    aws_string_destroy(*pub_key);
-    *pub_key = NULL;
+    if (pub_key) {
+        aws_string_destroy(*pub_key);
+        *pub_key = NULL;
+    }
 
     EC_KEY_free(keypair);
     EC_GROUP_free(group);

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -412,9 +412,9 @@ int aws_cryptosdk_sig_sign_start_keygen(
     struct aws_allocator *alloc,
     struct aws_string **pub_key,
     const struct aws_cryptosdk_alg_properties *props) {
-    AWS_PRECONDITION(pctx);
-    AWS_PRECONDITION(alloc);
-    AWS_PRECONDITION(props);
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(pctx));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(alloc));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(props));
     EC_GROUP *group = NULL;
     EC_KEY *keypair = NULL;
 
@@ -503,8 +503,9 @@ int aws_cryptosdk_sig_sign_start(
     struct aws_string **pub_key_str,
     const struct aws_cryptosdk_alg_properties *props,
     const struct aws_string *priv_key) {
-    AWS_PRECONDITION(ctx);
-    AWS_PRECONDITION(props);
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(ctx));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(alloc));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(props));
     AWS_PRECONDITION(aws_string_is_valid(priv_key));
     /* See comments in aws_cryptosdk_sig_get_privkey re the serialized format */
 

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -445,6 +445,10 @@ int aws_cryptosdk_sig_sign_start_keygen(
         goto rethrow;
     }
 
+    // If pub_key is NULL the conversion form is never set, and so it differs between the EC_KEY and EC_GROUP objects.
+    // If this is not a problem this line can be removed, but ec_key_is_valid needs to be changed in the CBMC model.
+    EC_KEY_set_conv_form(keypair, POINT_CONVERSION_COMPRESSED);
+
     *pctx = sign_start(alloc, keypair, props);
     if (!*pctx) {
         goto rethrow;

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -412,6 +412,9 @@ int aws_cryptosdk_sig_sign_start_keygen(
     struct aws_allocator *alloc,
     struct aws_string **pub_key,
     const struct aws_cryptosdk_alg_properties *props) {
+    AWS_PRECONDITION(pctx);
+    AWS_PRECONDITION(alloc);
+    AWS_PRECONDITION(props);
     EC_GROUP *group = NULL;
     EC_KEY *keypair = NULL;
 
@@ -421,6 +424,8 @@ int aws_cryptosdk_sig_sign_start_keygen(
     }
 
     if (!props->impl->curve_name) {
+        AWS_POSTCONDITION(!*pctx);
+        AWS_POSTCONDITION(!pub_key || !*pub_key);
         return AWS_OP_SUCCESS;
     }
 
@@ -457,6 +462,8 @@ int aws_cryptosdk_sig_sign_start_keygen(
     EC_KEY_free(keypair);
     EC_GROUP_free(group);
 
+    AWS_POSTCONDITION(aws_cryptosdk_sig_ctx_is_valid(*pctx) && (*pctx)->is_sign);
+    AWS_POSTCONDITION(!pub_key || aws_string_is_valid(*pub_key));
     return AWS_OP_SUCCESS;
 
 err:
@@ -473,6 +480,8 @@ rethrow:
     EC_KEY_free(keypair);
     EC_GROUP_free(group);
 
+    AWS_POSTCONDITION(!*pctx);
+    AWS_POSTCONDITION(!pub_key || !*pub_key);
     return AWS_OP_ERR;
 }
 


### PR DESCRIPTION
*Description of changes:*

1. Created proof harnesses for `aws_cryptosdk_sig_sign_start` and `aws_cryptosdk_sig_sign_start_keygen`.
2. Added pre and postconditions to these functions in `cipher_openssl.c`.
3. Fixed a NULL-pointer dereference in the cleanup code of `aws_cryptosdk_sig_sign_start_keygen`.
4. Added line setting conversion form in `aws_cryptosdk_sig_sign_start_keygen`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
