### PR TITLE
aws_cryptosdk_enc_ctx_clone proof

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/Makefile
@@ -1,0 +1,56 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+#########
+# Local vars
+MAX_NUM_ELEMS = 4
+# Time on my laptop: 4m50s
+#########
+#if we don't include the hash_table.c, we don't need to remove their function bodies
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_hash_table_no_slots_override.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_string_destroy_override.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_string_new_from_array_override.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/error.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/hash_table_generators.c
+
+CBMCFLAGS +=
+
+DEFINES += -DHASH_ITER_ELEMENT_GENERATOR=hash_iterator_string_string_generator
+DEFINES += -DHASH_TABLE_FIND_ELEMENT_GENERATOR=hash_find_string_string_generator
+DEFINES += -DMAX_NUM_ELEMS=$(MAX_NUM_ELEMS)
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/math.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
+
+ENTRY = aws_cryptosdk_enc_ctx_clone_harness
+
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_string_destroy
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_string_new_from_array
+
+UNWINDSET += aws_cryptosdk_enc_ctx_clone.0:$(shell echo $$(($(MAX_NUM_ELEMS) + 1)))
+UNWINDSET += aws_cryptosdk_enc_ctx_clone.1:$(shell echo $$(($(MAX_NUM_ELEMS) + 1)))
+
+###########
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/aws_cryptosdk_enc_ctx_clone_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/aws_cryptosdk_enc_ctx_clone_harness.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <aws/cryptosdk/enc_ctx.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void make_hash_table_with_no_backing_store(struct aws_hash_table *map, size_t max_table_entries);
+
+/**
+ * The actual proof
+ */
+void aws_cryptosdk_enc_ctx_clone_harness() {
+    struct aws_hash_table dest;
+    make_hash_table_with_no_backing_store(&dest, MAX_NUM_ELEMS);
+    __CPROVER_assume(aws_hash_table_is_valid(&dest));
+
+    struct aws_hash_table src;
+    make_hash_table_with_no_backing_store(&src, MAX_NUM_ELEMS);
+    __CPROVER_assume(aws_hash_table_is_valid(&src));
+
+    int rval = aws_cryptosdk_enc_ctx_clone(can_fail_allocator(), &dest, &src);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_enc_ctx_clone.0:5,aws_cryptosdk_enc_ctx_clone.1:5;--object-bits;8"
+goto: aws_cryptosdk_enc_ctx_clone_harness.goto
+expected: "SUCCESSFUL"

--- a/source/enc_ctx.c
+++ b/source/enc_ctx.c
@@ -196,6 +196,10 @@ static struct aws_string *clone_or_reuse_string(struct aws_allocator *allocator,
 
 int aws_cryptosdk_enc_ctx_clone(
     struct aws_allocator *alloc, struct aws_hash_table *dest, const struct aws_hash_table *src) {
+    AWS_PRECONDITION(aws_allocator_is_valid(alloc));
+    AWS_PRECONDITION(aws_hash_table_is_valid(dest));
+    AWS_PRECONDITION(aws_hash_table_is_valid(src));
+
     /* First, scan the destination for keys that don't belong, and remove them */
     for (struct aws_hash_iter iter = aws_hash_iter_begin(dest); !aws_hash_iter_done(&iter); aws_hash_iter_next(&iter)) {
         struct aws_hash_element *src_elem = NULL;


### PR DESCRIPTION
*Description of changes:*
CBMC proof for ```aws_cryptosdk_enc_ctx_clone```.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
