### PR TITLE
Proof for aws_cryptosdk_rsa_decrypt

### DIFF
--- a/.cbmc-batch/include/bn_utils.h
+++ b/.cbmc-batch/include/bn_utils.h
@@ -16,8 +16,8 @@
 #ifndef BN_UTILS_H
 #define BN_UTILS_H
 
-#include <stdbool.h>
 #include <openssl/bn.h>
+#include <stdbool.h>
 
 bool bignum_is_valid(BIGNUM *bn);
 BIGNUM *bignum_nondet_alloc();

--- a/.cbmc-batch/include/ec_utils.h
+++ b/.cbmc-batch/include/ec_utils.h
@@ -41,6 +41,10 @@ void initialize_max_encryption_size();
 
 size_t max_encryption_size();
 
+void initialize_max_decryption_size();
+
+size_t max_decryption_size();
+
 void write_unconstrained_data(unsigned char *out, size_t len);
 
 #endif

--- a/.cbmc-batch/include/ec_utils.h
+++ b/.cbmc-batch/include/ec_utils.h
@@ -33,6 +33,10 @@ void initialize_max_signature_size();
 
 size_t max_signature_size();
 
+void initialize_max_derivation_size();
+
+size_t max_derivation_size();
+
 void write_unconstrained_data(unsigned char *out, size_t len);
 
 #endif

--- a/.cbmc-batch/include/ec_utils.h
+++ b/.cbmc-batch/include/ec_utils.h
@@ -37,6 +37,10 @@ void initialize_max_derivation_size();
 
 size_t max_derivation_size();
 
+void initialize_max_encryption_size();
+
+size_t max_encryption_size();
+
 void write_unconstrained_data(unsigned char *out, size_t len);
 
 #endif

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -15,6 +15,7 @@
 
 #include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
+
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 #include <stdint.h>
@@ -25,3 +26,6 @@ void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ct
 
 /* Allocates the members of the context and ensures that internal pointers are pointing to the correct objects. */
 void ensure_sig_ctx_has_allocated_members(struct aws_cryptosdk_sig_ctx *ctx);
+
+/* Makes internal function from cipher.c accessible for CBMC */
+enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id alg_id);

--- a/.cbmc-batch/include/openssl/bio.h
+++ b/.cbmc-batch/include/openssl/bio.h
@@ -29,6 +29,9 @@ BIO *BIO_new_mem_buf(const void *buf, signed int len);
 EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x,
                                         pem_password_cb *cb, void *u);
 
+EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x,
+                                   pem_password_cb *cb, void *u);
+
 int BIO_free(BIO *a);
 
 

--- a/.cbmc-batch/include/openssl/bio.h
+++ b/.cbmc-batch/include/openssl/bio.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 1995-2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef HEADER_BIO_H
+# define HEADER_BIO_H
+
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
+# include <stdarg.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+#include <openssl/ossl_typ.h>
+
+
+typedef int pem_password_cb(char *buf, int size, int rwflag, void *u);
+
+
+BIO *BIO_new_mem_buf(const void *buf, signed int len);
+
+EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x,
+                                        pem_password_cb *cb, void *u);
+
+int BIO_free(BIO *a);
+
+
+# ifdef  __cplusplus
+}
+# endif
+#endif

--- a/.cbmc-batch/include/openssl/bio.h
+++ b/.cbmc-batch/include/openssl/bio.h
@@ -8,34 +8,29 @@
  */
 
 #ifndef HEADER_BIO_H
-# define HEADER_BIO_H
+#define HEADER_BIO_H
 
-# ifndef OPENSSL_NO_STDIO
-#  include <stdio.h>
-# endif
-# include <stdarg.h>
+#ifndef OPENSSL_NO_STDIO
+#    include <stdio.h>
+#endif
+#include <stdarg.h>
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 #include <openssl/ossl_typ.h>
 
-
 typedef int pem_password_cb(char *buf, int size, int rwflag, void *u);
-
 
 BIO *BIO_new_mem_buf(const void *buf, signed int len);
 
-EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x,
-                                        pem_password_cb *cb, void *u);
+EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x, pem_password_cb *cb, void *u);
 
-EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x,
-                                   pem_password_cb *cb, void *u);
+EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb, void *u);
 
 int BIO_free(BIO *a);
 
-
-# ifdef  __cplusplus
+#ifdef __cplusplus
 }
-# endif
+#endif
 #endif

--- a/.cbmc-batch/include/openssl/err.h
+++ b/.cbmc-batch/include/openssl/err.h
@@ -21,4 +21,6 @@
 
 void ERR_print_errors_fp(FILE *fp);
 
+signed int ERR_get_error(void);
+
 #endif

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -58,6 +58,8 @@ int EVP_CipherInit_ex(
     int enc);
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
+int EVP_EncryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
+                        ENGINE *impl, const unsigned char *key, const unsigned char *iv);
 int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -42,14 +42,8 @@ int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad);
 int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
-int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
-                        unsigned char *out, size_t *outlen,
-                        const unsigned char *in, size_t inlen);
-int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
-                        unsigned char *out, size_t *outlen,
-                        const unsigned char *in, size_t inlen);
-
-
+int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
+int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
 
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 int EVP_MD_CTX_size(const EVP_MD_CTX *ctx);
@@ -71,10 +65,10 @@ int EVP_CipherInit_ex(
     int enc);
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
-int EVP_EncryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
-                        ENGINE *impl, const unsigned char *key, const unsigned char *iv);
-int EVP_DecryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
-         ENGINE *impl, const unsigned char *key, const unsigned char *iv);
+int EVP_EncryptInit_ex(
+    EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv);
+int EVP_DecryptInit_ex(
+    EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv);
 int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -38,10 +38,14 @@ void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype, int cmd, int p1, void *p2);
 int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
 int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad);
 int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
+                        unsigned char *out, size_t *outlen,
+                        const unsigned char *in, size_t inlen);
+int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
                         unsigned char *out, size_t *outlen,
                         const unsigned char *in, size_t inlen);
 

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -22,16 +22,22 @@
 #include <openssl/ec.h>
 #include <openssl/ossl_typ.h>
 
-#define EVP_MAX_MD_SIZE 64 /* longest known is SHA512 */
+#define EVP_MAX_MD_SIZE 64  /* longest known is SHA512 */
+#define EVP_PKEY_HKDF 1036  // reference from obj_mac.h
 
 EVP_PKEY *EVP_PKEY_new(void);
 EC_KEY *EVP_PKEY_get0_EC_KEY(EVP_PKEY *pkey);
 int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key);
 void EVP_PKEY_free(EVP_PKEY *pkey);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
+EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);
+int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_sign_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen, const unsigned char *tbs, size_t tbslen);
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype, int cmd, int p1, void *p2);
+int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
+
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 int EVP_MD_CTX_size(const EVP_MD_CTX *ctx);
 void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
@@ -42,6 +48,22 @@ int EVP_DigestFinal(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *s);
 int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx, const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
 int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t siglen);
 
+EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void);
+int EVP_CipherInit_ex(
+    EVP_CIPHER_CTX *ctx,
+    const EVP_CIPHER *cipher,
+    ENGINE *impl,
+    const unsigned char *key,
+    const unsigned char *iv,
+    int enc);
+int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
+void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
+int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
+int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
+int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
+int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
+int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
+
 #define EVP_MD_CTX_create() EVP_MD_CTX_new()
 #define EVP_MD_CTX_destroy(ctx) EVP_MD_CTX_free((ctx))
 
@@ -51,6 +73,8 @@ const EVP_CIPHER *EVP_aes_256_gcm(void);
 const EVP_MD *EVP_sha256(void);
 const EVP_MD *EVP_sha384(void);
 const EVP_MD *EVP_sha512(void);
+
+int EVP_MD_size(const EVP_MD *md);
 
 #define EVP_CTRL_INIT 0x0
 #define EVP_CTRL_SET_KEY_LENGTH 0x1
@@ -76,5 +100,19 @@ const EVP_MD *EVP_sha512(void);
 #define EVP_CTRL_CCM_SET_IV_FIXED EVP_CTRL_AEAD_SET_IV_FIXED
 #define EVP_CTRL_CCM_SET_L 0x14
 #define EVP_CTRL_CCM_SET_MSGLEN 0x15
+
+#define EVP_PKEY_OP_UNDEFINED 0
+#define EVP_PKEY_OP_PARAMGEN (1 << 1)
+#define EVP_PKEY_OP_KEYGEN (1 << 2)
+#define EVP_PKEY_OP_SIGN (1 << 3)
+#define EVP_PKEY_OP_VERIFY (1 << 4)
+#define EVP_PKEY_OP_VERIFYRECOVER (1 << 5)
+#define EVP_PKEY_OP_SIGNCTX (1 << 6)
+#define EVP_PKEY_OP_VERIFYCTX (1 << 7)
+#define EVP_PKEY_OP_ENCRYPT (1 << 8)
+#define EVP_PKEY_OP_DECRYPT (1 << 9)
+#define EVP_PKEY_OP_DERIVE (1 << 10)
+
+#define EVP_PKEY_ALG_CTRL 0x1000
 
 #endif

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -60,6 +60,8 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
 int EVP_EncryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
                         ENGINE *impl, const unsigned char *key, const unsigned char *iv);
+int EVP_DecryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
+         ENGINE *impl, const unsigned char *key, const unsigned char *iv);
 int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -37,6 +37,15 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *siglen, const u
 void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype, int cmd, int p1, void *p2);
 int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
+int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad);
+int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
+int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
+int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
+                        unsigned char *out, size_t *outlen,
+                        const unsigned char *in, size_t inlen);
+
+
 
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 int EVP_MD_CTX_size(const EVP_MD_CTX *ctx);

--- a/.cbmc-batch/include/openssl/kdf.h
+++ b/.cbmc-batch/include/openssl/kdf.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef HEADER_KDF_H
+#define HEADER_KDF_H
+
+#include <openssl/evp.h>
+#include <openssl/ossl_typ.h>
+#include <stdarg.h>
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**** The legacy PKEY-based KDF API follows. ****/
+
+#define EVP_PKEY_CTRL_TLS_MD (EVP_PKEY_ALG_CTRL)
+#define EVP_PKEY_CTRL_TLS_SECRET (EVP_PKEY_ALG_CTRL + 1)
+#define EVP_PKEY_CTRL_TLS_SEED (EVP_PKEY_ALG_CTRL + 2)
+#define EVP_PKEY_CTRL_HKDF_MD (EVP_PKEY_ALG_CTRL + 3)
+#define EVP_PKEY_CTRL_HKDF_SALT (EVP_PKEY_ALG_CTRL + 4)
+#define EVP_PKEY_CTRL_HKDF_KEY (EVP_PKEY_ALG_CTRL + 5)
+#define EVP_PKEY_CTRL_HKDF_INFO (EVP_PKEY_ALG_CTRL + 6)
+#define EVP_PKEY_CTRL_HKDF_MODE (EVP_PKEY_ALG_CTRL + 7)
+#define EVP_PKEY_CTRL_PASS (EVP_PKEY_ALG_CTRL + 8)
+#define EVP_PKEY_CTRL_SCRYPT_SALT (EVP_PKEY_ALG_CTRL + 9)
+#define EVP_PKEY_CTRL_SCRYPT_N (EVP_PKEY_ALG_CTRL + 10)
+#define EVP_PKEY_CTRL_SCRYPT_R (EVP_PKEY_ALG_CTRL + 11)
+#define EVP_PKEY_CTRL_SCRYPT_P (EVP_PKEY_ALG_CTRL + 12)
+#define EVP_PKEY_CTRL_SCRYPT_MAXMEM_BYTES (EVP_PKEY_ALG_CTRL + 13)
+
+#define EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND EVP_KDF_HKDF_MODE_EXTRACT_AND_EXPAND
+#define EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY EVP_KDF_HKDF_MODE_EXTRACT_ONLY
+#define EVP_PKEY_HKDEF_MODE_EXPAND_ONLY EVP_KDF_HKDF_MODE_EXPAND_ONLY
+
+#define EVP_PKEY_CTX_set_hkdf_md(pctx, md) \
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_MD, 0, (void *)(md))
+
+#define EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt, saltlen) \
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_SALT, saltlen, (void *)(salt))
+
+#define EVP_PKEY_CTX_set1_hkdf_key(pctx, key, keylen) \
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_KEY, keylen, (void *)(key))
+
+#define EVP_PKEY_CTX_add1_hkdf_info(pctx, info, infolen) \
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_INFO, infolen, (void *)(info))
+
+#define EVP_PKEY_CTX_hkdf_mode(pctx, mode) \
+    EVP_PKEY_CTX_ctrl(pctx, -1, EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_MODE, mode, NULL)
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/.cbmc-batch/include/openssl/ossl_typ.h
+++ b/.cbmc-batch/include/openssl/ossl_typ.h
@@ -33,6 +33,7 @@ typedef struct bignum_st BIGNUM;
 typedef struct ec_key_st EC_KEY;
 
 typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
+typedef struct hmac_ctx_st HMAC_CTX;
 
 typedef struct evp_cipher_st EVP_CIPHER;
 typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;

--- a/.cbmc-batch/include/openssl/pem.h
+++ b/.cbmc-batch/include/openssl/pem.h
@@ -16,4 +16,4 @@
 
 /* Empty header. Necessary just because it is included in cipher.c */
 
- #include <openssl/bio.h>
+#include <openssl/bio.h>

--- a/.cbmc-batch/include/openssl/pem.h
+++ b/.cbmc-batch/include/openssl/pem.h
@@ -15,3 +15,5 @@
  */
 
 /* Empty header. Necessary just because it is included in cipher.c */
+
+ #include <openssl/bio.h>

--- a/.cbmc-batch/jobs/Makefile.aws_array_list
+++ b/.cbmc-batch/jobs/Makefile.aws_array_list
@@ -1,0 +1,28 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+# Sufficently long to get full coverage on the aws_array_list APIs
+# short enough that all proofs complete quickly
+MAX_ITEM_SIZE ?= 2
+
+# Necessary to get full coverage when using functions from math.h
+MAX_INITIAL_ITEM_ALLOCATION ?= 9223372036854775808
+
+DEFINES += -DMAX_ITEM_SIZE=$(MAX_ITEM_SIZE)
+DEFINES += -DMAX_INITIAL_ITEM_ALLOCATION=$(MAX_INITIAL_ITEM_ALLOCATION)

--- a/.cbmc-batch/jobs/Makefile.aws_byte_buf
+++ b/.cbmc-batch/jobs/Makefile.aws_byte_buf
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+# Sufficently long to get full coverage on the aws_byte_buf and aws_byte_cursor APIs
+# short enough that all proofs complete in less than a minute
+MAX_BUFFER_SIZE ?= 1024
+
+DEFINES += -DMAX_BUFFER_SIZE=$(MAX_BUFFER_SIZE)

--- a/.cbmc-batch/jobs/Makefile.aws_string
+++ b/.cbmc-batch/jobs/Makefile.aws_string
@@ -1,0 +1,19 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+# Sufficently long to get 100% coverage on the string APIs
+# short enough that all proofs complete quickly
+MAX_STRING_LEN ?= 16
+
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/Makefile
@@ -1,0 +1,48 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+include ../Makefile.aws_string
+
+
+UNWINDSET += flush_openssl_errors.0:1
+
+CBMCFLAGS += 
+
+ENTRY = aws_cryptosdk_aes_gcm_decrypt_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/aws_cryptosdk_aes_gcm_decrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/aws_cryptosdk_aes_gcm_decrypt_harness.c
@@ -20,7 +20,6 @@
 #define KEY_LEN 256
 
 void aws_cryptosdk_aes_gcm_decrypt_harness() {
-
     struct aws_byte_buf plain;
     struct aws_byte_cursor cipher;
     struct aws_byte_cursor tag;
@@ -67,7 +66,7 @@ void aws_cryptosdk_aes_gcm_decrypt_harness() {
     struct store_byte_from_buffer old_byte_from_aad;
     save_byte_from_array(aad.ptr, aad.len, &old_byte_from_aad);
 
-    if (aws_cryptosdk_aes_gcm_decrypt(&plain, cipher, tag, iv, aad, key) == AWS_OP_SUCCESS){
+    if (aws_cryptosdk_aes_gcm_decrypt(&plain, cipher, tag, iv, aad, key) == AWS_OP_SUCCESS) {
         assert(plain.len == cipher.len);
     }
     assert(aws_byte_buf_is_valid(&plain));
@@ -80,10 +79,7 @@ void aws_cryptosdk_aes_gcm_decrypt_harness() {
     if (iv.len != 0) {
         assert_byte_from_buffer_matches(iv.ptr, &old_byte_from_iv);
     }
-    if (aad.len != 0){
+    if (aad.len != 0) {
         assert_byte_from_buffer_matches(aad.ptr, &old_byte_from_aad);
     }
-
-
-
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/aws_cryptosdk_aes_gcm_decrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/aws_cryptosdk_aes_gcm_decrypt_harness.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+#define KEY_LEN 256
+
+void aws_cryptosdk_aes_gcm_decrypt_harness() {
+
+    struct aws_byte_buf plain;
+    struct aws_byte_cursor cipher;
+    struct aws_byte_cursor tag;
+    struct aws_byte_cursor iv;
+    struct aws_byte_cursor aad;
+    struct aws_string *key;
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&plain, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&plain);
+    __CPROVER_assume(aws_byte_buf_is_valid(&plain));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&cipher, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cipher));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&tag, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&tag);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&tag));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&iv, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&iv);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&iv));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&aad, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&aad);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&aad));
+
+    key = ensure_string_is_allocated_bounded_length(KEY_LEN);
+
+    aws_cryptosdk_aes_gcm_decrypt(&plain, cipher, tag, iv, aad, key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/aws_cryptosdk_aes_gcm_decrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/aws_cryptosdk_aes_gcm_decrypt_harness.c
@@ -50,5 +50,40 @@ void aws_cryptosdk_aes_gcm_decrypt_harness() {
 
     key = ensure_string_is_allocated_bounded_length(KEY_LEN);
 
-    aws_cryptosdk_aes_gcm_decrypt(&plain, cipher, tag, iv, aad, key);
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cipher = cipher;
+    struct store_byte_from_buffer old_byte_from_cipher;
+    save_byte_from_array(cipher.ptr, cipher.len, &old_byte_from_cipher);
+
+    struct aws_byte_cursor old_tag = tag;
+    struct store_byte_from_buffer old_byte_from_tag;
+    save_byte_from_array(tag.ptr, tag.len, &old_byte_from_tag);
+
+    struct aws_byte_cursor old_iv = iv;
+    struct store_byte_from_buffer old_byte_from_iv;
+    save_byte_from_array(iv.ptr, iv.len, &old_byte_from_iv);
+
+    struct aws_byte_cursor old_aad = aad;
+    struct store_byte_from_buffer old_byte_from_aad;
+    save_byte_from_array(aad.ptr, aad.len, &old_byte_from_aad);
+
+    if (aws_cryptosdk_aes_gcm_decrypt(&plain, cipher, tag, iv, aad, key) == AWS_OP_SUCCESS){
+        assert(plain.len == cipher.len);
+    }
+    assert(aws_byte_buf_is_valid(&plain));
+    if (cipher.len != 0) {
+        assert_byte_from_buffer_matches(cipher.ptr, &old_byte_from_cipher);
+    }
+    if (tag.len != 0) {
+        assert_byte_from_buffer_matches(tag.ptr, &old_byte_from_tag);
+    }
+    if (iv.len != 0) {
+        assert_byte_from_buffer_matches(iv.ptr, &old_byte_from_iv);
+    }
+    if (aad.len != 0){
+        assert_byte_from_buffer_matches(aad.ptr, &old_byte_from_aad);
+    }
+
+
+
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;flush_openssl_errors.0:1;--object-bits;8"
+goto: aws_cryptosdk_aes_gcm_decrypt_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/Makefile
@@ -1,0 +1,48 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+include ../Makefile.aws_string
+
+
+UNWINDSET += flush_openssl_errors.0:1
+
+CBMCFLAGS += 
+
+ENTRY = aws_cryptosdk_aes_gcm_encrypt_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
@@ -17,7 +17,7 @@
 #include <aws/cryptosdk/private/cipher.h>
 #include <make_common_data_structures.h>
 
-#define MSG_ID_LEN 16
+#define KEY_LEN 256
 
 void aws_cryptosdk_aes_gcm_encrypt_harness() {
     struct aws_byte_buf cipher;
@@ -47,7 +47,7 @@ void aws_cryptosdk_aes_gcm_encrypt_harness() {
     ensure_byte_cursor_has_allocated_buffer_member(&aad);
     __CPROVER_assume(aws_byte_cursor_is_valid(&aad));
 
-    key = ensure_string_is_allocated_bounded_length(256);
+    key = ensure_string_is_allocated_bounded_length(KEY_LEN);
 
     aws_cryptosdk_aes_gcm_encrypt(&cipher, &tag, plain, iv, aad, key);
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
@@ -63,7 +63,7 @@ void aws_cryptosdk_aes_gcm_encrypt_harness() {
 
     key = ensure_string_is_allocated_bounded_length(KEY_LEN);
 
-    if (aws_cryptosdk_aes_gcm_encrypt(&cipher, &tag, plain, iv, aad, key) == AWS_OP_SUCCESS){
+    if (aws_cryptosdk_aes_gcm_encrypt(&cipher, &tag, plain, iv, aad, key) == AWS_OP_SUCCESS) {
         assert(cipher.len == plain.len);
     }
 
@@ -74,7 +74,7 @@ void aws_cryptosdk_aes_gcm_encrypt_harness() {
     if (iv.len != 0) {
         assert_byte_from_buffer_matches(iv.ptr, &old_byte_from_iv);
     }
-    if (aad.len != 0){
+    if (aad.len != 0) {
         assert_byte_from_buffer_matches(aad.ptr, &old_byte_from_aad);
     }
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+#define MSG_ID_LEN 16
+
+void aws_cryptosdk_aes_gcm_encrypt_harness() {
+    /*struct aws_byte_buf *cipher,
+    struct aws_byte_buf *tag,
+    const struct aws_byte_cursor plain,
+    const struct aws_byte_cursor iv,
+    const struct aws_byte_cursor aad,
+    const struct aws_string *key */
+    /* arguments */
+
+    struct aws_byte_buf cipher;
+    struct aws_byte_buf tag;
+    struct aws_byte_cursor plain;
+    struct aws_byte_cursor iv;
+    struct aws_byte_cursor aad;
+    struct aws_string *key;
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&cipher, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_buf_is_valid(&cipher));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&tag, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&tag);
+    __CPROVER_assume(aws_byte_buf_is_valid(&tag));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&plain, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&plain);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&plain));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&iv, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&iv);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&iv));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&aad, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&aad);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&aad));
+
+    key = ensure_string_is_allocated_bounded_length(256);
+
+    aws_cryptosdk_aes_gcm_encrypt(&cipher, &tag, plain, iv, aad, key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
@@ -20,14 +20,6 @@
 #define MSG_ID_LEN 16
 
 void aws_cryptosdk_aes_gcm_encrypt_harness() {
-    /*struct aws_byte_buf *cipher,
-    struct aws_byte_buf *tag,
-    const struct aws_byte_cursor plain,
-    const struct aws_byte_cursor iv,
-    const struct aws_byte_cursor aad,
-    const struct aws_string *key */
-    /* arguments */
-
     struct aws_byte_buf cipher;
     struct aws_byte_buf tag;
     struct aws_byte_cursor plain;

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;flush_openssl_errors.0:1;--object-bits;8"
+goto: aws_cryptosdk_aes_gcm_encrypt_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_alg_props/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_alg_props/Makefile
@@ -1,0 +1,31 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET +=
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_alg_props_harness
+
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_alg_props/aws_cryptosdk_alg_props_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_alg_props/aws_cryptosdk_alg_props_harness.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+
+void aws_cryptosdk_alg_props_harness() {
+    /* arguments */
+    enum aws_cryptosdk_alg_id alg_id;
+
+    /* operation under verification */
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assertions */
+    if (props) {
+        assert(
+            props->impl->md_ctor == NULL || props->impl->md_ctor == EVP_sha256 || props->impl->md_ctor == EVP_sha384);
+        assert(
+            props->impl->cipher_ctor == NULL || props->impl->cipher_ctor == EVP_aes_128_gcm ||
+            props->impl->cipher_ctor == EVP_aes_192_gcm || props->impl->cipher_ctor == EVP_aes_256_gcm);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_alg_props/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_alg_props/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_alg_props_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_derive_key/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_derive_key/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += 
+
+CBMCFLAGS += 
+
+ENTRY = aws_cryptosdk_derive_key_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_derive_key/aws_cryptosdk_derive_key_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_derive_key/aws_cryptosdk_derive_key_harness.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+#define MSG_ID_LEN 16
+
+void aws_cryptosdk_derive_key_harness() {
+    /* arguments */
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    struct content_key *content_key = malloc(sizeof(content_key));
+    struct data_key *data_key       = malloc(sizeof(data_key));
+    uint8_t message_id;
+
+    /* assumptions */
+    __CPROVER_assume(props);
+    __CPROVER_assume(AWS_MEM_IS_WRITABLE(content_key->keybuf, sizeof(content_key->keybuf)));
+    __CPROVER_assume(AWS_MEM_IS_READABLE(message_id, MSG_ID_LEN));
+
+    aws_cryptosdk_derive_key(props, content_key, data_key, &message_id);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_derive_key/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_derive_key/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_derive_key_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_hkdf/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hkdf/Makefile
@@ -1,0 +1,44 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += 
+
+CBMCFLAGS += 
+
+ENTRY = aws_cryptosdk_hkdf_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_hkdf/aws_cryptosdk_hkdf_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hkdf/aws_cryptosdk_hkdf_harness.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_hkdf_harness() {
+    /* arguments */
+
+    struct aws_byte_buf okm;
+    enum aws_cryptosdk_alg_id alg_id;
+    enum aws_cryptosdk_sha_version which_sha = aws_cryptosdk_which_sha(alg_id);
+
+    struct aws_byte_buf salt;
+    struct aws_byte_buf ikm;
+    struct aws_byte_buf info;
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&okm, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&okm);
+    __CPROVER_assume(aws_byte_buf_is_valid(&okm));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&salt, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&salt);
+    __CPROVER_assume(aws_byte_buf_is_valid(&salt));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&ikm, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&ikm);
+    __CPROVER_assume(aws_byte_buf_is_valid(&ikm));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&info, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&info);
+    __CPROVER_assume(aws_byte_buf_is_valid(&info));
+
+    /* save current state of the data structure */
+    struct aws_byte_buf old_salt = salt;
+    struct store_byte_from_buffer old_byte_from_salt;
+    save_byte_from_array(salt.buffer, salt.len, &old_byte_from_salt);
+
+    struct aws_byte_buf old_ikm = ikm;
+    struct store_byte_from_buffer old_byte_from_ikm;
+    save_byte_from_array(ikm.buffer, ikm.len, &old_byte_from_ikm);
+
+    struct aws_byte_buf old_info = info;
+    struct store_byte_from_buffer old_byte_from_info;
+    save_byte_from_array(info.buffer, info.len, &old_byte_from_info);
+
+    aws_cryptosdk_hkdf(&okm, alg_id, &salt, &ikm, &info);
+
+    /* assertions */
+    assert(aws_byte_buf_is_valid(&salt));
+    assert(aws_byte_buf_is_valid(&ikm));
+    assert(aws_byte_buf_is_valid(&info));
+
+    assert_byte_buf_equivalence(&salt, &old_salt, &old_byte_from_salt);
+    assert_byte_buf_equivalence(&ikm, &old_ikm, &old_byte_from_ikm);
+    assert_byte_buf_equivalence(&info, &old_info, &old_byte_from_info);
+
+    assert(aws_byte_buf_is_valid(&okm));
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_hkdf/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hkdf/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_hkdf_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/Makefile
@@ -1,0 +1,49 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+include ../Makefile.aws_string
+
+
+UNWINDSET += 
+
+CBMCFLAGS += 
+
+ENTRY = aws_cryptosdk_rsa_decrypt_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bio_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/aws_cryptosdk_rsa_decrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/aws_cryptosdk_rsa_decrypt_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+#define KEY_LEN 256
+
+void aws_cryptosdk_rsa_decrypt_harness() {
+
+
+    struct aws_byte_buf plain;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_byte_cursor cipher;
+    struct aws_string *key = ensure_string_is_allocated_bounded_length(KEY_LEN);
+    enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode;
+
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&plain, MAX_BUFFER_SIZE));
+    //ensure_byte_buf_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_buf_is_valid(&plain));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&cipher, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cipher));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cipher = cipher;
+    struct store_byte_from_buffer old_byte_from_cipher;
+    save_byte_from_array(cipher.ptr, cipher.len, &old_byte_from_cipher);
+
+    if (aws_cryptosdk_rsa_decrypt(&plain, alloc, cipher, key, rsa_padding_mode) == AWS_OP_SUCCESS){
+        assert(aws_byte_buf_is_valid(&plain));
+    }
+    if (cipher.len != 0) {
+        assert_byte_from_buffer_matches(cipher.ptr, &old_byte_from_cipher);
+    }
+
+
+
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/aws_cryptosdk_rsa_decrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/aws_cryptosdk_rsa_decrypt_harness.c
@@ -20,17 +20,14 @@
 #define KEY_LEN 256
 
 void aws_cryptosdk_rsa_decrypt_harness() {
-
-
     struct aws_byte_buf plain;
     struct aws_allocator *alloc = can_fail_allocator();
     struct aws_byte_cursor cipher;
     struct aws_string *key = ensure_string_is_allocated_bounded_length(KEY_LEN);
     enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode;
 
-
     __CPROVER_assume(aws_byte_buf_is_bounded(&plain, MAX_BUFFER_SIZE));
-    //ensure_byte_buf_has_allocated_buffer_member(&cipher);
+    // ensure_byte_buf_has_allocated_buffer_member(&cipher);
     __CPROVER_assume(aws_byte_buf_is_valid(&plain));
 
     __CPROVER_assume(aws_byte_cursor_is_bounded(&cipher, MAX_BUFFER_SIZE));
@@ -42,14 +39,10 @@ void aws_cryptosdk_rsa_decrypt_harness() {
     struct store_byte_from_buffer old_byte_from_cipher;
     save_byte_from_array(cipher.ptr, cipher.len, &old_byte_from_cipher);
 
-    if (aws_cryptosdk_rsa_decrypt(&plain, alloc, cipher, key, rsa_padding_mode) == AWS_OP_SUCCESS){
+    if (aws_cryptosdk_rsa_decrypt(&plain, alloc, cipher, key, rsa_padding_mode) == AWS_OP_SUCCESS) {
         assert(aws_byte_buf_is_valid(&plain));
     }
     if (cipher.len != 0) {
         assert_byte_from_buffer_matches(cipher.ptr, &old_byte_from_cipher);
     }
-
-
-
-
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_rsa_decrypt_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/Makefile
@@ -1,0 +1,49 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+include ../Makefile.aws_string
+
+
+UNWINDSET += 
+
+CBMCFLAGS += 
+
+ENTRY = aws_cryptosdk_rsa_encrypt_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bio_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/aws_cryptosdk_rsa_encrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/aws_cryptosdk_rsa_encrypt_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+#define KEY_LEN 256
+
+void aws_cryptosdk_rsa_encrypt_harness() {
+
+
+    struct aws_byte_buf cipher;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_byte_cursor plain;
+    struct aws_string *key = ensure_string_is_allocated_bounded_length(KEY_LEN);
+    enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode;
+
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&cipher, MAX_BUFFER_SIZE));
+    //ensure_byte_buf_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_buf_is_valid(&cipher));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&plain, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&plain);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&plain));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_plain = plain;
+    struct store_byte_from_buffer old_byte_from_plain;
+    save_byte_from_array(plain.ptr, plain.len, &old_byte_from_plain);
+
+    if (aws_cryptosdk_rsa_encrypt(&cipher, alloc, plain, key, rsa_padding_mode) == AWS_OP_SUCCESS){
+        assert(aws_byte_buf_is_valid(&cipher));
+    }
+    if (plain.len != 0) {
+        assert_byte_from_buffer_matches(plain.ptr, &old_byte_from_plain);
+    }
+
+
+
+
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/aws_cryptosdk_rsa_encrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/aws_cryptosdk_rsa_encrypt_harness.c
@@ -20,17 +20,14 @@
 #define KEY_LEN 256
 
 void aws_cryptosdk_rsa_encrypt_harness() {
-
-
     struct aws_byte_buf cipher;
     struct aws_allocator *alloc = can_fail_allocator();
     struct aws_byte_cursor plain;
     struct aws_string *key = ensure_string_is_allocated_bounded_length(KEY_LEN);
     enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode;
 
-
     __CPROVER_assume(aws_byte_buf_is_bounded(&cipher, MAX_BUFFER_SIZE));
-    //ensure_byte_buf_has_allocated_buffer_member(&cipher);
+    // ensure_byte_buf_has_allocated_buffer_member(&cipher);
     __CPROVER_assume(aws_byte_buf_is_valid(&cipher));
 
     __CPROVER_assume(aws_byte_cursor_is_bounded(&plain, MAX_BUFFER_SIZE));
@@ -42,14 +39,10 @@ void aws_cryptosdk_rsa_encrypt_harness() {
     struct store_byte_from_buffer old_byte_from_plain;
     save_byte_from_array(plain.ptr, plain.len, &old_byte_from_plain);
 
-    if (aws_cryptosdk_rsa_encrypt(&cipher, alloc, plain, key, rsa_padding_mode) == AWS_OP_SUCCESS){
+    if (aws_cryptosdk_rsa_encrypt(&cipher, alloc, plain, key, rsa_padding_mode) == AWS_OP_SUCCESS) {
         assert(aws_byte_buf_is_valid(&cipher));
     }
     if (plain.len != 0) {
         assert_byte_from_buffer_matches(plain.ptr, &old_byte_from_plain);
     }
-
-
-
-
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_rsa_encrypt_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/Makefile
@@ -1,0 +1,48 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += strcmp.0:11, aws_base64_encode.0:22 # computed according to MAX_PUBKEY_SIZE and the implementation of aws_base64_encode
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_sign_start_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/asn1_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/aws_cryptosdk_sig_sign_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/aws_cryptosdk_sig_sign_start_harness.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_sign_start_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_string *pub_key;
+    struct aws_string *priv_key = ensure_string_is_allocated_nondet_length();
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assumptions */
+    __CPROVER_assume(props);
+    assert(aws_string_is_valid(priv_key));
+
+    bool save_pub_key = nondet_bool();
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_sign_start(
+            &ctx, alloc, save_pub_key ? &pub_key : NULL, props, priv_key /* priv_key can't be NULL */) ==
+        AWS_OP_SUCCESS) {
+        /* assertion: on success, context is initialized unless no curve name was given */
+        assert((!props->impl->curve_name && !ctx) || (aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx) && ctx->is_sign));
+    }
+
+    /* assertions */
+    if (save_pub_key) assert(!pub_key || aws_string_is_valid(pub_key));
+    assert(aws_string_is_valid(priv_key));
+
+    /* clean up */
+    if (ctx) {
+        ec_key_unconditional_free(ctx->keypair);
+        evp_pkey_unconditional_free(ctx->pkey);
+        evp_md_ctx_shallow_free(ctx->ctx);
+    }
+    aws_mem_release(alloc, ctx);
+    if (save_pub_key) free(pub_key);
+    free(priv_key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_encode.0:22;--object-bits;8"
+goto: aws_cryptosdk_sig_sign_start_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += strcmp.0:11, aws_base64_encode.0:22 # computed according to MAX_PUBKEY_SIZE and the implementation of aws_base64_encode
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_sign_start_keygen_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/aws_cryptosdk_sig_sign_start_keygen_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/aws_cryptosdk_sig_sign_start_keygen_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_sign_start_keygen_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *pctx;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_string *pub_key;
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assumptions */
+    __CPROVER_assume(props);
+
+    bool save_pub_key = nondet_bool();
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_sign_start_keygen(&pctx, alloc, save_pub_key ? &pub_key : NULL, props) == AWS_OP_SUCCESS) {
+        /* assertion: on success, context is initialized unless no curve name was given */
+        assert((!props->impl->curve_name && !pctx) || (aws_cryptosdk_sig_ctx_is_valid_cbmc(pctx) && pctx->is_sign));
+    }
+
+    /* assertions */
+    if (save_pub_key) assert(!pub_key || aws_string_is_valid(pub_key));
+
+    /* clean up */
+    if (pctx) {
+        ec_key_unconditional_free(pctx->keypair);
+        evp_pkey_unconditional_free(pctx->pkey);
+        evp_md_ctx_shallow_free(pctx->ctx);
+    }
+    aws_mem_release(alloc, pctx);
+    if (save_pub_key) free(pub_key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_sign_start_keygen/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_encode.0:22;--object-bits;8"
+goto: aws_cryptosdk_sig_sign_start_keygen_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET +=
+
+# Added check for memory leak
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_verify_finish_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_verify_finish_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx = can_fail_malloc(sizeof(struct aws_cryptosdk_sig_ctx));
+    struct aws_string *signature      = ensure_string_is_allocated_nondet_length();
+
+    /* assumptions */
+    __CPROVER_assume(ctx);
+    ensure_sig_ctx_has_allocated_members(ctx);
+    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+    __CPROVER_assume(ctx->alloc);
+    __CPROVER_assume(!ctx->is_sign);
+    assert(aws_string_is_valid(signature));
+
+    /* saving state */
+    EC_KEY *keypair        = ctx->keypair;
+    int keypair_references = ec_key_get_reference_count(keypair);
+    EVP_PKEY *pkey         = ctx->pkey;
+    int pkey_references    = evp_pkey_get_reference_count(pkey);
+
+    /* operation under verification */
+    aws_cryptosdk_sig_verify_finish(ctx, signature);
+
+    /* clean up (necessary because we are checking for memory leaks) */
+    free(signature);
+    if (pkey_references > 2) {
+        evp_pkey_unconditional_free(pkey);
+        ec_key_unconditional_free(keypair);  // pkey holds a reference to keypair, have to free that as well
+    } else if (keypair_references > 2) {     // pkey was freed but keypair was not
+        ec_key_unconditional_free(keypair);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_sig_verify_finish_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += strcmp.0:11, aws_base64_decode.0:16
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_verify_start_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES +=	$(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_verify_start_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_string *pub_key  = ensure_string_is_allocated_bounded_length(MAX_PUBKEY_SIZE);
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assumptions */
+    __CPROVER_assume(props);
+    assert(aws_string_is_valid(pub_key));
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_verify_start(&ctx, alloc, pub_key, props) == AWS_OP_SUCCESS) {
+        /* assertions */
+        assert((!props->impl->curve_name && !ctx) || (aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx) && !ctx->is_sign));
+    }
+
+    /* assertions */
+    assert(aws_string_is_valid(pub_key));
+
+    /* clean up */
+    if (ctx) {
+        EVP_PKEY_free(ctx->pkey);
+        EVP_MD_CTX_free(ctx->ctx);
+        EC_KEY_free(ctx->keypair);
+    }
+    aws_mem_release(alloc, ctx);
+    free(pub_key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_decode.0:16;--object-bits;8"
+goto: aws_cryptosdk_sig_verify_start_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sign_header/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sign_header/Makefile
@@ -1,0 +1,43 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += 
+
+CBMCFLAGS += 
+
+ENTRY = aws_cryptosdk_sign_header_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sign_header/aws_cryptosdk_sign_header_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sign_header/aws_cryptosdk_sign_header_harness.c
@@ -17,7 +17,6 @@
 #include <aws/cryptosdk/private/cipher.h>
 #include <make_common_data_structures.h>
 
-
 void aws_cryptosdk_sign_header_harness() {
     /* arguments */
     enum aws_cryptosdk_alg_id alg_id;
@@ -53,5 +52,4 @@ void aws_cryptosdk_sign_header_harness() {
     assert(aws_byte_buf_is_valid(&header));
     assert(aws_byte_buf_is_valid(&authtag));
     assert_byte_buf_equivalence(&header, &old_header, &old_byte_from_header);
-    
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_sign_header/aws_cryptosdk_sign_header_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sign_header/aws_cryptosdk_sign_header_harness.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+
+void aws_cryptosdk_sign_header_harness() {
+    /* arguments */
+    enum aws_cryptosdk_alg_id alg_id;
+
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    struct content_key *c_key;
+    struct aws_byte_buf authtag;
+    struct aws_byte_buf header;
+
+    /* assumptions*/
+    __CPROVER_assume(props);
+    __CPROVER_assume(
+        props->impl->cipher_ctor == EVP_aes_128_gcm || props->impl->cipher_ctor == EVP_aes_192_gcm ||
+        props->impl->cipher_ctor == EVP_aes_256_gcm);
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&authtag, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&authtag);
+    __CPROVER_assume(aws_byte_buf_is_valid(&authtag));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&header, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&header);
+    __CPROVER_assume(aws_byte_buf_is_valid(&header));
+
+    /* save current state of the data structure */
+    struct aws_byte_buf old_header = header;
+    struct store_byte_from_buffer old_byte_from_header;
+    save_byte_from_array(header.buffer, header.len, &old_byte_from_header);
+
+    aws_cryptosdk_sign_header(props, c_key, &authtag, &header);
+
+    /* assertions */
+    assert(aws_byte_buf_is_valid(&header));
+    assert(aws_byte_buf_is_valid(&authtag));
+    assert_byte_buf_equivalence(&header, &old_header, &old_byte_from_header);
+    
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sign_header/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sign_header/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_sign_header_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_verify_header/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_verify_header/Makefile
@@ -1,0 +1,43 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+UNWINDSET += 
+
+CBMCFLAGS += 
+
+ENTRY = aws_cryptosdk_verify_header_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_verify_header/aws_cryptosdk_verify_header_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_verify_header/aws_cryptosdk_verify_header_harness.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+
+void aws_cryptosdk_verify_header_harness() {
+    /* arguments */
+    enum aws_cryptosdk_alg_id alg_id;
+
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    struct content_key *c_key;
+    struct aws_byte_buf authtag;
+    struct aws_byte_buf header;
+
+    /* assumptions*/
+    __CPROVER_assume(props);
+    __CPROVER_assume(
+        props->impl->cipher_ctor == EVP_aes_128_gcm || props->impl->cipher_ctor == EVP_aes_192_gcm ||
+        props->impl->cipher_ctor == EVP_aes_256_gcm);
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&authtag, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&authtag);
+    __CPROVER_assume(aws_byte_buf_is_valid(&authtag));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&header, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&header);
+    __CPROVER_assume(aws_byte_buf_is_valid(&header));
+
+    /* save current state of the data structure */
+    struct aws_byte_buf old_header = header;
+    struct store_byte_from_buffer old_byte_from_header;
+    save_byte_from_array(header.buffer, header.len, &old_byte_from_header);
+
+    aws_cryptosdk_verify_header(props, c_key, &authtag, &header);
+
+    /* assertions */
+    assert(aws_byte_buf_is_valid(&header));
+    assert(aws_byte_buf_is_valid(&authtag));
+    assert_byte_buf_equivalence(&header, &old_header, &old_byte_from_header);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_verify_header/aws_cryptosdk_verify_header_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_verify_header/aws_cryptosdk_verify_header_harness.c
@@ -17,7 +17,6 @@
 #include <aws/cryptosdk/private/cipher.h>
 #include <make_common_data_structures.h>
 
-
 void aws_cryptosdk_verify_header_harness() {
     /* arguments */
     enum aws_cryptosdk_alg_id alg_id;

--- a/.cbmc-batch/jobs/aws_cryptosdk_verify_header/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_verify_header/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_verify_header_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -16,6 +16,8 @@
 #include <openssl/ec.h>
 #include <openssl/evp.h>
 
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/hkdf.h>
 #include <cipher_openssl.h>
 #include <ec_utils.h>
 #include <evp_utils.h>
@@ -42,5 +44,20 @@ void ensure_sig_ctx_has_allocated_members(struct aws_cryptosdk_sig_ctx *ctx) {
     } else {
         // Need to ensure consistency of reference count later by assuming ctx is valid
         evp_md_ctx_set0_evp_pkey(ctx->ctx, ctx->pkey);
+    }
+}
+
+enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id alg_id) {
+    switch (alg_id) {
+        case ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384:
+        case ALG_AES192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384: return AWS_CRYPTOSDK_SHA384;
+        case ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256:
+        case ALG_AES256_GCM_IV12_TAG16_HKDF_SHA256:
+        case ALG_AES192_GCM_IV12_TAG16_HKDF_SHA256:
+        case ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256: return AWS_CRYPTOSDK_SHA256;
+        case ALG_AES256_GCM_IV12_TAG16_NO_KDF:
+        case ALG_AES192_GCM_IV12_TAG16_NO_KDF:
+        case ALG_AES128_GCM_IV12_TAG16_NO_KDF:
+        default: return AWS_CRYPTOSDK_NOSHA;
     }
 }

--- a/.cbmc-batch/source/openssl/bio_override.c
+++ b/.cbmc-batch/source/openssl/bio_override.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <proof_helpers/proof_allocators.h>
+
+/* Abstraction of the BIO struct */
+
+struct bio_st {    
+    size_t public_key_len;
+};
+
+/*
+* Decription: BIO_new_mem_buf() creates a memory BIO using len bytes of data at buf, if len is -1 then the buf is 
+* assumed to be null terminated and its length is determined by strlen. The BIO is set to a read only state and as a result
+* cannot be written to. This is useful when some data needs to be made available from a static area of memory in the form of a BIO.
+* The supplied data is read directly from the supplied buffer: it is not copied first, so the supplied area of memory must
+* be unchanged until the BIO is freed.
+*/
+BIO *BIO_new_mem_buf(const void *buf, signed int len){
+    BIO *bio = can_fail_malloc(sizeof(BIO));
+    if (bio){
+    	bio->public_key_len = len;
+	}
+    return bio;
+}
+
+/*
+* The PUBKEY functions process a public key using an EVP_PKEY structure. The public key is encoded as a SubjectPublicKeyInfo structure.
+*/
+EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x,
+                                        pem_password_cb *cb, void *u){
+	 x = EVP_PKEY_new();
+	 return x;
+
+}
+
+/*
+* BIO_free() frees up a single BIO, BIO_vfree() also frees up a single BIO but it does not return a value.
+* If a is NULL nothing is done. Calling BIO_free() may also have some effect on the underlying I/O structure, 
+* for example it may close the file being referred to under certain circumstances. For more details see the individual 
+* BIO_METHOD descriptions.
+*/
+int BIO_free(BIO *a){
+	if (a != NULL){
+		free(a);
+	}
+
+}

--- a/.cbmc-batch/source/openssl/bio_override.c
+++ b/.cbmc-batch/source/openssl/bio_override.c
@@ -20,7 +20,7 @@
 /* Abstraction of the BIO struct */
 
 struct bio_st {    
-    size_t public_key_len;
+    size_t key_len;
 };
 
 /*
@@ -33,7 +33,7 @@ struct bio_st {
 BIO *BIO_new_mem_buf(const void *buf, signed int len){
     BIO *bio = can_fail_malloc(sizeof(BIO));
     if (bio){
-    	bio->public_key_len = len;
+    	bio->key_len = len;
 	}
     return bio;
 }
@@ -46,6 +46,15 @@ EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x,
 	 x = EVP_PKEY_new();
 	 return x;
 
+}
+
+/*
+* Read a private key from a BIO. 
+*/
+EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x,
+                                   pem_password_cb *cb, void *u){
+ 	x = EVP_PKEY_new();
+ 	return x;
 }
 
 /*

--- a/.cbmc-batch/source/openssl/bio_override.c
+++ b/.cbmc-batch/source/openssl/bio_override.c
@@ -19,53 +19,50 @@
 
 /* Abstraction of the BIO struct */
 
-struct bio_st {    
+struct bio_st {
     size_t key_len;
 };
 
 /*
-* Decription: BIO_new_mem_buf() creates a memory BIO using len bytes of data at buf, if len is -1 then the buf is 
-* assumed to be null terminated and its length is determined by strlen. The BIO is set to a read only state and as a result
-* cannot be written to. This is useful when some data needs to be made available from a static area of memory in the form of a BIO.
-* The supplied data is read directly from the supplied buffer: it is not copied first, so the supplied area of memory must
-* be unchanged until the BIO is freed.
-*/
-BIO *BIO_new_mem_buf(const void *buf, signed int len){
+ * Decription: BIO_new_mem_buf() creates a memory BIO using len bytes of data at buf, if len is -1 then the buf is
+ * assumed to be null terminated and its length is determined by strlen. The BIO is set to a read only state and as a
+ * result cannot be written to. This is useful when some data needs to be made available from a static area of memory in
+ * the form of a BIO. The supplied data is read directly from the supplied buffer: it is not copied first, so the
+ * supplied area of memory must be unchanged until the BIO is freed.
+ */
+BIO *BIO_new_mem_buf(const void *buf, signed int len) {
     BIO *bio = can_fail_malloc(sizeof(BIO));
-    if (bio){
-    	bio->key_len = len;
-	}
+    if (bio) {
+        bio->key_len = len;
+    }
     return bio;
 }
 
 /*
-* The PUBKEY functions process a public key using an EVP_PKEY structure. The public key is encoded as a SubjectPublicKeyInfo structure.
-*/
-EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x,
-                                        pem_password_cb *cb, void *u){
-	 x = EVP_PKEY_new();
-	 return x;
-
+ * The PUBKEY functions process a public key using an EVP_PKEY structure. The public key is encoded as a
+ * SubjectPublicKeyInfo structure.
+ */
+EVP_PKEY *PEM_read_bio_PUBKEY(BIO *bp, EVP_PKEY **x, pem_password_cb *cb, void *u) {
+    x = EVP_PKEY_new();
+    return x;
 }
 
 /*
-* Read a private key from a BIO. 
-*/
-EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x,
-                                   pem_password_cb *cb, void *u){
- 	x = EVP_PKEY_new();
- 	return x;
+ * Read a private key from a BIO.
+ */
+EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb, void *u) {
+    x = EVP_PKEY_new();
+    return x;
 }
 
 /*
-* BIO_free() frees up a single BIO, BIO_vfree() also frees up a single BIO but it does not return a value.
-* If a is NULL nothing is done. Calling BIO_free() may also have some effect on the underlying I/O structure, 
-* for example it may close the file being referred to under certain circumstances. For more details see the individual 
-* BIO_METHOD descriptions.
-*/
-int BIO_free(BIO *a){
-	if (a != NULL){
-		free(a);
-	}
-
+ * BIO_free() frees up a single BIO, BIO_vfree() also frees up a single BIO but it does not return a value.
+ * If a is NULL nothing is done. Calling BIO_free() may also have some effect on the underlying I/O structure,
+ * for example it may close the file being referred to under certain circumstances. For more details see the individual
+ * BIO_METHOD descriptions.
+ */
+int BIO_free(BIO *a) {
+    if (a != NULL) {
+        free(a);
+    }
 }

--- a/.cbmc-batch/source/openssl/ec_override.c
+++ b/.cbmc-batch/source/openssl/ec_override.c
@@ -469,6 +469,20 @@ size_t max_encryption_size() {
     return encryption_size;
 }
 
+static size_t decryption_size;
+
+void initialize_max_decryption_size() {
+    size_t size;
+    // At different times, this value is stored in a size_t, a long and an int
+    __CPROVER_assume(0 < size && size <= INT_MAX);
+    encryption_size = size;
+}
+
+size_t max_decryption_size() {
+    return encryption_size;
+}
+
+
 /* Writes arbitrary data into the buffer out. */
 void write_unconstrained_data(unsigned char *out, size_t len) {
     assert(AWS_MEM_IS_WRITABLE(out, len));

--- a/.cbmc-batch/source/openssl/ec_override.c
+++ b/.cbmc-batch/source/openssl/ec_override.c
@@ -456,6 +456,19 @@ size_t max_derivation_size() {
     return derivation_size;
 }
 
+static size_t encryption_size;
+
+void initialize_max_encryption_size() {
+    size_t size;
+    // At different times, this value is stored in a size_t, a long and an int
+    __CPROVER_assume(0 < size && size <= INT_MAX);
+    encryption_size = size;
+}
+
+size_t max_encryption_size() {
+    return encryption_size;
+}
+
 /* Writes arbitrary data into the buffer out. */
 void write_unconstrained_data(unsigned char *out, size_t len) {
     assert(AWS_MEM_IS_WRITABLE(out, len));

--- a/.cbmc-batch/source/openssl/ec_override.c
+++ b/.cbmc-batch/source/openssl/ec_override.c
@@ -443,6 +443,19 @@ size_t max_signature_size() {
     return signature_size;
 }
 
+static size_t derivation_size;
+
+void initialize_max_derivation_size() {
+    size_t size;
+    // At different times, this value is stored in a size_t, a long and an int
+    __CPROVER_assume(0 < size && size <= INT_MAX);
+    derivation_size = size;
+}
+
+size_t max_derivation_size() {
+    return derivation_size;
+}
+
 /* Writes arbitrary data into the buffer out. */
 void write_unconstrained_data(unsigned char *out, size_t len) {
     assert(AWS_MEM_IS_WRITABLE(out, len));

--- a/.cbmc-batch/source/openssl/ec_override.c
+++ b/.cbmc-batch/source/openssl/ec_override.c
@@ -482,7 +482,6 @@ size_t max_decryption_size() {
     return encryption_size;
 }
 
-
 /* Writes arbitrary data into the buffer out. */
 void write_unconstrained_data(unsigned char *out, size_t len) {
     assert(AWS_MEM_IS_WRITABLE(out, len));

--- a/.cbmc-batch/source/openssl/err_override.c
+++ b/.cbmc-batch/source/openssl/err_override.c
@@ -19,6 +19,6 @@ void ERR_print_errors_fp(FILE *fp) {
     assert(fp == stderr);
 }
 
-signed int ERR_get_error(){
-	return 0;
+signed int ERR_get_error() {
+    return 0;
 }

--- a/.cbmc-batch/source/openssl/err_override.c
+++ b/.cbmc-batch/source/openssl/err_override.c
@@ -18,3 +18,7 @@
 void ERR_print_errors_fp(FILE *fp) {
     assert(fp == stderr);
 }
+
+signed int ERR_get_error(){
+	return 0;
+}

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -13,23 +13,21 @@
  * permissions and limitations under the License.
  */
 
-#include <openssl/evp.h>
-#include <openssl/kdf.h>
-#include <openssl/hmac.h>
-#include <openssl/rsa.h>
 #include <ec_utils.h>
 #include <make_common_data_structures.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/kdf.h>
+#include <openssl/rsa.h>
 #include <proof_helpers/nondet.h>
 
-#define DEFAULT_IV_LEN 12  // For GCM AES and OCB AES the default is 12 (i.e. 96 bits).
+#define DEFAULT_IV_LEN 12       // For GCM AES and OCB AES the default is 12 (i.e. 96 bits).
 #define DEFAULT_BLOCK_SIZE 128  // For GCM AES, the default block size is 128
-
 
 /* Abstraction of the EVP_PKEY struct */
 struct evp_pkey_st {
     int references;
     EC_KEY *ec_key;
-
 };
 
 /*
@@ -49,10 +47,10 @@ EVP_PKEY *EVEVP_EncryptInit_exP_PKEY_new() {
 }
 
 /*
-* Decription: The EVP_PKEY_new() function allocates an empty EVP_PKEY structure which is used by OpenSSL to store public 
-* and private keys. The reference count is set to 1.
-*/
-EVP_PKEY *EVP_PKEY_new(void){
+ * Decription: The EVP_PKEY_new() function allocates an empty EVP_PKEY structure which is used by OpenSSL to store
+ * public and private keys. The reference count is set to 1.
+ */
+EVP_PKEY *EVP_PKEY_new(void) {
     EVP_PKEY *pkey = can_fail_malloc(sizeof(EVP_PKEY));
     if (pkey) {
         pkey->references = 1;
@@ -281,11 +279,11 @@ int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen) {
 }
 
 /*
-* The EVP_PKEY_encrypt_init() function initializes a public key algorithm context using key pkey for an encryption operation.
-* EVP_PKEY_encrypt_init() and EVP_PKEY_encrypt() return 1 for success and 0 or a negative value for failure. 
-* In particular a return value of -2 indicates the operation is not supported by the public key algorithm.
-*/
-int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx){
+ * The EVP_PKEY_encrypt_init() function initializes a public key algorithm context using key pkey for an encryption
+ * operation. EVP_PKEY_encrypt_init() and EVP_PKEY_encrypt() return 1 for success and 0 or a negative value for failure.
+ * In particular a return value of -2 indicates the operation is not supported by the public key algorithm.
+ */
+int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx) {
     assert(ctx != NULL);
     assert(ctx->pkey != NULL);
     if (nondet_bool()) {
@@ -297,13 +295,12 @@ int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx){
     return rv;
 }
 
-
 /*
-* The EVP_PKEY_decrypt_init() function initializes a public key algorithm context using key pkey for a decryption operation.
-* EVP_PKEY_decrypt_init() and EVP_PKEY_decrypt() return 1 for success and 0 or a negative value for failure. 
-* In particular a return value of -2 indicates the operation is not supported by the public key algorithm.
-*/
-int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx){
+ * The EVP_PKEY_decrypt_init() function initializes a public key algorithm context using key pkey for a decryption
+ * operation. EVP_PKEY_decrypt_init() and EVP_PKEY_decrypt() return 1 for success and 0 or a negative value for failure.
+ * In particular a return value of -2 indicates the operation is not supported by the public key algorithm.
+ */
+int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx) {
     assert(ctx != NULL);
     assert(ctx->pkey != NULL);
     if (nondet_bool()) {
@@ -313,22 +310,21 @@ int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx){
     int rv;
     __CPROVER_assume(rv <= 0);
     return rv;
-
 }
 
-
 /*
-* The macro EVP_PKEY_CTX_set_rsa_padding() sets the RSA padding mode for ctx. The pad parameter can take the value 
-* RSA_PKCS1_PADDING for PKCS#1 padding, RSA_SSLV23_PADDING for SSLv23 padding, RSA_NO_PADDING for no padding,
-* RSA_PKCS1_OAEP_PADDING for OAEP padding (encrypt and decrypt only), RSA_X931_PADDING for X9.31 padding (signature operations only)
-* and RSA_PKCS1_PSS_PADDING (sign and verify only).
-*
-*/
-int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad){
+ * The macro EVP_PKEY_CTX_set_rsa_padding() sets the RSA padding mode for ctx. The pad parameter can take the value
+ * RSA_PKCS1_PADDING for PKCS#1 padding, RSA_SSLV23_PADDING for SSLv23 padding, RSA_NO_PADDING for no padding,
+ * RSA_PKCS1_OAEP_PADDING for OAEP padding (encrypt and decrypt only), RSA_X931_PADDING for X9.31 padding (signature
+ * operations only) and RSA_PKCS1_PSS_PADDING (sign and verify only).
+ *
+ */
+int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad) {
     assert(ctx != NULL);
-    assert(pad == RSA_PKCS1_PADDING || pad == RSA_SSLV23_PADDING || pad == RSA_NO_PADDING || pad == RSA_PKCS1_OAEP_PADDING || 
-        pad == RSA_X931_PADDING || pad == RSA_PKCS1_PSS_PADDING);
-    if (pad == RSA_X931_PADDING){
+    assert(
+        pad == RSA_PKCS1_PADDING || pad == RSA_SSLV23_PADDING || pad == RSA_NO_PADDING ||
+        pad == RSA_PKCS1_OAEP_PADDING || pad == RSA_X931_PADDING || pad == RSA_PKCS1_PSS_PADDING);
+    if (pad == RSA_X931_PADDING) {
         assert(ctx->is_initialized_for_signing);
     }
     ctx->rsa_pad = pad;
@@ -337,11 +333,11 @@ int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad){
     return rv;
 }
 /*
-* The EVP_PKEY_CTX_set_rsa_oaep_md() macro sets the message digest type used in RSA OAEP to md. 
-* The padding mode must have been set to RSA_PKCS1_OAEP_PADDING.
-*/
-int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md){
-    assert(ctx!= NULL);
+ * The EVP_PKEY_CTX_set_rsa_oaep_md() macro sets the message digest type used in RSA OAEP to md.
+ * The padding mode must have been set to RSA_PKCS1_OAEP_PADDING.
+ */
+int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) {
+    assert(ctx != NULL);
     assert(ctx->rsa_pad == RSA_PKCS1_OAEP_PADDING);
     int rv;
     __CPROVER_assume(rv == 0 || rv == 1);
@@ -349,29 +345,27 @@ int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md){
 }
 
 /*
-* The EVP_PKEY_CTX_set_rsa_mgf1_md() macro sets the MGF1 digest for RSA padding schemes to md.
-* If not explicitly set the signing digest is used. The padding mode must have been set to RSA_PKCS1_OAEP_PADDING or 
-* RSA_PKCS1_PSS_PADDING.
-*/
-int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md){
-    assert(ctx!= NULL);
+ * The EVP_PKEY_CTX_set_rsa_mgf1_md() macro sets the MGF1 digest for RSA padding schemes to md.
+ * If not explicitly set the signing digest is used. The padding mode must have been set to RSA_PKCS1_OAEP_PADDING or
+ * RSA_PKCS1_PSS_PADDING.
+ */
+int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md) {
+    assert(ctx != NULL);
     assert(ctx->rsa_pad == RSA_PKCS1_OAEP_PADDING || ctx->rsa_pad == RSA_PKCS1_PSS_PADDING);
     int rv;
     __CPROVER_assume(rv == 0 || rv == 1);
     return rv;
- }
+}
 
 /*
-* The EVP_PKEY_encrypt() function performs a public key encryption operation using ctx.
-* The data to be encrypted is specified using the in and inlen parameters. If out is NULL then the maximum size of the
-* output buffer is written to the outlen parameter. If out is not NULL then before the call the outlen parameter should 
-* contain the length of the out buffer, if the call is successful the encrypted data is written to out and the amount of
-* data written to outlen.
-*/
-int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
-                        unsigned char *out, size_t *outlen,
-                        const unsigned char *in, size_t inlen){
-    assert(ctx!= NULL);
+ * The EVP_PKEY_encrypt() function performs a public key encryption operation using ctx.
+ * The data to be encrypted is specified using the in and inlen parameters. If out is NULL then the maximum size of the
+ * output buffer is written to the outlen parameter. If out is not NULL then before the call the outlen parameter should
+ * contain the length of the out buffer, if the call is successful the encrypted data is written to out and the amount
+ * of data written to outlen.
+ */
+int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen) {
+    assert(ctx != NULL);
     // Encyption size is nondeterministic but fixed. See ec_override.c for details.
     size_t max_required_size = max_encryption_size();
 
@@ -394,14 +388,12 @@ int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
 }
 
 /*
-* The EVP_PKEY_decrypt() function performs a public key decryption operation using ctx. The data to be decrypted is 
-* specified using the in and inlen parameters. If out is NULL then the maximum size of the output buffer is written to
-* the outlen parameter. If out is not NULL then before the call the outlen parameter should contain the length of the 
-* out buffer, if the call is successful the decrypted data is written to out and the amount of data written to outlen.
-*/
-int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
-                        unsigned char *out, size_t *outlen,
-                        const unsigned char *in, size_t inlen){
+ * The EVP_PKEY_decrypt() function performs a public key decryption operation using ctx. The data to be decrypted is
+ * specified using the in and inlen parameters. If out is NULL then the maximum size of the output buffer is written to
+ * the outlen parameter. If out is not NULL then before the call the outlen parameter should contain the length of the
+ * out buffer, if the call is successful the decrypted data is written to out and the amount of data written to outlen.
+ */
+int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen) {
     assert(ctx != NULL);
     // Decryption size is nondeterministic but fixed. See ec_override.c for details.
     size_t max_required_size = max_decryption_size();
@@ -422,20 +414,16 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
     }
 
     return 1;
-
- }
-
-/*
-*EVP_PKEY_CTX_free() frees up the context ctx. If ctx is NULL, nothing is done.
-*/
-void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx){
-    if (ctx){
-        free(ctx);
-    }
-
 }
 
-
+/*
+ *EVP_PKEY_CTX_free() frees up the context ctx. If ctx is NULL, nothing is done.
+ */
+void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx) {
+    if (ctx) {
+        free(ctx);
+    }
+}
 
 enum evp_aes { EVP_AES_128_GCM, EVP_AES_192_GCM, EVP_AES_256_GCM };
 
@@ -472,7 +460,7 @@ struct evp_cipher_ctx_st {
     bool iv_set;          // boolean marks if iv has been set. Default:false.
     bool padding;         // boolean marks if padding is enabled. Default:true.
     bool data_processed;  // boolean marks if has encrypt/decrypt final has been called. Default:false.
-    int data_remaining; //how much is left to be encrypted/decrypted. Default: 0. 
+    int data_remaining;   // how much is left to be encrypted/decrypted. Default: 0.
 };
 
 /*
@@ -485,8 +473,8 @@ EVP_CIPHER_CTX *EVP_CIPHER_CTX_new() {
         cipher_ctx->iv_set         = false;
         cipher_ctx->padding        = true;
         cipher_ctx->data_processed = false;
-        cipher_ctx->data_remaining = 0; 
-        cipher_ctx->cipher = NULL;
+        cipher_ctx->data_remaining = 0;
+        cipher_ctx->cipher         = NULL;
     }
     return cipher_ctx;
 }
@@ -530,12 +518,12 @@ int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr) {
         ctx->iv_len = arg;
     }
     if (type == EVP_CTRL_GCM_GET_TAG) {
-        assert(ctx->encrypt == 1);  //only legal when encrypting data
+        assert(ctx->encrypt == 1);  // only legal when encrypting data
         assert(ctx->data_processed == true);
         AWS_MEM_IS_WRITABLE(ptr, arg);  // need to be able to write taglen (arg) bytes to buffer ptr.
     }
     if (type == EVP_CTRL_GCM_SET_TAG) {
-        assert(ctx->encrypt == 0);  //only legal when decrypting data
+        assert(ctx->encrypt == 0);      // only legal when decrypting data
         AWS_MEM_IS_WRITABLE(ptr, arg);  // need to be able to write taglen (arg) bytes to buffer ptr.
     }
     int rv;
@@ -555,31 +543,30 @@ void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx) {
 }
 
 /*
-* EVP_EncryptInit_ex() sets up cipher context ctx for encryption with cipher type from ENGINE impl.
-* ctx must be created before calling this function. type is normally supplied by a function such as EVP_aes_256_cbc().
-* If impl is NULL then the default implementation is used. key is the symmetric key to use and iv is the IV to use (if necessary), 
-* the actual number of bytes used for the key and IV depends on the cipher. It is possible to set all parameters to NULL except 
-* type in an initial call and supply the remaining parameters in subsequent calls, all of which have type set to NULL. 
-* This is done when the default cipher parameters are not appropriate.
-*/
-int EVP_EncryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
-                        ENGINE *impl, const unsigned char *key, const unsigned char *iv){
+ * EVP_EncryptInit_ex() sets up cipher context ctx for encryption with cipher type from ENGINE impl.
+ * ctx must be created before calling this function. type is normally supplied by a function such as EVP_aes_256_cbc().
+ * If impl is NULL then the default implementation is used. key is the symmetric key to use and iv is the IV to use (if
+ * necessary), the actual number of bytes used for the key and IV depends on the cipher. It is possible to set all
+ * parameters to NULL except type in an initial call and supply the remaining parameters in subsequent calls, all of
+ * which have type set to NULL. This is done when the default cipher parameters are not appropriate.
+ */
+int EVP_EncryptInit_ex(
+    EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv) {
     assert(ctx != NULL);
-    assert(type!= NULL);
+    assert(type != NULL);
     ctx->encrypt = 1;
     int rv;
     __CPROVER_assume(rv == 0 || rv == 1);
     return rv;
-
 }
 
 /*
-* EVP_DecryptInit_ex() is the corresponding decryption operation. 
-*/
-int EVP_DecryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
-         ENGINE *impl, const unsigned char *key, const unsigned char *iv){
+ * EVP_DecryptInit_ex() is the corresponding decryption operation.
+ */
+int EVP_DecryptInit_ex(
+    EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv) {
     assert(ctx != NULL);
-    assert(type!= NULL);
+    assert(type != NULL);
     ctx->encrypt = 0;
     int rv;
     __CPROVER_assume(rv == 0 || rv == 1);
@@ -591,8 +578,8 @@ int EVP_DecryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
  * or encryption. The operation performed depends on the value of the enc parameter. It should be set to 1 for
  * encryption, 0 for decryption and -1 to leave the value unchanged (the actual value of 'enc' being supplied in a
  * previous call). Return 1 for success and 0 for failure.
- * To specify any additional authenticated data (AAD) a call to EVP_CipherUpdate(), EVP_EncryptUpdate() or EVP_DecryptUpdate() 
- * should be made with the output parameter out set to NULL.
+ * To specify any additional authenticated data (AAD) a call to EVP_CipherUpdate(), EVP_EncryptUpdate() or
+ * EVP_DecryptUpdate() should be made with the output parameter out set to NULL.
  */
 int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) {
     assert(ctx != NULL);
@@ -614,16 +601,15 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
     assert(ctx->data_processed == false);
     int rv;
     __CPROVER_assume(rv == 0 || rv == 1);
-    if (out == NULL){ //specifying aad
-        return rv;   
+    if (out == NULL) {  // specifying aad
+        return rv;
     }
     size_t out_size;
     __CPROVER_assume(out_size >= 0);
-    if (ctx->cipher){
-        __CPROVER_assume(out_size <= inl + DEFAULT_BLOCK_SIZE - 1); 
-    }
-    else{
-        __CPROVER_assume(out_size <= inl); 
+    if (ctx->cipher) {
+        __CPROVER_assume(out_size <= inl + DEFAULT_BLOCK_SIZE - 1);
+    } else {
+        __CPROVER_assume(out_size <= inl);
         ctx->data_remaining = inl - out_size;
     }
     assert(AWS_MEM_IS_WRITABLE(out, out_size));
@@ -641,23 +627,22 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
 int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) {
     assert(ctx != NULL);
     assert(ctx->data_processed == false);
-     int rv;
+    int rv;
     __CPROVER_assume(rv == 0 || rv == 1);
-    if (out == NULL){ //specifying aad
-        return rv;   
+    if (out == NULL) {  // specifying aad
+        return rv;
     }
     size_t out_size;
     __CPROVER_assume(out_size >= 0);
-    if (ctx->cipher){
-        if (ctx->padding){
+    if (ctx->cipher) {
+        if (ctx->padding) {
             __CPROVER_assume(out_size <= inl + DEFAULT_BLOCK_SIZE);
-        } 
-    }
-    else{
-        __CPROVER_assume(out_size <= inl); 
+        }
+    } else {
+        __CPROVER_assume(out_size <= inl);
         ctx->data_remaining = inl - out_size;
     }
-    assert(AWS_MEM_IS_WRITABLE(out,out_size));
+    assert(AWS_MEM_IS_WRITABLE(out, out_size));
     *outl = out_size;
     return rv;
 }
@@ -909,52 +894,57 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t sigl
     return nondet_int();
 }
 
-/* Abstraction of the HMAC_CTX struct has been moved to hmcac.h*/ 
+/* Abstraction of the HMAC_CTX struct has been moved to hmcac.h*/
 
-/* 
-* Description: HMAC_CTX_init() initialises a HMAC_CTX before first use. It must be called.
-*/
-void HMAC_CTX_init(HMAC_CTX *ctx){
-    HMAC_CTX *ctx_new = can_fail_malloc(sizeof(HMAC_CTX));
-    __CPROVER_assume(ctx_new); //cannot be null
-    ctx_new->is_initialized = true;
-    ctx_new->md = malloc(sizeof(EVP_MD));
-    *ctx = *ctx_new;
- }
-
- /*
-HMAC() computes the message authentication code of the n bytes at d using the hash function evp_md and the 
-key key which is key_len bytes long.
-It places the result in md (which must have space for the output of the hash function, 
-which is no more than EVP_MAX_MD_SIZE bytes). If md is NULL, the digest is placed in a static array. 
-The size of the output is placed in md_len, unless it is NULL. 
-Note: passing a NULL value for md to use the static array is not thread safe.
+/*
+ * Description: HMAC_CTX_init() initialises a HMAC_CTX before first use. It must be called.
  */
+void HMAC_CTX_init(HMAC_CTX *ctx) {
+    HMAC_CTX *ctx_new = can_fail_malloc(sizeof(HMAC_CTX));
+    __CPROVER_assume(ctx_new);  // cannot be null
+    ctx_new->is_initialized = true;
+    ctx_new->md             = malloc(sizeof(EVP_MD));
+    *ctx                    = *ctx_new;
+}
 
-unsigned char *HMAC(const EVP_MD *evp_md, const void *key, int key_len,
-                    const unsigned char *d, size_t n, unsigned char *md,
-                    unsigned int *md_len){
+/*
+HMAC() computes the message authentication code of the n bytes at d using the hash function evp_md and the
+key key which is key_len bytes long.
+It places the result in md (which must have space for the output of the hash function,
+which is no more than EVP_MAX_MD_SIZE bytes). If md is NULL, the digest is placed in a static array.
+The size of the output is placed in md_len, unless it is NULL.
+Note: passing a NULL value for md to use the static array is not thread safe.
+*/
+
+unsigned char *HMAC(
+    const EVP_MD *evp_md,
+    const void *key,
+    int key_len,
+    const unsigned char *d,
+    size_t n,
+    unsigned char *md,
+    unsigned int *md_len) {
     assert(evp_md != NULL);
-    size_t amount_of_data_written; 
+    size_t amount_of_data_written;
     __CPROVER_assume(amount_of_data_written <= EVP_MAX_MD_SIZE);
-    if (md != NULL){
+    if (md != NULL) {
         write_unconstrained_data(md, amount_of_data_written);
         *md_len = amount_of_data_written;
         return md;
     }
-    //create a static array to return the result 
-    unsigned char *res = malloc( sizeof(unsigned char) * ( amount_of_data_written + 1 ) );
+    // create a static array to return the result
+    unsigned char *res = malloc(sizeof(unsigned char) * (amount_of_data_written + 1));
     write_unconstrained_data(res, amount_of_data_written);
     return res;
-
-
 }
 
 /*
-* HMAC_Init_ex() initializes or reuses a HMAC_CTX structure to use the hash function evp_md and key key. 
-* If both are NULL (or evp_md is the same as the previous digest used by ctx and key is NULL) the existing key is reused. 
-* ctx must have been created with HMAC_CTX_new() before the first use of an HMAC_CTX in this function. 
-* N.B. HMAC_Init() had this undocumented behaviour in previous versions of OpenSSL - failure to switch to HMAC_Init_ex() in 
+* HMAC_Init_ex() initializes or reuses a HMAC_CTX structure to use the hash function evp_md and key key.
+* If both are NULL (or evp_md is the same as the previous digest used by ctx and key is NULL) the existing key is
+reused.
+* ctx must have been created with HMAC_CTX_new() before the first use of an HMAC_CTX in this function.
+* N.B. HMAC_Init() had this undocumented behaviour in previous versions of OpenSSL - failure to switch to HMAC_Init_ex()
+in
 * programs that expect it will cause them to stop working.
 
 * NB: if HMAC_Init_ex() is called with key NULL and evp_md is not the same as the previous digest used by ctx then an
@@ -962,11 +952,10 @@ unsigned char *HMAC(const EVP_MD *evp_md, const void *key, int key_len,
 *
 * Return 1 for success or 0 if an error occurred.
 */
-int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
-                            const EVP_MD *md, ENGINE *impl){
+int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len, const EVP_MD *md, ENGINE *impl) {
     assert(hmac_ctx_is_valid(ctx));
-    if (md != NULL){
-        if (key != NULL){
+    if (md != NULL) {
+        if (key != NULL) {
             ctx->md = md;
         }
     }
@@ -976,24 +965,20 @@ int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
 }
 
 /*
-* HMAC_Update() can be called repeatedly with chunks of the message to be authenticated (len bytes at data).
-* Return 1 for success or 0 if an error occurred.
-*/
-int HMAC_Update(HMAC_CTX *ctx, const unsigned char *data,
-                           size_t len){
+ * HMAC_Update() can be called repeatedly with chunks of the message to be authenticated (len bytes at data).
+ * Return 1 for success or 0 if an error occurred.
+ */
+int HMAC_Update(HMAC_CTX *ctx, const unsigned char *data, size_t len) {
     assert(hmac_ctx_is_valid(ctx));
     int rv;
     __CPROVER_assume(rv == 1 || rv == 0);
     return rv;
-
 }
 
 /*
-*HMAC_Final() places the message authentication code in md, which must have space for the hash function output.
-*/
-int HMAC_Final(HMAC_CTX *ctx, unsigned char *md,
-                          unsigned int *len){
-
+ *HMAC_Final() places the message authentication code in md, which must have space for the hash function output.
+ */
+int HMAC_Final(HMAC_CTX *ctx, unsigned char *md, unsigned int *len) {
     assert(hmac_ctx_is_valid(ctx));
     assert(ctx->md != NULL);
     int md_size = EVP_MD_size(ctx->md);
@@ -1001,7 +986,7 @@ int HMAC_Final(HMAC_CTX *ctx, unsigned char *md,
     *len = md_size;
     int rv;
     __CPROVER_assume(rv == 1 || rv == 0);
-    __CPROVER_assume(AWS_MEM_IS_READABLE(md,md_size));
+    __CPROVER_assume(AWS_MEM_IS_READABLE(md, md_size));
     return rv;
 }
 

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -16,6 +16,7 @@
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
 #include <openssl/hmac.h>
+#include <openssl/rsa.h>
 #include <ec_utils.h>
 #include <make_common_data_structures.h>
 #include <proof_helpers/nondet.h>
@@ -28,6 +29,7 @@
 struct evp_pkey_st {
     int references;
     EC_KEY *ec_key;
+
 };
 
 /*
@@ -43,6 +45,19 @@ EVP_PKEY *EVEVP_EncryptInit_exP_PKEY_new() {
         pkey->ec_key     = NULL;
     }
 
+    return pkey;
+}
+
+/*
+* Decription: The EVP_PKEY_new() function allocates an empty EVP_PKEY structure which is used by OpenSSL to store public 
+* and private keys. The reference count is set to 1.
+*/
+EVP_PKEY *EVP_PKEY_new(void){
+    EVP_PKEY *pkey = can_fail_malloc(sizeof(EVP_PKEY));
+    if (pkey) {
+        pkey->references = 1;
+        pkey->ec_key     = NULL;
+    }
     return pkey;
 }
 
@@ -91,6 +106,8 @@ void EVP_PKEY_free(EVP_PKEY *pkey) {
 struct evp_pkey_ctx_st {
     bool is_initialized_for_signing;
     bool is_initialized_for_derivation;
+    bool is_initialized_for_encryption;
+    int rsa_pad;
     EVP_PKEY *pkey;
 };
 
@@ -108,6 +125,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e) {
     if (ctx) {
         ctx->is_initialized_for_signing    = false;
         ctx->is_initialized_for_derivation = false;
+        ctx->is_initialized_for_encryption = false;
         ctx->pkey                          = pkey;
         pkey->references += 1;
     }
@@ -129,6 +147,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e) {
     if (ctx) {
         ctx->is_initialized_for_signing    = false;
         ctx->is_initialized_for_derivation = false;
+        ctx->is_initialized_for_encryption = false;
         ctx->pkey                          = NULL;
     }
 
@@ -259,14 +278,109 @@ int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen) {
 }
 
 /*
- * Description: EVP_PKEY_CTX_free() frees up the context ctx. If ctx is NULL, nothing is done.
- */
-void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx) {
-    if (ctx) {
-        EVP_PKEY_free(ctx->pkey);
+* The EVP_PKEY_encrypt_init() function initializes a public key algorithm context using key pkey for an encryption operation.
+* EVP_PKEY_encrypt_init() and EVP_PKEY_encrypt() return 1 for success and 0 or a negative value for failure. 
+* In particular a return value of -2 indicates the operation is not supported by the public key algorithm.
+*/
+int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx){
+    assert(ctx != NULL);
+    assert(ctx->pkey != NULL);
+    if (nondet_bool()) {
+        ctx->is_initialized_for_encryption = true;
+        return 1;
+    }
+    int rv;
+    __CPROVER_assume(rv <= 0);
+    return rv;
+}
+
+/*
+* The macro EVP_PKEY_CTX_set_rsa_padding() sets the RSA padding mode for ctx. The pad parameter can take the value 
+* RSA_PKCS1_PADDING for PKCS#1 padding, RSA_SSLV23_PADDING for SSLv23 padding, RSA_NO_PADDING for no padding,
+* RSA_PKCS1_OAEP_PADDING for OAEP padding (encrypt and decrypt only), RSA_X931_PADDING for X9.31 padding (signature operations only)
+* and RSA_PKCS1_PSS_PADDING (sign and verify only).
+*
+*/
+int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad){
+    assert(ctx != NULL);
+    assert(pad == RSA_PKCS1_PADDING || pad == RSA_SSLV23_PADDING || pad == RSA_NO_PADDING || pad == RSA_PKCS1_OAEP_PADDING || 
+        pad == RSA_X931_PADDING || pad == RSA_PKCS1_PSS_PADDING);
+    if (pad == RSA_X931_PADDING){
+        assert(ctx->is_initialized_for_signing);
+    }
+    ctx->rsa_pad = pad;
+    int rv;
+    __CPROVER_assume(rv == 0 || rv == 1);
+    return rv;
+}
+/*
+* The EVP_PKEY_CTX_set_rsa_oaep_md() macro sets the message digest type used in RSA OAEP to md. 
+* The padding mode must have been set to RSA_PKCS1_OAEP_PADDING.
+*/
+int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md){
+    assert(ctx!= NULL);
+    assert(ctx->rsa_pad == RSA_PKCS1_OAEP_PADDING);
+    int rv;
+    __CPROVER_assume(rv == 0 || rv == 1);
+    return rv;
+}
+
+/*
+* The EVP_PKEY_CTX_set_rsa_mgf1_md() macro sets the MGF1 digest for RSA padding schemes to md.
+* If not explicitly set the signing digest is used. The padding mode must have been set to RSA_PKCS1_OAEP_PADDING or 
+* RSA_PKCS1_PSS_PADDING.
+*/
+int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md){
+    assert(ctx!= NULL);
+    assert(ctx->rsa_pad == RSA_PKCS1_OAEP_PADDING || ctx->rsa_pad == RSA_PKCS1_PSS_PADDING);
+    int rv;
+    __CPROVER_assume(rv == 0 || rv == 1);
+    return rv;
+ }
+
+/*
+* The EVP_PKEY_encrypt() function performs a public key encryption operation using ctx.
+* The data to be encrypted is specified using the in and inlen parameters. If out is NULL then the maximum size of the
+* output buffer is written to the outlen parameter. If out is not NULL then before the call the outlen parameter should 
+* contain the length of the out buffer, if the call is successful the encrypted data is written to out and the amount of
+* data written to outlen.
+*/
+int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
+                        unsigned char *out, size_t *outlen,
+                        const unsigned char *in, size_t inlen){
+    assert(ctx!= NULL);
+    // Encyption size is nondeterministic but fixed. See ec_override.c for details.
+    size_t max_required_size = max_encryption_size();
+
+    if (nondet_bool()) {
+        int rv;
+        __CPROVER_assume(rv <= 0);
+        return rv;
+    }
+
+    if (!out) {
+        *outlen = max_required_size;
+    } else {
+        size_t amount_of_data_written;
+        __CPROVER_assume(amount_of_data_written <= *outlen);
+        write_unconstrained_data(out, amount_of_data_written);
+        *outlen = amount_of_data_written;
+    }
+
+    return 1;
+}
+
+/*
+*EVP_PKEY_CTX_free() frees up the context ctx. If ctx is NULL, nothing is done.
+*/
+void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx){
+    if (ctx){
         free(ctx);
     }
+
 }
+
+
 
 enum evp_aes { EVP_AES_128_GCM, EVP_AES_192_GCM, EVP_AES_256_GCM };
 
@@ -845,7 +959,7 @@ bool hmac_ctx_is_valid(HMAC_CTX *ctx) {
 
 /* Helper function for CBMC proofs: checks if EVP_PKEY is valid. */
 bool evp_pkey_is_valid(EVP_PKEY *pkey) {
-    return pkey && (pkey->references > 0) && ec_key_is_valid(pkey->ec_key);
+    return pkey && (pkey->references > 0) && (pkey->ec_key == NULL || ec_key_is_valid(pkey->ec_key));
 }
 
 /* Helper function for CBMC proofs: allocates EVP_PKEY nondeterministically. */

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -14,7 +14,8 @@
  */
 
 #include <openssl/evp.h>
-
+#include <openssl/kdf.h>
+#include <openssl/hmac.h>
 #include <ec_utils.h>
 #include <make_common_data_structures.h>
 #include <proof_helpers/nondet.h>
@@ -678,7 +679,108 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig, size_t sigl
     return nondet_int();
 }
 
+/* Abstraction of the HMAC_CTX struct has been moved to hmcac.h*/ 
+
+/* 
+* Description: HMAC_CTX_init() initialises a HMAC_CTX before first use. It must be called.
+*/
+void HMAC_CTX_init(HMAC_CTX *ctx){
+    HMAC_CTX *ctx_new = can_fail_malloc(sizeof(HMAC_CTX));
+    __CPROVER_assume(ctx_new); //cannot be null
+    ctx_new->is_initialized = true;
+    ctx_new->md = malloc(sizeof(EVP_MD));
+    *ctx = *ctx_new;
+ }
+
+ /*
+HMAC() computes the message authentication code of the n bytes at d using the hash function evp_md and the 
+key key which is key_len bytes long.
+It places the result in md (which must have space for the output of the hash function, 
+which is no more than EVP_MAX_MD_SIZE bytes). If md is NULL, the digest is placed in a static array. 
+The size of the output is placed in md_len, unless it is NULL. 
+Note: passing a NULL value for md to use the static array is not thread safe.
+ */
+
+unsigned char *HMAC(const EVP_MD *evp_md, const void *key, int key_len,
+                    const unsigned char *d, size_t n, unsigned char *md,
+                    unsigned int *md_len){
+    assert(evp_md != NULL);
+    size_t amount_of_data_written; 
+    __CPROVER_assume(amount_of_data_written <= EVP_MAX_MD_SIZE);
+    if (md != NULL){
+        write_unconstrained_data(md, amount_of_data_written);
+        *md_len = amount_of_data_written;
+        return md;
+    }
+    //create a static array to return the result 
+    unsigned char *res = malloc( sizeof(unsigned char) * ( amount_of_data_written + 1 ) );
+    write_unconstrained_data(res, amount_of_data_written);
+    return res;
+
+
+}
+
+/*
+* HMAC_Init_ex() initializes or reuses a HMAC_CTX structure to use the hash function evp_md and key key. 
+* If both are NULL (or evp_md is the same as the previous digest used by ctx and key is NULL) the existing key is reused. 
+* ctx must have been created with HMAC_CTX_new() before the first use of an HMAC_CTX in this function. 
+* N.B. HMAC_Init() had this undocumented behaviour in previous versions of OpenSSL - failure to switch to HMAC_Init_ex() in 
+* programs that expect it will cause them to stop working.
+
+* NB: if HMAC_Init_ex() is called with key NULL and evp_md is not the same as the previous digest used by ctx then an
+* error is returned because reuse of an existing key with a different digest is not supported.
+*
+* Return 1 for success or 0 if an error occurred.
+*/
+int HMAC_Init_ex(HMAC_CTX *ctx, const void *key, int len,
+                            const EVP_MD *md, ENGINE *impl){
+    assert(hmac_ctx_is_valid(ctx));
+    if (md != NULL){
+        if (key != NULL){
+            ctx->md = md;
+        }
+    }
+    int rv;
+    __CPROVER_assume(rv == 1 || rv == 0);
+    return rv;
+}
+
+/*
+* HMAC_Update() can be called repeatedly with chunks of the message to be authenticated (len bytes at data).
+* Return 1 for success or 0 if an error occurred.
+*/
+int HMAC_Update(HMAC_CTX *ctx, const unsigned char *data,
+                           size_t len){
+    assert(hmac_ctx_is_valid(ctx));
+    int rv;
+    __CPROVER_assume(rv == 1 || rv == 0);
+    return rv;
+
+}
+
+/*
+*HMAC_Final() places the message authentication code in md, which must have space for the hash function output.
+*/
+int HMAC_Final(HMAC_CTX *ctx, unsigned char *md,
+                          unsigned int *len){
+
+    assert(hmac_ctx_is_valid(ctx));
+    assert(ctx->md != NULL);
+    int md_size = EVP_MD_size(ctx->md);
+    AWS_MEM_IS_WRITABLE(md, md_size);
+    *len = md_size;
+    int rv;
+    __CPROVER_assume(rv == 1 || rv == 0);
+    __CPROVER_assume(AWS_MEM_IS_READABLE(md,md_size));
+    return rv;
+}
+
 /* CBMC helper functions */
+
+/* Helper function for CBMC proofs: checks if HMAC_CTX is valid. */
+bool hmac_ctx_is_valid(HMAC_CTX *ctx) {
+    return ctx && ctx->is_initialized;
+}
 
 /* Helper function for CBMC proofs: checks if EVP_PKEY is valid. */
 bool evp_pkey_is_valid(EVP_PKEY *pkey) {

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -107,6 +107,7 @@ struct evp_pkey_ctx_st {
     bool is_initialized_for_signing;
     bool is_initialized_for_derivation;
     bool is_initialized_for_encryption;
+    bool is_initialized_for_decryption;
     int rsa_pad;
     EVP_PKEY *pkey;
 };
@@ -126,6 +127,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e) {
         ctx->is_initialized_for_signing    = false;
         ctx->is_initialized_for_derivation = false;
         ctx->is_initialized_for_encryption = false;
+        ctx->is_initialized_for_decryption = false;
         ctx->pkey                          = pkey;
         pkey->references += 1;
     }
@@ -148,6 +150,7 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e) {
         ctx->is_initialized_for_signing    = false;
         ctx->is_initialized_for_derivation = false;
         ctx->is_initialized_for_encryption = false;
+        ctx->is_initialized_for_decryption = false;
         ctx->pkey                          = NULL;
     }
 
@@ -294,6 +297,26 @@ int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx){
     return rv;
 }
 
+
+/*
+* The EVP_PKEY_decrypt_init() function initializes a public key algorithm context using key pkey for a decryption operation.
+* EVP_PKEY_decrypt_init() and EVP_PKEY_decrypt() return 1 for success and 0 or a negative value for failure. 
+* In particular a return value of -2 indicates the operation is not supported by the public key algorithm.
+*/
+int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx){
+    assert(ctx != NULL);
+    assert(ctx->pkey != NULL);
+    if (nondet_bool()) {
+        ctx->is_initialized_for_decryption = true;
+        return 1;
+    }
+    int rv;
+    __CPROVER_assume(rv <= 0);
+    return rv;
+
+}
+
+
 /*
 * The macro EVP_PKEY_CTX_set_rsa_padding() sets the RSA padding mode for ctx. The pad parameter can take the value 
 * RSA_PKCS1_PADDING for PKCS#1 padding, RSA_SSLV23_PADDING for SSLv23 padding, RSA_NO_PADDING for no padding,
@@ -369,6 +392,38 @@ int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
 
     return 1;
 }
+
+/*
+* The EVP_PKEY_decrypt() function performs a public key decryption operation using ctx. The data to be decrypted is 
+* specified using the in and inlen parameters. If out is NULL then the maximum size of the output buffer is written to
+* the outlen parameter. If out is not NULL then before the call the outlen parameter should contain the length of the 
+* out buffer, if the call is successful the decrypted data is written to out and the amount of data written to outlen.
+*/
+int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
+                        unsigned char *out, size_t *outlen,
+                        const unsigned char *in, size_t inlen){
+    assert(ctx != NULL);
+    // Decryption size is nondeterministic but fixed. See ec_override.c for details.
+    size_t max_required_size = max_decryption_size();
+
+    if (nondet_bool()) {
+        int rv;
+        __CPROVER_assume(rv <= 0);
+        return rv;
+    }
+
+    if (!out) {
+        *outlen = max_required_size;
+    } else {
+        size_t amount_of_data_written;
+        __CPROVER_assume(amount_of_data_written <= *outlen);
+        write_unconstrained_data(out, amount_of_data_written);
+        *outlen = amount_of_data_written;
+    }
+
+    return 1;
+
+ }
 
 /*
 *EVP_PKEY_CTX_free() frees up the context ctx. If ctx is NULL, nothing is done.

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -203,7 +203,7 @@ int aws_cryptosdk_sign_header(
      */
     aws_secure_zero(iv, props->iv_len);
 
-    int result          = AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN;
+    int result = AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN;
 
     EVP_CIPHER_CTX *ctx = evp_gcm_cipher_init(props, content_key, iv, true);
     if (!ctx) goto out;

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -119,7 +119,7 @@ static EVP_CIPHER_CTX *evp_gcm_cipher_init(
     EVP_CIPHER_CTX *ctx = NULL;
 
     if (!(ctx = EVP_CIPHER_CTX_new())) goto err;
-    if (!EVP_CipherInit_ex(ctx, props->impl->cipher_ctor(), NULL, NULL, NULL, enc)) goto err;
+    if (!EVP_CipherInit_ex(ctx, props->impl->cipher_ctor(), NULL, NULL, NULL, (int)enc)) goto err;  // cast for CBMC
     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, props->iv_len, NULL)) goto err;
     if (!EVP_CipherInit_ex(ctx, NULL, NULL, content_key->keybuf, iv, -1)) goto err;
 
@@ -203,7 +203,7 @@ int aws_cryptosdk_sign_header(
      */
     aws_secure_zero(iv, props->iv_len);
 
-    int result = AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN;
+    int result          = AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN;
 
     EVP_CIPHER_CTX *ctx = evp_gcm_cipher_init(props, content_key, iv, true);
     if (!ctx) goto out;

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -412,6 +412,9 @@ int aws_cryptosdk_sig_sign_start_keygen(
     struct aws_allocator *alloc,
     struct aws_string **pub_key,
     const struct aws_cryptosdk_alg_properties *props) {
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(pctx));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(alloc));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(props));
     EC_GROUP *group = NULL;
     EC_KEY *keypair = NULL;
 
@@ -421,6 +424,8 @@ int aws_cryptosdk_sig_sign_start_keygen(
     }
 
     if (!props->impl->curve_name) {
+        AWS_POSTCONDITION(!*pctx);
+        AWS_POSTCONDITION(!pub_key || !*pub_key);
         return AWS_OP_SUCCESS;
     }
 
@@ -445,6 +450,10 @@ int aws_cryptosdk_sig_sign_start_keygen(
         goto rethrow;
     }
 
+    // If pub_key is NULL the conversion form is never set, and so it differs between the EC_KEY and EC_GROUP objects.
+    // If this is not a problem this line can be removed, but ec_key_is_valid needs to be changed in the CBMC model.
+    EC_KEY_set_conv_form(keypair, POINT_CONVERSION_COMPRESSED);
+
     *pctx = sign_start(alloc, keypair, props);
     if (!*pctx) {
         goto rethrow;
@@ -453,6 +462,8 @@ int aws_cryptosdk_sig_sign_start_keygen(
     EC_KEY_free(keypair);
     EC_GROUP_free(group);
 
+    AWS_POSTCONDITION(aws_cryptosdk_sig_ctx_is_valid(*pctx) && (*pctx)->is_sign);
+    AWS_POSTCONDITION(!pub_key || aws_string_is_valid(*pub_key));
     return AWS_OP_SUCCESS;
 
 err:
@@ -461,12 +472,16 @@ rethrow:
     aws_cryptosdk_sig_abort(*pctx);
     *pctx = NULL;
 
-    aws_string_destroy(*pub_key);
-    *pub_key = NULL;
+    if (pub_key) {
+        aws_string_destroy(*pub_key);
+        *pub_key = NULL;
+    }
 
     EC_KEY_free(keypair);
     EC_GROUP_free(group);
 
+    AWS_POSTCONDITION(!*pctx);
+    AWS_POSTCONDITION(!pub_key || !*pub_key);
     return AWS_OP_ERR;
 }
 
@@ -490,6 +505,10 @@ int aws_cryptosdk_sig_sign_start(
     struct aws_string **pub_key_str,
     const struct aws_cryptosdk_alg_properties *props,
     const struct aws_string *priv_key) {
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(ctx));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(alloc));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(props));
+    AWS_PRECONDITION(aws_string_is_valid(priv_key));
     /* See comments in aws_cryptosdk_sig_get_privkey re the serialized format */
 
     *ctx = NULL;
@@ -498,12 +517,18 @@ int aws_cryptosdk_sig_sign_start(
     }
 
     if (!props->impl->curve_name) {
+        AWS_POSTCONDITION(!*ctx);
+        AWS_POSTCONDITION(!pub_key_str || !*pub_key_str);
+        AWS_POSTCONDITION(aws_string_is_valid(priv_key));
         return AWS_OP_SUCCESS;
     }
 
     if (priv_key->len < 5) {
         // We don't have room for the algorithm ID plus the serialized private key.
         // Someone has apparently handed us a truncated private key?
+        AWS_POSTCONDITION(!*ctx);
+        AWS_POSTCONDITION(!pub_key_str || !*pub_key_str);
+        AWS_POSTCONDITION(aws_string_is_valid(priv_key));
         return aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);
     }
 
@@ -527,6 +552,9 @@ int aws_cryptosdk_sig_sign_start(
 
     if (serialized_alg_id != props->alg_id) {
         // Algorithm mismatch
+        AWS_POSTCONDITION(!*ctx);
+        AWS_POSTCONDITION(!pub_key_str || !*pub_key_str);
+        AWS_POSTCONDITION(aws_string_is_valid(priv_key));
         return aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);
     }
 
@@ -592,6 +620,9 @@ int aws_cryptosdk_sig_sign_start(
 
     if (pub_key_str && serialize_pubkey(alloc, keypair, pub_key_str)) {
         EC_KEY_free(keypair);
+        AWS_POSTCONDITION(!*ctx);
+        AWS_POSTCONDITION(!*pub_key_str);
+        AWS_POSTCONDITION(aws_string_is_valid(priv_key));
         return AWS_OP_ERR;
     }
 
@@ -604,6 +635,9 @@ int aws_cryptosdk_sig_sign_start(
 out:
     // EC_KEYs are reference counted
     EC_KEY_free(keypair);
+    AWS_POSTCONDITION(!*ctx || (aws_cryptosdk_sig_ctx_is_valid(*ctx) && (*ctx)->is_sign));
+    AWS_POSTCONDITION(!pub_key_str || (!*ctx && !*pub_key_str) || aws_string_is_valid(*pub_key_str));
+    AWS_POSTCONDITION(aws_string_is_valid(priv_key));
     return *ctx ? AWS_OP_SUCCESS : AWS_OP_ERR;
 }
 


### PR DESCRIPTION
Proofs harness for aws_cryptosdk_rsa_decrypt from the cipher module and openssl stubs. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
