### PR TITLE
Missing include to bn_utils.h

### DIFF
--- a/.cbmc-batch/include/bn_utils.h
+++ b/.cbmc-batch/include/bn_utils.h
@@ -16,6 +16,7 @@
 #ifndef BN_UTILS_H
 #define BN_UTILS_H
 
+#include <stdbool.h>
 #include <openssl/bn.h>
 
 bool bignum_is_valid(BIGNUM *bn);


### PR DESCRIPTION
*Description of changes:*

Added missing `#include <stdbool.h>` to `bn_utils.h`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
