### PR TITLE
Proofs for keyring_trace module eq, clear and clean_up functions

### DIFF
--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -14,10 +14,10 @@
  */
 
 #include <aws/common/common.h>
-#include <proof_helpers/make_common_data_structures.h>
-#include <proof_helpers/proof_allocators.h>
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/framefmt.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/common.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props);

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -22,3 +22,5 @@
 #include <stdlib.h>
 
 void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props);
+void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len);
+void ensure_trace_has_allocated_records(struct aws_array_list *trace, size_t max_len);

--- a/.cbmc-batch/jobs/Makefile.aws_array_list
+++ b/.cbmc-batch/jobs/Makefile.aws_array_list
@@ -1,0 +1,28 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+# Sufficently long to get full coverage on the aws_array_list APIs
+# short enough that all proofs complete quickly
+MAX_ITEM_SIZE ?= 2
+
+# Necessary to get full coverage when using functions from math.h
+MAX_INITIAL_ITEM_ALLOCATION ?= 9223372036854775808
+
+DEFINES += -DMAX_ITEM_SIZE=$(MAX_ITEM_SIZE)
+DEFINES += -DMAX_INITIAL_ITEM_ALLOCATION=$(MAX_INITIAL_ITEM_ALLOCATION)

--- a/.cbmc-batch/jobs/Makefile.aws_byte_buf
+++ b/.cbmc-batch/jobs/Makefile.aws_byte_buf
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+# Sufficently long to get full coverage on the aws_byte_buf and aws_byte_cursor APIs
+# short enough that all proofs complete in less than a minute
+MAX_BUFFER_SIZE ?= 10
+
+DEFINES += -DMAX_BUFFER_SIZE=$(MAX_BUFFER_SIZE)

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -48,12 +48,21 @@ CBMCFLAGS += --undefined-shift-check
 CBMCFLAGS += --unsigned-overflow-check
 CBMCFLAGS += --unwind 1
 CBMCFLAGS += --unwinding-assertions
+CBMCFLAGS += $(CBMC_UNWINDSET)
 
 
 UNWIND ?= 0
 SIMPLIFY ?= 0
 
 ABSTRACTIONS ?=
+
+
+################################################################
+# Preprocess the unwindset
+
+ifneq ($(UNWINDSET),)
+CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
+endif
 
 ################################################################
 # makes a symlink if one doesn't already exist

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -191,7 +191,7 @@ gitclean: veryclean
 	$(RM) -r $(COMMONDIR)
 
 
-.PHONY: cbmc property coverage report clean veryclean common-symlinks common-git harness-symlink fill-linkfarm helper-symlinks
+.PHONY: cbmc property coverage report clean veryclean common-symlinks common-git harness-symlink fill-linkfarm helper-symlinks ci-yaml
 
 ################################################################
 # Launching cbmc on cbmc-batch
@@ -240,6 +240,16 @@ $(ENTRY).yaml: $(ENTRY).goto Makefile
 	echo 'property_memory: $(PROPMEM)' >> $@
 	echo 'coverage_memory: $(COVMEM)' >> $@
 	echo 'expected: "SUCCESSFUL"' >> $@
+
+batch-yaml: $(ENTRY).yaml
+
+cbmc-batch.yaml: $(ENTRY).goto Makefile
+	echo 'jobos: ubuntu16' > $@
+	echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CBMCFLAGS)))' >> $@
+	echo 'goto: $(ENTRY).goto' >> $@
+	echo 'expected: "SUCCESSFUL"' >> $@
+
+ci-yaml: cbmc-batch.yaml
 
 launch: $(ENTRY).goto Makefile
 	mkdir -p $(WS)

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -17,12 +17,15 @@ default: report
 
 ################################################################
 # Helper-inc must go first, so it can override other includes.
-INC += \
-	-I$(SRCDIR)/helper-inc \
-	-I$(SRCDIR)/c-enc-sdk-inc \
-	-I$(SRCDIR)/c-common-inc 
-	 
+INC += -I$(SRCDIR)/helper-inc
+INC += -I$(SRCDIR)/c-enc-sdk-inc
+INC += -I$(SRCDIR)/c-common-inc
+INC += -I$(SRCDIR)/c-common-helper-inc
+INC += -I/usr/local/opt/openssl@1.1/include/
 
+CBMC_OBJECT_BITS ?= 8
+CBMCFLAGS +=  --object-bits $(CBMC_OBJECT_BITS)
+DEF += -DCBMC_OBJECT_BITS=$(CBMC_OBJECT_BITS)
 DEF += -DCBMC=1
 
 OPT += 
@@ -31,15 +34,21 @@ CFLAGS += $(CFLAGS2) $(DEF) $(OPT)
 
 LINKFARM = $(abspath ./link-farm)
 
+HARNESS_NAME ?= $(ENTRY)_harness.c
+
 ################################################################
-CBMCFLAGS += \
-	--bounds-check \
-	--pointer-check \
-	--signed-overflow-check \
-	--unsigned-overflow-check \
-	--pointer-overflow-check \
-	--div-by-zero-check \
-	--unwinding-assertions
+CBMCFLAGS += --bounds-check
+CBMCFLAGS += --div-by-zero-check
+CBMCFLAGS += --float-overflow-check
+CBMCFLAGS += --nan-check
+CBMCFLAGS += --pointer-check
+CBMCFLAGS += --pointer-overflow-check
+CBMCFLAGS += --signed-overflow-check
+CBMCFLAGS += --undefined-shift-check
+CBMCFLAGS += --unsigned-overflow-check
+CBMCFLAGS += --unwind 1
+CBMCFLAGS += --unwinding-assertions
+
 
 UNWIND ?= 0
 SIMPLIFY ?= 0
@@ -74,6 +83,10 @@ common-symlinks: common-git linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(COMMONDIR)/include, c-common-inc)
 	$(call make_symlink, $(LINKFARM), $(COMMONDIR)/source, c-common-src)
 
+common-helper-symlinks: common-git linkfarm-dir
+	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/include, c-common-helper-inc)
+	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/source, c-common-helper-src)
+
 enc-sdk-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(SDKDIR)/include, c-enc-sdk-inc)
 	$(call make_symlink, $(LINKFARM), $(SDKDIR)/source, c-enc-sdk-src)
@@ -86,20 +99,20 @@ helper-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(HELPERDIR)/source, helper-src)
 
 
-fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks helper-symlinks
+fill-linkfarm: harness-symlink enc-sdk-symlinks common-symlinks common-helper-symlinks helper-symlinks
 
 $(ENTRY)1.goto: fill-linkfarm $(OBJS)
 	$(GOTO_CC) --function harness -o $@ $(OBJS)
 
 $(ENTRY)3.goto: $(ENTRY)1.goto
 	 $(GOTO_INSTRUMENT) $(ABSTRACTIONS) --add-library $< $@ \
-		2>&1 | tee $(ENTRY)3.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)3.log ; exit $${PIPESTATUS[0]}
 
 # Simplify and constant propagation may benefit from unwinding first
 $(ENTRY)4.goto: $(ENTRY)3.goto
 ifeq ($(UNWIND_GOTO), 1)
 	$(GOTO_INSTRUMENT) $(UNWINDING) $< $@ \
-		2>&1 | tee $(ENTRY)4.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)4.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
@@ -108,7 +121,7 @@ endif
 $(ENTRY)5.goto: $(ENTRY)4.goto
 ifeq ($(SIMPLIFY), 1)
 	$(GOTO_INSTRUMENT) --generate-function-body '.*' $< $@ \
-		2>&1 | tee $(ENTRY)5.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)5.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
@@ -117,18 +130,18 @@ endif
 $(ENTRY)6.goto: $(ENTRY)5.goto
 ifeq ($(SIMPLIFY), 1)
 	$(GOTO_ANALYZER) --simplify $@ $< \
-		2>&1 | tee $(ENTRY)6.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)6.log ; exit $${PIPESTATUS[0]}
 else
 	cp $< $@
 endif
 
 $(ENTRY)7.goto: $(ENTRY)6.goto
 	$(GOTO_INSTRUMENT) --drop-unused-functions $< $@ \
-		2>&1 | tee $(ENTRY)7.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)7.log ; exit $${PIPESTATUS[0]}
 
 $(ENTRY)8.goto: $(ENTRY)7.goto
 	$(GOTO_INSTRUMENT) --slice-global-inits $< $@ \
-		2>&1 | tee $(ENTRY)8.txt ; exit $${PIPESTATUS[0]}
+		2>&1 | tee $(ENTRY)8.log ; exit $${PIPESTATUS[0]}
 
 $(ENTRY).goto: $(ENTRY)8.goto
 	cp $< $@
@@ -138,7 +151,7 @@ $(ENTRY).goto: $(ENTRY)8.goto
 
 goto: $(ENTRY).goto 
 
-cbmc.txt: $(ENTRY).goto
+cbmc.log: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --trace $< 2>&1 | tee $@
 
 property.xml: $(ENTRY).goto
@@ -147,27 +160,27 @@ property.xml: $(ENTRY).goto
 coverage.xml: $(ENTRY).goto
 	cbmc $(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui $< 2>&1 > $@
 
-cbmc: cbmc.txt
+cbmc: cbmc.log
 
 property: property.xml
 
 coverage: coverage.xml
 
-report: cbmc.txt property.xml coverage.xml
+report: cbmc.log property.xml coverage.xml
 	$(VIEWER) \
 	--goto $(ENTRY).goto \
 	--srcdir $(SRCDIR) \
 	--htmldir html \
 	--srcexclude "(./verification|./tests|./tools|./lib/third_party)" \
-	--result cbmc.txt \
+	--result cbmc.log \
 	--property property.xml \
 	--block coverage.xml
 
 clean:
 	$(RM) $(GOTOS)
 	$(RM) $(OBJS) $(ENTRY).goto
-	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].txt
-	$(RM) cbmc.txt property.xml coverage.xml TAGS
+	$(RM) $(ENTRY)[0-9].goto $(ENTRY)[0-9].log
+	$(RM) cbmc.log property.xml coverage.xml TAGS
 	$(RM) *~ \#*
 
 veryclean: clean

--- a/.cbmc-batch/jobs/Makefile.local_default
+++ b/.cbmc-batch/jobs/Makefile.local_default
@@ -24,5 +24,6 @@ SRCDIR ?= $(abspath ./link-farm)
 BASEDIR ?= $(abspath ../../../..)
 COMMON_REPO_NAME ?= aws-c-common-for-cryptosdk-proofs
 COMMONDIR ?= $(BASEDIR)/$(COMMON_REPO_NAME)
+COMMON_HELPERDIR ?= $(COMMONDIR)/.cbmc-batch
 SDKDIR ?= $(abspath ../../..)
 HELPERDIR ?= $(SDKDIR)/.cbmc-batch

--- a/.cbmc-batch/jobs/Makefile.string
+++ b/.cbmc-batch/jobs/Makefile.string
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+# Sufficently long to get 100% coverage on the string APIs
+# short enough that all proofs complete quickly
+MAX_STRING_LEN ?= 16
+
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/Makefile
@@ -1,0 +1,43 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.string
+include ../Makefile.aws_array_list
+
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+CBMC_UNWINDSET += 
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_add_record_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/array_list.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/Makefile
@@ -15,8 +15,6 @@
 include ../Makefile.string
 include ../Makefile.aws_array_list
 
-
-## At the moment this is not used in the Makefile.common of encryption-sdk
 CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
 
 CBMCFLAGS +=

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/Makefile
@@ -17,7 +17,7 @@ include ../Makefile.aws_array_list
 
 
 ## At the moment this is not used in the Makefile.common of encryption-sdk
-CBMC_UNWINDSET += 
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/aws_cryptosdk_keyring_trace_add_record_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/aws_cryptosdk_keyring_trace_add_record_harness.c
@@ -15,20 +15,21 @@
 
 #include <aws/common/array_list.h>
 #include <aws/common/string.h>
-#include <aws/cryptosdk/private/keyring_trace.h>
 #include <aws/cryptosdk/keyring_trace.h>
-#include <proof_helpers/make_common_data_structures.h>
-#include <proof_helpers/utils.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
 #include <aws/cryptosdk/private/utils.h>
 #include <make_common_data_structures.h>
-
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
 
 void aws_cryptosdk_keyring_trace_add_record_harness() {
     /* data structure */
     struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
-    struct aws_array_list trace; /* Precondition: trace must be non-null */
-    struct aws_string *namespace = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN); /* Precondition: namespace must be non-null */
-    struct aws_string *name = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN); /* Precondition: name must be non-null */
+    struct aws_array_list trace;                        /* Precondition: trace must be non-null */
+    struct aws_string *namespace =
+        ensure_string_is_allocated_bounded_length(MAX_STRING_LEN); /* Precondition: namespace must be non-null */
+    struct aws_string *name =
+        ensure_string_is_allocated_bounded_length(MAX_STRING_LEN); /* Precondition: name must be non-null */
     uint32_t flags;
 
     __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
@@ -42,15 +43,12 @@ void aws_cryptosdk_keyring_trace_add_record_harness() {
     struct store_byte_from_buffer old_byte;
     save_byte_from_array((uint8_t *)trace.data, trace.current_size, &old_byte);
 
-
-	if (aws_cryptosdk_keyring_trace_add_record(alloc, &trace, namespace, name, flags) == AWS_OP_SUCCESS){
+    if (aws_cryptosdk_keyring_trace_add_record(alloc, &trace, namespace, name, flags) == AWS_OP_SUCCESS) {
         /* assertions */
-        assert(aws_cryptosdk_keyring_trace_is_valid(&trace)); 
+        assert(aws_cryptosdk_keyring_trace_is_valid(&trace));
         assert(trace.length = old.length + 1);
-    }
-    else {
+    } else {
         /* assertions */
         assert_array_list_equivalence(&trace, &old, &old_byte);
     }
-
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/aws_cryptosdk_keyring_trace_add_record_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/aws_cryptosdk_keyring_trace_add_record_harness.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/common/string.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+#include <aws/cryptosdk/private/utils.h>
+
+
+void aws_cryptosdk_keyring_trace_add_record_harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_array_list trace; /* Precondition: trace must be non-null */
+    struct aws_string *namespace = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN); /* Precondition: namespace must be non-null */
+    struct aws_string *name = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN); /* Precondition: name must be non-null */
+    uint32_t flags;
+
+    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+
+    struct aws_array_list old = trace;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)trace.data, trace.current_size, &old_byte);
+
+
+	if (aws_cryptosdk_keyring_trace_add_record(alloc, &trace, namespace, name, flags) == AWS_OP_SUCCESS){
+        /* assertions */
+        assert(aws_array_list_is_valid(&trace));
+        assert(trace.length = old.length + 1);
+    }
+    else {
+        /* assertions */
+        assert_array_list_equivalence(&trace, &old, &old_byte);
+    }
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/aws_cryptosdk_keyring_trace_add_record_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/aws_cryptosdk_keyring_trace_add_record_harness.c
@@ -16,9 +16,11 @@
 #include <aws/common/array_list.h>
 #include <aws/common/string.h>
 #include <aws/cryptosdk/private/keyring_trace.h>
+#include <aws/cryptosdk/keyring_trace.h>
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/utils.h>
 #include <aws/cryptosdk/private/utils.h>
+#include <make_common_data_structures.h>
 
 
 void aws_cryptosdk_keyring_trace_add_record_harness() {
@@ -30,8 +32,11 @@ void aws_cryptosdk_keyring_trace_add_record_harness() {
     uint32_t flags;
 
     __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     ensure_array_list_has_allocated_data_member(&trace);
     __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
 
     struct aws_array_list old = trace;
     struct store_byte_from_buffer old_byte;
@@ -40,7 +45,7 @@ void aws_cryptosdk_keyring_trace_add_record_harness() {
 
 	if (aws_cryptosdk_keyring_trace_add_record(alloc, &trace, namespace, name, flags) == AWS_OP_SUCCESS){
         /* assertions */
-        assert(aws_array_list_is_valid(&trace));
+        assert(aws_cryptosdk_keyring_trace_is_valid(&trace)); 
         assert(trace.length = old.length + 1);
     }
     else {

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.string
+include ../Makefile.aws_array_list
+include ../Makefile.aws_byte_buf
+
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_add_record_buf_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/array_list.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/aws_cryptosdk_keyring_trace_add_record_buf_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/aws_cryptosdk_keyring_trace_add_record_buf_harness.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/common/string.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <aws/cryptosdk/private/utils.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+#include <make_common_data_structures.h>
+
+
+void aws_cryptosdk_keyring_trace_add_record_buf_harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_array_list trace;
+    struct aws_byte_buf namespace;
+    struct aws_byte_buf name;
+    uint32_t flags;
+
+    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&namespace, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&namespace);
+    __CPROVER_assume(aws_byte_buf_is_valid(&namespace));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&name, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&name);
+    __CPROVER_assume(aws_byte_buf_is_valid(&name));
+
+    struct aws_array_list old = trace;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)trace.data, trace.current_size, &old_byte);
+
+    if (aws_cryptosdk_keyring_trace_add_record_buf(alloc, &trace, &namespace, &name, flags) == AWS_OP_SUCCESS) {
+        /* assertions */
+        assert(aws_cryptosdk_keyring_trace_is_valid(&trace));
+        assert(trace.length = old.length + 1);
+    } else {
+        /* assertions */
+        assert_array_list_equivalence(&trace, &old, &old_byte);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.aws_array_list
+include ../Makefile.aws_byte_buf
+
+
+CBMC_UNWINDSET += --unwindset strlen.0:$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_add_record_c_str_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/array_list.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/Makefile
@@ -14,9 +14,10 @@
 ###########
 include ../Makefile.aws_array_list
 include ../Makefile.aws_byte_buf
+include ../Makefile.string
 
 
-CBMC_UNWINDSET += --unwindset strlen.0:$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
+CBMC_UNWINDSET += --unwindset strlen.0:$(shell echo $$((1 + $(MAX_BUFFER_SIZE)))),aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/aws_cryptosdk_keyring_trace_add_record_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/aws_cryptosdk_keyring_trace_add_record_c_str_harness.c
@@ -16,9 +16,10 @@
 #include <aws/common/array_list.h>
 #include <aws/common/string.h>
 #include <aws/cryptosdk/private/keyring_trace.h>
+#include <aws/cryptosdk/private/utils.h>
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/utils.h>
-#include <aws/cryptosdk/private/utils.h>
+#include <make_common_data_structures.h>
 
 
 void aws_cryptosdk_keyring_trace_add_record_c_str_harness() {
@@ -26,27 +27,27 @@ void aws_cryptosdk_keyring_trace_add_record_c_str_harness() {
     struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
     struct aws_array_list trace;
     const char *c_str_namespace = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
-    const char *c_str_name = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    const char *c_str_name      = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
     uint32_t flags;
 
     __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     ensure_array_list_has_allocated_data_member(&trace);
     __CPROVER_assume(aws_array_list_is_valid(&trace));
-
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
 
     struct aws_array_list old = trace;
     struct store_byte_from_buffer old_byte;
     save_byte_from_array((uint8_t *)trace.data, trace.current_size, &old_byte);
 
-
-	if (aws_cryptosdk_keyring_trace_add_record_c_str(alloc, &trace, c_str_namespace, c_str_name, flags) == AWS_OP_SUCCESS){
+    if (aws_cryptosdk_keyring_trace_add_record_c_str(alloc, &trace, c_str_namespace, c_str_name, flags) ==
+        AWS_OP_SUCCESS) {
         /* assertions */
-        assert(aws_array_list_is_valid(&trace));
+        assert(aws_cryptosdk_keyring_trace_is_valid(&trace));
         assert(trace.length = old.length + 1);
-    }
-    else {
+    } else {
         /* assertions */
         assert_array_list_equivalence(&trace, &old, &old_byte);
     }
-
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/aws_cryptosdk_keyring_trace_add_record_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/aws_cryptosdk_keyring_trace_add_record_c_str_harness.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/common/string.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+#include <aws/cryptosdk/private/utils.h>
+
+
+void aws_cryptosdk_keyring_trace_add_record_c_str_harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_array_list trace;
+    const char *c_str_namespace = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    const char *c_str_name = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    uint32_t flags;
+
+    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+
+
+    struct aws_array_list old = trace;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)trace.data, trace.current_size, &old_byte);
+
+
+	if (aws_cryptosdk_keyring_trace_add_record_c_str(alloc, &trace, c_str_namespace, c_str_name, flags) == AWS_OP_SUCCESS){
+        /* assertions */
+        assert(aws_array_list_is_valid(&trace));
+        assert(trace.length = old.length + 1);
+    }
+    else {
+        /* assertions */
+        assert_array_list_equivalence(&trace, &old, &old_byte);
+    }
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/Makefile
@@ -1,0 +1,43 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.string 
+include ../Makefile.aws_array_list
+
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_clean_up_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+
+
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/aws_cryptosdk_keyring_trace_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/aws_cryptosdk_keyring_trace_clean_up_harness.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_trace_clean_up_harness() {
+    /* data structure */
+    struct aws_array_list trace;
+
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
+
+    aws_cryptosdk_keyring_trace_clean_up(&trace);
+
+    /* assertions */
+    assert(aws_array_list_is_wiped(&trace));
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_array_list
+
+CBMC_UNWINDSET +=  --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_clear_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/aws_cryptosdk_keyring_trace_clear_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/aws_cryptosdk_keyring_trace_clear_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_trace_clear_harness() {
+    /* data structure */
+    struct aws_array_list trace;
+
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
+
+    /* save current state of the data structure */
+    struct aws_array_list old = trace;
+
+    aws_cryptosdk_keyring_trace_clear(&trace);
+
+    /* assertions */
+    assert(aws_array_list_is_valid(&trace));
+    assert(trace.length == 0);
+    assert(trace.alloc == old.alloc);
+    assert(trace.current_size == old.current_size);
+    assert(trace.item_size == old.item_size);
+    assert(trace.data == old.data);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/Makefile
@@ -1,0 +1,43 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_array_list
+
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_eq_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+
+
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/aws_cryptosdk_keyring_trace_eq_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/aws_cryptosdk_keyring_trace_eq_harness.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_trace_eq_harness() {
+    /* data structure */
+    struct aws_array_list lhs;
+    struct aws_array_list rhs;
+
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&lhs, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(lhs.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&lhs);
+    __CPROVER_assume(aws_array_list_is_valid(&lhs));
+    ensure_trace_has_allocated_records(&lhs, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&lhs));
+
+    __CPROVER_assume(aws_array_list_is_bounded(&rhs, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(rhs.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&rhs);
+    __CPROVER_assume(aws_array_list_is_valid(&rhs));
+    ensure_trace_has_allocated_records(&rhs, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&rhs));
+
+    /* save current state of the data structure */
+    struct aws_array_list old_lhs = lhs;
+    struct store_byte_from_buffer old_byte_from_lhs;
+    save_byte_from_array((uint8_t *)lhs.data, lhs.current_size, &old_byte_from_lhs);
+    struct aws_array_list old_rhs = rhs;
+    struct store_byte_from_buffer old_byte_from_rhs;
+    save_byte_from_array((uint8_t *)rhs.data, rhs.current_size, &old_byte_from_rhs);
+
+    if (aws_cryptosdk_keyring_trace_eq(&lhs, &rhs)) {
+        /* assertions */
+        assert(lhs.length == rhs.length);
+        size_t num_records = aws_array_list_length(&lhs);
+        size_t idx;
+        __CPROVER_assume(idx < num_records);
+        struct aws_cryptosdk_keyring_trace_record *lhs_rec;
+        struct aws_cryptosdk_keyring_trace_record *rhs_rec;
+        aws_array_list_get_at_ptr(&lhs, (void **)&lhs_rec, idx);
+        aws_array_list_get_at_ptr(&rhs, (void **)&rhs_rec, idx);
+        assert(aws_string_eq(lhs_rec->wrapping_key_namespace, rhs_rec->wrapping_key_namespace));
+        assert(aws_string_eq(lhs_rec->wrapping_key_name, rhs_rec->wrapping_key_name));
+        assert(lhs_rec->flags == rhs_rec->flags);
+    }
+    /* assertions */
+    assert(aws_array_list_is_valid(&lhs));
+    assert(aws_array_list_is_valid(&rhs));
+    assert_array_list_equivalence(&lhs, &old_lhs, &old_byte_from_lhs);
+    assert_array_list_equivalence(&rhs, &old_rhs, &old_byte_from_rhs);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/Makefile
@@ -1,0 +1,39 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+UNWINDSET += 
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_init
+
+OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
+OBJS +=	$(SRCDIR)/c-common-src/common.goto
+OBJS +=	$(SRCDIR)/c-common-src/error.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.goto
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/Makefile
@@ -17,22 +17,20 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 
-## At the moment this is not used in the Makefile.common of encryption-sdk
 UNWINDSET += 
 
 CBMCFLAGS +=
 
-ENTRY = aws_cryptosdk_keyring_trace_init
+ENTRY = aws_cryptosdk_keyring_trace_init_harness
 
-OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
-OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
-OBJS +=	$(SRCDIR)/c-common-src/common.goto
-OBJS +=	$(SRCDIR)/c-common-src/error.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.goto
-OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
-OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/aws_cryptosdk_keyring_trace_init_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/aws_cryptosdk_keyring_trace_init_harness.c
@@ -18,7 +18,7 @@
 #include <make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void harness() {
+void aws_cryptosdk_keyring_trace_init_harness() {
     /* data structure */
     struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
     struct aws_array_list trace; /* Precondition: trace must be non-null */

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/aws_cryptosdk_keyring_trace_init_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/aws_cryptosdk_keyring_trace_init_harness.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/cryptosdk/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_array_list trace; /* Precondition: trace must be non-null */
+
+    if (aws_cryptosdk_keyring_trace_init(alloc, &trace) == AWS_OP_SUCCESS){
+        /* assertions */
+        assert(aws_array_list_is_valid(&trace));
+        assert(trace.alloc == alloc);
+        assert(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+        assert(trace.length == 0);
+    }
+
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--object-bits;8;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions"
+goto: aws_cryptosdk_keyring_trace_init.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/Makefile
@@ -1,0 +1,39 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+UNWINDSET += 
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_record_clean_up
+
+OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
+OBJS +=	$(SRCDIR)/c-common-src/common.goto
+OBJS +=	$(SRCDIR)/c-common-src/error.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.goto
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/Makefile
@@ -22,17 +22,16 @@ UNWINDSET +=
 
 CBMCFLAGS +=
 
-ENTRY = aws_cryptosdk_keyring_trace_record_clean_up
+ENTRY = aws_cryptosdk_keyring_trace_record_clean_up_harness
 
-OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
-OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
-OBJS +=	$(SRCDIR)/c-common-src/common.goto
-OBJS +=	$(SRCDIR)/c-common-src/error.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.goto
-OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
-OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/aws_cryptosdk_keyring_trace_record_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/aws_cryptosdk_keyring_trace_record_clean_up_harness.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void harness() {
+    /* data structure */
+    struct aws_cryptosdk_keyring_trace_record record; /* Precondition: record is non-null */
+
+    aws_cryptosdk_keyring_trace_record_clean_up(&record);
+    assert(record.flags == 0);
+    assert(record.wrapping_key_name == NULL);
+    assert(record.wrapping_key_namespace == NULL);
+
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/aws_cryptosdk_keyring_trace_record_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/aws_cryptosdk_keyring_trace_record_clean_up_harness.c
@@ -18,7 +18,7 @@
 #include <make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void harness() {
+void aws_cryptosdk_keyring_trace_record_clean_up_harness() {
     /* data structure */
     struct aws_cryptosdk_keyring_trace_record record; /* Precondition: record is non-null */
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--object-bits;8;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions"
+goto: aws_cryptosdk_keyring_trace_record_clean_up.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/Makefile
@@ -1,0 +1,39 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+sinclude ../Makefile.string
+
+CBMC_UNWINDSET += --unwindset memcmp.0:17
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_record_init_clone
+
+OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
+OBJS +=	$(SRCDIR)/c-common-src/common.goto
+OBJS +=	$(SRCDIR)/c-common-src/error.goto
+OBJS +=	$(SRCDIR)/c-common-src/string.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/utils.goto
+OBJS += $(COMMON_HELPERDIR)/stubs/memcmp_override.goto
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/Makefile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 ###########
-sinclude ../Makefile.string
+include ../Makefile.string
 
 CBMC_UNWINDSET += --unwindset memcmp.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/Makefile
@@ -14,24 +14,23 @@
 ###########
 sinclude ../Makefile.string
 
-CBMC_UNWINDSET += --unwindset memcmp.0:17
+CBMC_UNWINDSET += --unwindset memcmp.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 
 CBMCFLAGS +=
 
-ENTRY = aws_cryptosdk_keyring_trace_record_init_clone
+ENTRY = aws_cryptosdk_keyring_trace_record_init_clone_harness
 
-OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
-OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
-OBJS +=	$(SRCDIR)/c-common-src/common.goto
-OBJS +=	$(SRCDIR)/c-common-src/error.goto
-OBJS +=	$(SRCDIR)/c-common-src/string.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/utils.goto
-OBJS += $(COMMON_HELPERDIR)/stubs/memcmp_override.goto
-OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
-OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
 
 ###########

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/aws_cryptosdk_keyring_trace_record_init_clone_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/aws_cryptosdk_keyring_trace_record_init_clone_harness.c
@@ -17,9 +17,7 @@
 #include <make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-const size_t MAX_STRING_LEN = 16; //TODO: move this to the Makefile
-
-void harness() {
+void aws_cryptosdk_keyring_trace_record_init_clone_harness() {
     /* data structure */
     struct aws_cryptosdk_keyring_trace_record source_record; /* Precondition: record is non-null */
     struct aws_cryptosdk_keyring_trace_record dest_record; /* Precondition: record is non-null */

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/aws_cryptosdk_keyring_trace_record_init_clone_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/aws_cryptosdk_keyring_trace_record_init_clone_harness.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+const size_t MAX_STRING_LEN = 16; //TODO: move this to the Makefile
+
+void harness() {
+    /* data structure */
+    struct aws_cryptosdk_keyring_trace_record source_record; /* Precondition: record is non-null */
+    struct aws_cryptosdk_keyring_trace_record dest_record; /* Precondition: record is non-null */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+
+    source_record.wrapping_key_namespace = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+    source_record.wrapping_key_name = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+
+
+    if ( aws_cryptosdk_keyring_trace_record_init_clone(alloc, &dest_record, &source_record) == AWS_OP_SUCCESS) {
+    	/* assertions */
+    	assert(aws_string_eq(source_record.wrapping_key_namespace, dest_record.wrapping_key_namespace));
+    	assert(aws_string_eq(source_record.wrapping_key_name, dest_record.wrapping_key_name));
+    	assert(source_record.flags == dest_record.flags);
+    }
+    else {
+    	/* assertions */
+    	assert(dest_record.flags == 0);
+    	assert(dest_record.wrapping_key_name == NULL);
+    	assert(dest_record.wrapping_key_namespace == NULL);
+    }
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--object-bits;8;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17"
+goto: aws_cryptosdk_keyring_trace_record_init_clone.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
@@ -20,12 +20,10 @@ include ../Makefile.local_default
 
 ######### 
 ENTRY = MultiKeyringNew
-HARNESS_NAME = $(ENTRY)_harness.c
-OBJS = \
-	$(SRCDIR)/$(ENTRY)_harness.goto \
-	$(SRCDIR)/c-enc-sdk-src/multi_keyring.goto \
-	$(SRCDIR)/c-common-src/common.goto \
-	$(SRCDIR)/helper-src/proof_allocators.goto
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+OBJS += $(SRCDIR)/c-enc-sdk-src/multi_keyring.goto
+OBJS += $(SRCDIR)/c-common-src/common.goto
+OBJS += $(SRCDIR)/helper-src/proof_allocators.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
@@ -1,0 +1,39 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+UNWINDSET += 
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_serialize_frame
+
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/framefmt.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+OBJS +=	$(SRCDIR)/c-common-src/common.goto
+OBJS +=	$(SRCDIR)/c-common-src/error.goto
+OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
+OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -42,5 +42,9 @@ void harness() {
         assert(aws_cryptosdk_frame_is_valid(&frame));
         assert(ciphertext_buf.buffer == old_ciphertext_buffer);
         assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
-    }
+    } else {
+        // Assert that the ciphertext buffer is zeroed in case of failure
+        assert_all_zeroes(ciphertext_buf.buffer, ciphertext_buf.capacity);
+        assert(ciphertext_buf.len == 0);
+    }   
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <make_common_data_structures.h>
+
+void harness() {
+    
+    /* data structure */
+    struct aws_cryptosdk_frame frame;
+    size_t ciphertext_size;
+    size_t plaintext_size;
+    struct aws_byte_buf ciphertext_buf;
+    struct aws_cryptosdk_alg_properties alg_props;
+
+    /* Assumptions about the function input */
+    ensure_byte_buf_has_allocated_buffer_member(&ciphertext_buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&ciphertext_buf));
+
+    ensure_alg_properties_has_allocated_names(&alg_props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(&alg_props));
+
+    /* Save the old state of the ciphertext buffer */
+    uint8_t *old_ciphertext_buffer = ciphertext_buf.buffer;
+    size_t old_ciphertext_buffer_len = ciphertext_buf.len;
+    
+    int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, &alg_props);
+    if (rval == AWS_OP_SUCCESS) {
+        assert(aws_cryptosdk_frame_is_valid(&frame));
+        assert(ciphertext_buf.buffer == old_ciphertext_buffer);
+        assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
+    }
+
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -15,11 +15,10 @@
 
 #include <aws/common/byte_buf.h>
 #include <aws/cryptosdk/private/framefmt.h>
-#include <proof_helpers/make_common_data_structures.h>
 #include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
 
 void harness() {
-    
     /* data structure */
     struct aws_cryptosdk_frame frame;
     size_t ciphertext_size;
@@ -35,15 +34,13 @@ void harness() {
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(&alg_props));
 
     /* Save the old state of the ciphertext buffer */
-    uint8_t *old_ciphertext_buffer = ciphertext_buf.buffer;
+    uint8_t *old_ciphertext_buffer   = ciphertext_buf.buffer;
     size_t old_ciphertext_buffer_len = ciphertext_buf.len;
-    
+
     int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, &alg_props);
     if (rval == AWS_OP_SUCCESS) {
         assert(aws_cryptosdk_frame_is_valid(&frame));
         assert(ciphertext_buf.buffer == old_ciphertext_buffer);
         assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
     }
-
-
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_byte_cursor_advance_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-goto: aws_byte_cursor_advance_harness.goto
+cbmcflags: "--object-bits;8;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions"
+goto: aws_cryptosdk_serialize_frame.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/Makefile
@@ -12,14 +12,7 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
-#sinclude ../Makefile.local
-#otherwise, use the default values
-#include ../Makefile.local_default
 include ../Makefile.string
-
-MAX_STRING_LEN ?= 16
-DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN) 
 
 CBMC_UNWINDSET += --unwindset memcmp.0:17
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/Makefile
@@ -14,23 +14,22 @@
 ###########
 include ../Makefile.string
 
-CBMC_UNWINDSET += --unwindset memcmp.0:17
+CBMC_UNWINDSET += --unwindset memcmp.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 
 CBMCFLAGS +=
 
-ENTRY = aws_cryptosdk_string_dup
+ENTRY = aws_cryptosdk_string_dup_harness
 
-OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
-OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
-OBJS +=	$(SRCDIR)/c-common-src/common.goto
-OBJS +=	$(SRCDIR)/c-common-src/error.goto
-OBJS +=	$(SRCDIR)/c-common-src/string.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-OBJS +=	$(SRCDIR)/c-enc-sdk-src/utils.goto
-OBJS += $(COMMON_HELPERDIR)/stubs/memcmp_override.goto
-OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
-OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/Makefile
@@ -1,0 +1,44 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+#sinclude ../Makefile.local
+#otherwise, use the default values
+#include ../Makefile.local_default
+include ../Makefile.string
+
+MAX_STRING_LEN ?= 16
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN) 
+
+CBMC_UNWINDSET += --unwindset memcmp.0:17
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_string_dup
+
+OBJS +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+OBJS +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+OBJS +=	$(SRCDIR)/c-common-src/byte_buf.goto
+OBJS +=	$(SRCDIR)/c-common-src/common.goto
+OBJS +=	$(SRCDIR)/c-common-src/error.goto
+OBJS +=	$(SRCDIR)/c-common-src/string.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+OBJS +=	$(SRCDIR)/c-enc-sdk-src/utils.goto
+OBJS += $(COMMON_HELPERDIR)/stubs/memcmp_override.goto
+OBJS += $(SRCDIR)/$(ENTRY)_harness.goto
+OBJS += $(SRCDIR)/helper-src/make_common_data_structures.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/aws_cryptosdk_string_dup_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/aws_cryptosdk_string_dup_harness.c
@@ -20,9 +20,7 @@
 #include <proof_helpers/utils.h>
 #include <aws/cryptosdk/private/utils.h>
 
-const size_t MAX_STRING_LEN = 16; //TODO: this should be defined in Makefile. 
-
-void harness() {
+void aws_cryptosdk_string_dup_harness() {
     /* data structure */
     struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
     struct aws_string *str_a = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/aws_cryptosdk_string_dup_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/aws_cryptosdk_string_dup_harness.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/string.h>
+#include <aws/common/array_list.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+#include <aws/cryptosdk/private/utils.h>
+
+const size_t MAX_STRING_LEN = 16; //TODO: this should be defined in Makefile. 
+
+void harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_string *str_a = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+
+    struct aws_string *str_b = aws_cryptosdk_string_dup(alloc, str_a);
+    /* assertions */ 
+    aws_string_eq(str_a, str_b);
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--object-bits;8;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17,strlen.0:17,memcpy_impl.0:17,memset_impl.0:17"
+goto: aws_cryptosdk_string_dup.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -14,6 +14,7 @@
  */
 
 #include <make_common_data_structures.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
 
 void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props) {
     size_t md_name_size;
@@ -22,4 +23,23 @@ void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properti
     alg_props->cipher_name = can_fail_malloc(cipher_name_size);
     size_t alg_name_size;
     alg_props->alg_name = can_fail_malloc(alg_name_size);
+}
+
+void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len) {
+    record->wrapping_key_namespace = ensure_string_is_allocated_bounded_length(max_len);
+    record->wrapping_key_name = ensure_string_is_allocated_bounded_length(max_len);
+    record->flags = malloc(sizeof(uint32_t));
+
+}
+
+void ensure_trace_has_allocated_records(struct aws_array_list *trace, size_t max_len){
+    /* iterate over each record in the keyring trace */
+    size_t num_records = aws_array_list_length(trace);
+    for (size_t idx = 0; idx < num_records; ++idx) {
+        struct aws_cryptosdk_keyring_trace_record *record;
+        if (!aws_array_list_get_at_ptr(trace, (void **)&record, idx)) {
+            /* make sure each record is valid */
+            ensure_record_has_allocated_members(record, max_len);
+        }
+    }
 }

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <make_common_data_structures.h>
+
+void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properties *const alg_props) {
+    size_t md_name_size;
+    alg_props->md_name = can_fail_malloc(md_name_size);
+    size_t cipher_name_size;
+    alg_props->cipher_name = can_fail_malloc(cipher_name_size);
+    size_t alg_name_size;
+    alg_props->alg_name = can_fail_malloc(alg_name_size);
+}
+
+

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -23,5 +23,3 @@ void ensure_alg_properties_has_allocated_names(struct aws_cryptosdk_alg_properti
     size_t alg_name_size;
     alg_props->alg_name = can_fail_malloc(alg_name_size);
 }
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 *.[ch]-e
 .DS_Store
 *.goto
+*.log
+.cbmc-batch/jobs/*/link-farm
+.cbmc-batch/jobs/*/html

--- a/include/aws/cryptosdk/cipher.h
+++ b/include/aws/cryptosdk/cipher.h
@@ -101,6 +101,13 @@ struct aws_cryptosdk_alg_properties {
 AWS_CRYPTOSDK_API
 const struct aws_cryptosdk_alg_properties *aws_cryptosdk_alg_props(enum aws_cryptosdk_alg_id alg_id);
 
+
+/**
+ * Checks whether an aws_cryptosdk_alg_properties is valid and is supported by the SDK.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props);
+
 /**
  * An opaque structure representing an ongoing sign or verify operation
  */

--- a/include/aws/cryptosdk/cipher.h
+++ b/include/aws/cryptosdk/cipher.h
@@ -101,7 +101,6 @@ struct aws_cryptosdk_alg_properties {
 AWS_CRYPTOSDK_API
 const struct aws_cryptosdk_alg_properties *aws_cryptosdk_alg_props(enum aws_cryptosdk_alg_id alg_id);
 
-
 /**
  * Checks whether an aws_cryptosdk_alg_properties is valid and is supported by the SDK.
  */

--- a/include/aws/cryptosdk/keyring_trace.h
+++ b/include/aws/cryptosdk/keyring_trace.h
@@ -83,6 +83,19 @@ extern "C" {
 #endif
 
 /**
+ * Evaluates the set of properties that define the shape of all valid 
+ * aws_cryptosdk_keyring_trace_record structures.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_keyring_trace_record_is_valid(struct aws_cryptosdk_keyring_trace_record *record);
+
+/**
+ * Iterates over each memeber of a keyring_trace and ensures that each is a valid record.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_keyring_trace_is_valid(struct aws_array_list *trace);
+
+/**
  * Add a record to the trace with the specified namespace, name, and flags.
  * Makes duplicates of namespace and name strings. Will be deallocated
  * when the keyring trace object is cleared or cleaned up.

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -17,6 +17,7 @@
 #define AWS_CRYPTOSDK_PRIVATE_FRAMEFMT_H
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/cipher.h>
 

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -34,7 +34,13 @@ struct aws_cryptosdk_frame {
     struct aws_byte_buf authtag;
 };
 
-#define MAX_PLAINTEXT_SIZE 65535
+// MAX_FRAME_SIZE = 2^32 - 1
+#define MAX_FRAME_SIZE 0xFFFFFFFF
+// MAX_FRAMES = 2^32 - 1
+#define MAX_FRAMES 0xFFFFFFFF
+// MAX_UNFRAMED_PLAINTEXT_SIZE = 2^36 - 32
+#define MAX_UNFRAMED_PLAINTEXT_SIZE 0xFFFFFFFE0ull
+
 
 /**
  * Checks whether a frame struct is valid. At the moment this means

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -33,6 +33,15 @@ struct aws_cryptosdk_frame {
     struct aws_byte_buf authtag;
 };
 
+#define MAX_PLAINTEXT_SIZE 65535
+
+/**
+ * Checks whether a frame struct is valid. At the moment this means
+ * that it checks the validity of the byte buffers and the fact that
+ * they should have NULL allocators.
+ */
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame);
+
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all
  * fields except for the IV, ciphertext, and authtag - for those three fields,

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -41,7 +41,6 @@ struct aws_cryptosdk_frame {
 // MAX_UNFRAMED_PLAINTEXT_SIZE = 2^36 - 32
 #define MAX_UNFRAMED_PLAINTEXT_SIZE 0xFFFFFFFE0ull
 
-
 /**
  * Checks whether a frame struct is valid. At the moment this means
  * that it checks the validity of the byte buffers and the fact that

--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -21,7 +21,6 @@
 #include <aws/cryptosdk/session.h>
 
 #define DEFAULT_FRAME_SIZE (256 * 1024)
-#define MAX_FRAME_SIZE 0xFFFFFFFF
 
 enum session_state {
     /*** Common states ***/

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -108,40 +108,35 @@ static bool str_eq(const char *const str1, const char *const str2) {
 #endif
 }
 
-static bool alg_properties_equal(const struct aws_cryptosdk_alg_properties alg_props1,
-                                 const struct aws_cryptosdk_alg_properties alg_props2) {
+static bool alg_properties_equal(
+    const struct aws_cryptosdk_alg_properties alg_props1, const struct aws_cryptosdk_alg_properties alg_props2) {
     return
         /* Note: strcmp messes with CBMC so we should either define
-           this to be different for CBMC or bound the size of names */ 
+           this to be different for CBMC or bound the size of names */
         /* strcmp(alg_props1.md_name, alg_props2.md_name) == 0 && */
         /* strcmp(alg_props1.cipher_name, alg_props2.cipher_name) == 0 && */
         /* strcmp(alg_props1.alg_name, alg_props2.alg_name) == 0 && */
-        
+
         /* Note: for now we don't check the equiality of the alg_impl
          * struct. Is there a way to check for equality of the impl
          * structure? */
         alg_props1.data_key_len == alg_props2.data_key_len &&
-        alg_props1.content_key_len == alg_props2.content_key_len &&
-        alg_props1.iv_len == alg_props2.iv_len &&
-        alg_props1.tag_len == alg_props2.tag_len &&
-        alg_props1.signature_len == alg_props2.signature_len &&
+        alg_props1.content_key_len == alg_props2.content_key_len && alg_props1.iv_len == alg_props2.iv_len &&
+        alg_props1.tag_len == alg_props2.tag_len && alg_props1.signature_len == alg_props2.signature_len &&
         alg_props1.alg_id == alg_props2.alg_id;
 }
 
 bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props) {
     if (alg_props == NULL) {
         return false;
-    }   
-    enum aws_cryptosdk_alg_id id = alg_props->alg_id;
+    }
+    enum aws_cryptosdk_alg_id id                       = alg_props->alg_id;
     struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
     if (std_alg_props == NULL) {
         return false;
     }
-    return
-        alg_props->md_name &&
-        alg_props->cipher_name &&
-        alg_props->alg_name &&
-        alg_properties_equal(*alg_props, *std_alg_props);
+    return alg_props->md_name && alg_props->cipher_name && alg_props->alg_name &&
+           alg_properties_equal(*alg_props, *std_alg_props);
 }
 
 int aws_cryptosdk_derive_key(

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -113,9 +113,9 @@ static bool alg_properties_equal(
     return
         /* Note: strcmp messes with CBMC so we should either define
            this to be different for CBMC or bound the size of names */
-        /* strcmp(alg_props1.md_name, alg_props2.md_name) == 0 && */
-        /* strcmp(alg_props1.cipher_name, alg_props2.cipher_name) == 0 && */
-        /* strcmp(alg_props1.alg_name, alg_props2.alg_name) == 0 && */
+        str_eq(alg_props1.md_name, alg_props2.md_name) &&
+        str_eq(alg_props1.cipher_name, alg_props2.cipher_name) &&
+        str_eq(alg_props1.alg_name, alg_props2.alg_name) &&
 
         /* Note: for now we don't check the equiality of the alg_impl
          * struct. Is there a way to check for equality of the impl
@@ -131,7 +131,7 @@ bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_proper
         return false;
     }
     enum aws_cryptosdk_alg_id id                       = alg_props->alg_id;
-    struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
+    const struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
     if (std_alg_props == NULL) {
         return false;
     }

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -88,41 +88,17 @@ static enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk
     }
 }
 
-static bool str_eq(const char *const str1, const char *const str2) {
-    if ((str1 && !str2) || (!str1 && str2)) {
-        return false;
-    }
-    if (!str1 && !str2) {
-        return true;
-    }
-#ifdef CBMC
-    /* TODO: Bound the alg_props_string size to 128 characters (or any
-       reasonable max size).  This is only useful for CBMC to work,
-       not a real precondition. (We have to include that in the
-       validity check for alg_props (checking for that bound) so that
-       it is at least checked in debug_mode. */
-    /* For now just assert that they both point somewhere */
-    return true;
-#else
-    return strcmp(str1, str2) == 0;
-#endif
-}
-
 static bool alg_properties_equal(
     const struct aws_cryptosdk_alg_properties alg_props1, const struct aws_cryptosdk_alg_properties alg_props2) {
-    return
-        /* Note: strcmp messes with CBMC so we should either define
-           this to be different for CBMC or bound the size of names */
-        str_eq(alg_props1.md_name, alg_props2.md_name) && str_eq(alg_props1.cipher_name, alg_props2.cipher_name) &&
-        str_eq(alg_props1.alg_name, alg_props2.alg_name) &&
+    /* Note: We are not checking whether the names (md/cipher/alg) are
+     * equal */
 
-        /* Note: for now we don't check the equiality of the alg_impl
-         * struct. Is there a way to check for equality of the impl
-         * structure? */
-        alg_props1.data_key_len == alg_props2.data_key_len &&
-        alg_props1.content_key_len == alg_props2.content_key_len && alg_props1.iv_len == alg_props2.iv_len &&
-        alg_props1.tag_len == alg_props2.tag_len && alg_props1.signature_len == alg_props2.signature_len &&
-        alg_props1.alg_id == alg_props2.alg_id;
+    /* Note: We are not checking whether the underlying alg_impl
+     * structs are equal. */
+    return alg_props1.data_key_len == alg_props2.data_key_len &&
+           alg_props1.content_key_len == alg_props2.content_key_len && alg_props1.iv_len == alg_props2.iv_len &&
+           alg_props1.tag_len == alg_props2.tag_len && alg_props1.signature_len == alg_props2.signature_len &&
+           alg_props1.alg_id == alg_props2.alg_id;
 }
 
 bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props) {

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -113,8 +113,7 @@ static bool alg_properties_equal(
     return
         /* Note: strcmp messes with CBMC so we should either define
            this to be different for CBMC or bound the size of names */
-        str_eq(alg_props1.md_name, alg_props2.md_name) &&
-        str_eq(alg_props1.cipher_name, alg_props2.cipher_name) &&
+        str_eq(alg_props1.md_name, alg_props2.md_name) && str_eq(alg_props1.cipher_name, alg_props2.cipher_name) &&
         str_eq(alg_props1.alg_name, alg_props2.alg_name) &&
 
         /* Note: for now we don't check the equiality of the alg_impl
@@ -130,7 +129,7 @@ bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_proper
     if (alg_props == NULL) {
         return false;
     }
-    enum aws_cryptosdk_alg_id id                       = alg_props->alg_id;
+    enum aws_cryptosdk_alg_id id                             = alg_props->alg_id;
     const struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
     if (std_alg_props == NULL) {
         return false;

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -215,14 +215,22 @@ static inline int serde_nonframed(
 }
 
 bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame) {
-    bool iv_valid         = aws_byte_buf_is_valid(&frame->iv);
-    bool ciphertext_valid = aws_byte_buf_is_valid(&frame->ciphertext);
+    bool iv_byte_buf_valid = aws_byte_buf_is_valid(&frame->iv);
+    bool iv_byte_buf_static = frame->iv.allocator == NULL;
+
+    bool authtag_byte_buf_valid = aws_byte_buf_is_valid(&frame->authtag);
+    bool authtag_byte_buf_static = frame->authtag.allocator == NULL;
+    
+    bool ciphertext_byte_buf_valid = aws_byte_buf_is_valid(&frame->ciphertext);
     /* This happens when input plaintext size is 0 */
     bool ciphertext_valid_zero =
         frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0;
-    bool authtag_valid = aws_byte_buf_is_valid(&frame->authtag);
-    return iv_valid && frame->iv.allocator == NULL && (ciphertext_valid || ciphertext_valid_zero) &&
-           frame->ciphertext.allocator == NULL && authtag_valid && frame->authtag.allocator == NULL;
+    bool ciphertext_valid = ciphertext_byte_buf_valid || ciphertext_valid_zero;
+    bool ciphertext_static = frame->ciphertext.allocator == NULL;
+
+    return iv_byte_buf_valid && iv_byte_buf_static &&
+        authtag_byte_buf_valid && authtag_byte_buf_static &&
+        ciphertext_valid && ciphertext_static;
 }
 
 /**
@@ -252,7 +260,10 @@ int aws_cryptosdk_serialize_frame(
 
     // The plaintext_size should be bound to prevent arithmetic
     // overflows due to addition
-    if (plaintext_size > MAX_PLAINTEXT_SIZE) {
+    if ((frame->type == FRAME_TYPE_SINGLE && plaintext_size > MAX_UNFRAMED_PLAINTEXT_SIZE) ||
+        (frame->type != FRAME_TYPE_SINGLE && plaintext_size > MAX_FRAME_SIZE)) {
+        // Clear the ciphertext buffer
+        aws_byte_buf_secure_zero(ciphertext_buf);
         return aws_raise_error(AWS_CRYPTOSDK_ERR_LIMIT_EXCEEDED);
     }
 

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -215,19 +215,14 @@ static inline int serde_nonframed(
 }
 
 bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame) {
-    bool iv_valid = aws_byte_buf_is_valid(&frame->iv);
+    bool iv_valid         = aws_byte_buf_is_valid(&frame->iv);
     bool ciphertext_valid = aws_byte_buf_is_valid(&frame->ciphertext);
     /* This happens when input plaintext size is 0 */
-    bool ciphertext_valid_zero = frame->ciphertext.len == 0 &&
-        frame->ciphertext.buffer &&
-        frame->ciphertext.capacity == 0;
+    bool ciphertext_valid_zero =
+        frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0;
     bool authtag_valid = aws_byte_buf_is_valid(&frame->authtag);
-    return iv_valid &&
-        frame->iv.allocator == NULL &&
-        (ciphertext_valid || ciphertext_valid_zero) &&
-        frame->ciphertext.allocator == NULL &&
-        authtag_valid &&
-        frame->authtag.allocator == NULL;
+    return iv_valid && frame->iv.allocator == NULL && (ciphertext_valid || ciphertext_valid_zero) &&
+           frame->ciphertext.allocator == NULL && authtag_valid && frame->authtag.allocator == NULL;
 }
 
 /**
@@ -260,7 +255,7 @@ int aws_cryptosdk_serialize_frame(
     if (plaintext_size > MAX_PLAINTEXT_SIZE) {
         return aws_raise_error(AWS_CRYPTOSDK_ERR_LIMIT_EXCEEDED);
     }
-    
+
     // We assume that the max frame size is equal to the plaintext size. This
     // lets us avoid having to pass in a redundant argument, avoids needing to
     // take a branch in serde_framed, and does not impact the serialized

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -215,22 +215,21 @@ static inline int serde_nonframed(
 }
 
 bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame) {
-    bool iv_byte_buf_valid = aws_byte_buf_is_valid(&frame->iv);
+    bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
     bool iv_byte_buf_static = frame->iv.allocator == NULL;
 
-    bool authtag_byte_buf_valid = aws_byte_buf_is_valid(&frame->authtag);
+    bool authtag_byte_buf_valid  = aws_byte_buf_is_valid(&frame->authtag);
     bool authtag_byte_buf_static = frame->authtag.allocator == NULL;
-    
+
     bool ciphertext_byte_buf_valid = aws_byte_buf_is_valid(&frame->ciphertext);
     /* This happens when input plaintext size is 0 */
     bool ciphertext_valid_zero =
         frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0;
-    bool ciphertext_valid = ciphertext_byte_buf_valid || ciphertext_valid_zero;
+    bool ciphertext_valid  = ciphertext_byte_buf_valid || ciphertext_valid_zero;
     bool ciphertext_static = frame->ciphertext.allocator == NULL;
 
-    return iv_byte_buf_valid && iv_byte_buf_static &&
-        authtag_byte_buf_valid && authtag_byte_buf_static &&
-        ciphertext_valid && ciphertext_static;
+    return iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid && authtag_byte_buf_static &&
+           ciphertext_valid && ciphertext_static;
 }
 
 /**

--- a/source/keyring_trace.c
+++ b/source/keyring_trace.c
@@ -214,6 +214,10 @@ static bool aws_cryptosdk_keyring_trace_record_eq(
 }
 
 bool aws_cryptosdk_keyring_trace_eq(const struct aws_array_list *a, const struct aws_array_list *b) {
+    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(a));
+    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(b));
+    AWS_FATAL_PRECONDITION(a->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    AWS_FATAL_PRECONDITION(b->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     size_t num_records = aws_array_list_length(a);
     if (num_records != aws_array_list_length(b)) return false;
 
@@ -229,6 +233,8 @@ bool aws_cryptosdk_keyring_trace_eq(const struct aws_array_list *a, const struct
 }
 
 void aws_cryptosdk_keyring_trace_clear(struct aws_array_list *trace) {
+    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(trace));
+    AWS_FATAL_PRECONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     size_t num_records = aws_array_list_length(trace);
     for (size_t idx = 0; idx < num_records; ++idx) {
         struct aws_cryptosdk_keyring_trace_record *record;
@@ -240,6 +246,8 @@ void aws_cryptosdk_keyring_trace_clear(struct aws_array_list *trace) {
 }
 
 void aws_cryptosdk_keyring_trace_clean_up(struct aws_array_list *trace) {
+    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(trace));
+    AWS_FATAL_PRECONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     aws_cryptosdk_keyring_trace_clear(trace);
     aws_array_list_clean_up(trace);
 }

--- a/source/keyring_trace.c
+++ b/source/keyring_trace.c
@@ -117,6 +117,7 @@ int aws_cryptosdk_keyring_trace_add_record(
     AWS_FATAL_PRECONDITION(wk_namespace != NULL);
     AWS_FATAL_PRECONDITION(wk_name != NULL);
     AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(trace));
+    AWS_FATAL_PRECONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     struct aws_cryptosdk_keyring_trace_record record;
     int ret = record_init_from_strings(alloc, &record, wk_namespace, wk_name, flags);
     if (ret) return ret;
@@ -129,6 +130,12 @@ int aws_cryptosdk_keyring_trace_add_record_c_str(
     const char *wk_namespace,
     const char *wk_name,
     uint32_t flags) {
+    AWS_FATAL_PRECONDITION(alloc != NULL);
+    AWS_FATAL_PRECONDITION(trace != NULL);
+    AWS_FATAL_PRECONDITION(wk_namespace != NULL);
+    AWS_FATAL_PRECONDITION(wk_name != NULL);
+    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(trace));
+    AWS_FATAL_PRECONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     struct aws_cryptosdk_keyring_trace_record record;
     int ret = record_init_from_c_strs(alloc, &record, wk_namespace, wk_name, flags);
     if (ret) return ret;
@@ -142,6 +149,14 @@ int aws_cryptosdk_keyring_trace_add_record_buf(
     const struct aws_byte_buf *wk_namespace,
     const struct aws_byte_buf *wk_name,
     uint32_t flags) {
+    AWS_FATAL_PRECONDITION(alloc != NULL);
+    AWS_FATAL_PRECONDITION(trace != NULL);
+    AWS_FATAL_PRECONDITION(wk_namespace != NULL);
+    AWS_FATAL_PRECONDITION(wk_name != NULL);
+    AWS_FATAL_PRECONDITION(aws_byte_buf_is_valid(wk_namespace));
+    AWS_FATAL_PRECONDITION(aws_byte_buf_is_valid(wk_name));
+    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(trace));
+    AWS_FATAL_PRECONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     struct aws_cryptosdk_keyring_trace_record record;
     int ret = record_init_from_bufs(alloc, &record, wk_namespace, wk_name, flags);
     if (ret) return ret;

--- a/source/utils.c
+++ b/source/utils.c
@@ -10,6 +10,7 @@
  * limitations under the License.
  */
 #include <assert.h>
+#include <aws/common/string.h>
 #include <aws/cryptosdk/private/utils.h>
 
 int aws_cryptosdk_compare_hash_elems_by_key_string(const void *elem_a, const void *elem_b) {
@@ -38,6 +39,9 @@ int aws_cryptosdk_hash_elems_array_init(
 }
 
 struct aws_string *aws_cryptosdk_string_dup(struct aws_allocator *alloc, const struct aws_string *str) {
-    if (str->allocator) return aws_string_new_from_string(alloc, str);
+    AWS_FATAL_PRECONDITION(alloc != NULL);
+    if (str->allocator) {
+        return aws_string_new_from_string(alloc, str);
+    }
     return (struct aws_string *)str;
 }


### PR DESCRIPTION
Proofs and harnesses for aws_cryptosdk_keyring_trace_eq, aws_cryptosdk_keyring_trace_clear and aws_cryptosdk_keyring_trace_clean_up functions. 

Added corresponding assumptions to the source code. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
