### PR TITLE
Proof harness for aws_cryptosdk_alg_props

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_alg_props/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_alg_props/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_alg_props_harness
+
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_alg_props/aws_cryptosdk_alg_props_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_alg_props/aws_cryptosdk_alg_props_harness.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+
+void aws_cryptosdk_alg_props_harness() {
+    /* arguments */
+    enum aws_cryptosdk_alg_id alg_id;
+
+    /* operation under verification */
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assertions */
+    if (props) {
+        assert(
+            props->impl->md_ctor == NULL || props->impl->md_ctor == EVP_sha256 || props->impl->md_ctor == EVP_sha384);
+        assert(
+            props->impl->cipher_ctor == NULL || props->impl->cipher_ctor == EVP_aes_128_gcm ||
+            props->impl->cipher_ctor == EVP_aes_192_gcm || props->impl->cipher_ctor == EVP_aes_256_gcm);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_alg_props/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_alg_props/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_alg_props_harness.goto
+expected: "SUCCESSFUL"


### PR DESCRIPTION
*Description of changes:*

Created proof harness for `aws_cryptosdk_alg_props`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
