### PR TITLE
#448 test failures

### DIFF
--- a/aws-encryption-sdk-cpp/tests/integration/t_integration_kms_keyring.cpp
+++ b/aws-encryption-sdk-cpp/tests/integration/t_integration_kms_keyring.cpp
@@ -16,7 +16,7 @@
 #include <aws/common/encoding.h>
 #include <aws/core/utils/logging/AWSLogging.h>
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
-#include <aes/cryptosdk/cryptosdk.h>
+#include <aws/cryptosdk/cryptosdk.h>
 #include <aws/cryptosdk/cpp/kms_keyring.h>
 #include <aws/cryptosdk/enc_ctx.h>
 

--- a/aws-encryption-sdk-cpp/tests/integration/t_integration_kms_keyring.cpp
+++ b/aws-encryption-sdk-cpp/tests/integration/t_integration_kms_keyring.cpp
@@ -16,6 +16,7 @@
 #include <aws/common/encoding.h>
 #include <aws/core/utils/logging/AWSLogging.h>
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
+#include <aes/cryptosdk/cryptosdk.h>
 #include <aws/cryptosdk/cpp/kms_keyring.h>
 #include <aws/cryptosdk/enc_ctx.h>
 
@@ -533,7 +534,9 @@ class LoggingRAII {
 }  // namespace
 
 int main() {
-    aws_cryptosdk_load_error_strings();
+
+    struct aws_allocator *alloc = aws_default_allocator();
+    aws_cryptosdk_init(alloc);
 
     LoggingRAII logging;
 
@@ -568,4 +571,5 @@ int main() {
     logging.clear();
 
     Aws::ShutdownAPI(options);
+    aws_cryptosdk_clean_up();
 }

--- a/aws-encryption-sdk-cpp/tests/test_vectors/static_test_vectors.cpp
+++ b/aws-encryption-sdk-cpp/tests/test_vectors/static_test_vectors.cpp
@@ -18,6 +18,7 @@
 #include <aws/common/encoding.h>
 #include <aws/common/error.h>
 #include <aws/core/Aws.h>
+#include <aws/cryptosdk/cryptosdk.h>
 #include <aws/cryptosdk/cpp/kms_keyring.h>
 #include <aws/cryptosdk/default_cmm.h>
 #include <aws/cryptosdk/error.h>
@@ -461,10 +462,15 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Wrong number of arguments\nUsage: ./static_test_vectors /path/to/manifest/files\n");
         return EXIT_FAILURE;
     }
-    aws_cryptosdk_load_error_strings();
+
+    struct aws_allocator *alloc         = aws_default_allocator();
+    aws_cryptosdk_init(alloc);
+
     SDKOptions options;
     Aws::InitAPI(options);
     int rv = test_vector_runner(argv[1]);
     Aws::ShutdownAPI(options);
+    aws_cryptosdk_clean_up();
+
     return rv;
 }

--- a/aws-encryption-sdk-cpp/tests/unit/t_kms_keyring.cpp
+++ b/aws-encryption-sdk-cpp/tests/unit/t_kms_keyring.cpp
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <aws/cryptosdk/cryptosdk.h>
 #include <aws/cryptosdk/enc_ctx.h>
 #include <aws/cryptosdk/private/cpputils.h>
 #include <aws/cryptosdk/private/kms_keyring.h>
@@ -713,10 +714,12 @@ int t_assert_encrypt_with_default_values(aws_cryptosdk_keyring *kms_keyring, Enc
 }
 
 int main() {
+    struct aws_allocator *alloc         = aws_default_allocator();
+
     Aws::SDKOptions *options = Aws::New<Aws::SDKOptions>(CLASS_TAG);
     Aws::InitAPI(*options);
 
-    aws_cryptosdk_load_error_strings();
+    aws_cryptosdk_init(alloc);
 
     RUN_TEST(encrypt_validInputs_returnSuccess());
     RUN_TEST(encrypt_kmsFails_returnError());
@@ -738,5 +741,7 @@ int main() {
 
     Aws::ShutdownAPI(*options);
     Aws::Delete(options);
+
+    aws_cryptosdk_clean_up();
     return 0;
 }

--- a/include/aws/cryptosdk/cryptosdk.h
+++ b/include/aws/cryptosdk/cryptosdk.h
@@ -1,0 +1,21 @@
+#ifndef AWS_CRYPTOSDK_CRYPTOSDK_H
+#define AWS_CRYPTOSDK_CRYPTOSDK_H
+
+#include <aws/common/common.h>
+#include <aws/cryptosdk/exports.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+AWS_CRYPTOSDK_API
+void aws_cryptosdk_init(struct aws_allocator *allocator);
+
+AWS_CRYPTOSDK_API
+void aws_cryptosdk_clean_up(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/aws/cryptosdk/error.h
+++ b/include/aws/cryptosdk/error.h
@@ -58,6 +58,22 @@ enum aws_cryptosdk_err {
  * Implicitly registers error strings for aws-c-common as well.
  */
 AWS_CRYPTOSDK_API
+void aws_cryptosdk_register_error_info();
+
+/**
+ * Unregister error strings with the core error reporting APIs. This function is
+ * threadsafe and idempotent, and should be called at on application startup.
+ * Implicitly registers error strings for aws-c-common as well.
+ */
+AWS_CRYPTOSDK_API
+void aws_cryptosdk_unregister_error_info();
+
+/**
+ * DEPRECATED
+ * This function is left in place to not break existing applications.
+ * Users will notice that aws-c-common errors will not have been loaded.
+ */
+AWS_CRYPTOSDK_API
 void aws_cryptosdk_load_error_strings();
 
 #ifdef __cplusplus

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -383,7 +383,7 @@ int aws_cryptosdk_decrypt_body(
     const struct content_key *key,
     const uint8_t *tag,
     int body_frame_type) {
-    if (inp->len != outp->capacity - outp->len) {
+    if (inp->len > outp->capacity - outp->len) {
         return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
     }
 
@@ -606,6 +606,7 @@ int aws_cryptosdk_rsa_decrypt(
     const struct aws_byte_cursor cipher,
     const struct aws_string *rsa_private_key_pem,
     enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode) {
+
     if (plain->buffer) return aws_raise_error(AWS_CRYPTOSDK_ERR_BAD_STATE);
     int padding = get_openssl_rsa_padding_mode(rsa_padding_mode);
     if (padding < 0) return aws_raise_error(AWS_CRYPTOSDK_ERR_UNSUPPORTED_FORMAT);

--- a/source/cryptosdk.c
+++ b/source/cryptosdk.c
@@ -10,16 +10,14 @@ void aws_cryptosdk_init(struct aws_allocator *allocator) {
     if (!crypto_sdk_initialized) {
         crypto_sdk_initialized = true;
         //aws_common_library_init(allocator);
-        //aws_load_error_strings();
-        aws_cryptosdk_load_error_strings();
-        //aws_cryptosdk_register_error_info();
+        aws_cryptosdk_register_error_info();
     }
 }
 
 void aws_cryptosdk_clean_up(void) {
     if (crypto_sdk_initialized) {
         crypto_sdk_initialized = false;
-        //aws_cryptosdk_unregister_error_info();
+        aws_cryptosdk_unregister_error_info();
         //aws_common_library_clean_up();
     }
 }

--- a/source/cryptosdk.c
+++ b/source/cryptosdk.c
@@ -1,0 +1,25 @@
+#include <aws/common/common.h>
+
+#include <aws/cryptosdk/error.h>
+#include <aws/cryptosdk/cryptosdk.h>
+
+static bool crypto_sdk_initialized = false;
+
+void aws_cryptosdk_init(struct aws_allocator *allocator) {
+    (void)allocator;
+    if (!crypto_sdk_initialized) {
+        crypto_sdk_initialized = true;
+        //aws_common_library_init(allocator);
+        //aws_load_error_strings();
+        aws_cryptosdk_load_error_strings();
+        //aws_cryptosdk_register_error_info();
+    }
+}
+
+void aws_cryptosdk_clean_up(void) {
+    if (crypto_sdk_initialized) {
+        crypto_sdk_initialized = false;
+        //aws_cryptosdk_unregister_error_info();
+        //aws_common_library_clean_up();
+    }
+}

--- a/source/edk.c
+++ b/source/edk.c
@@ -20,9 +20,12 @@ int aws_cryptosdk_edk_list_init(struct aws_allocator *alloc, struct aws_array_li
 }
 
 void aws_cryptosdk_edk_clean_up(struct aws_cryptosdk_edk *edk) {
-    aws_byte_buf_clean_up(&edk->provider_id);
-    aws_byte_buf_clean_up(&edk->provider_info);
-    aws_byte_buf_clean_up(&edk->ciphertext);
+    if (edk->provider_id.allocator)
+        aws_byte_buf_clean_up(&edk->provider_id);
+    if (edk->provider_info.allocator)
+        aws_byte_buf_clean_up(&edk->provider_info);
+    if (edk->ciphertext.allocator)
+        aws_byte_buf_clean_up(&edk->ciphertext);
 }
 
 void aws_cryptosdk_edk_list_clear(struct aws_array_list *edk_list) {

--- a/source/error.c
+++ b/source/error.c
@@ -29,6 +29,14 @@ static const struct aws_error_info error_info[] = {
 static const struct aws_error_info_list error_info_list = { .error_list = error_info,
                                                             .count      = sizeof(error_info) / sizeof(error_info[0]) };
 
+void aws_cryptosdk_register_error_info() {
+    aws_register_error_info(&error_info_list);
+}
+
+void aws_cryptosdk_unregister_error_info() {
+    //aws_unregister_error_info(&error_info_list);
+}
+
 void aws_cryptosdk_load_error_strings() {
     aws_register_error_info(&error_info_list);
 }

--- a/source/error.c
+++ b/source/error.c
@@ -30,6 +30,5 @@ static const struct aws_error_info_list error_info_list = { .error_list = error_
                                                             .count      = sizeof(error_info) / sizeof(error_info[0]) };
 
 void aws_cryptosdk_load_error_strings() {
-    aws_load_error_strings();
     aws_register_error_info(&error_info_list);
 }

--- a/source/header.c
+++ b/source/header.c
@@ -302,6 +302,8 @@ int aws_cryptosdk_hdr_write(
     // TODO - unify everything on byte_bufs when the aws-c-common refactor lands
     // See: https://github.com/awslabs/aws-c-common/pull/130
     struct aws_byte_buf aad_length_field;
+    aws_byte_buf_init(&aad_length_field, aws_default_allocator(), 0);
+
     if (!aws_byte_buf_advance(&output, &aad_length_field, 2)) goto WRITE_ERR;
 
     size_t old_len = output.len;
@@ -321,13 +323,13 @@ int aws_cryptosdk_hdr_write(
         const struct aws_cryptosdk_edk *edk = vp_edk;
 
         if (!aws_byte_buf_write_be16(&output, (uint16_t)edk->provider_id.len)) goto WRITE_ERR;
-        if (!aws_byte_buf_write_from_whole_buffer(&output, edk->provider_id)) goto WRITE_ERR;
+        if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(edk->provider_id.buffer, edk->provider_id.len))) goto WRITE_ERR;
 
         if (!aws_byte_buf_write_be16(&output, (uint16_t)edk->provider_info.len)) goto WRITE_ERR;
-        if (!aws_byte_buf_write_from_whole_buffer(&output, edk->provider_info)) goto WRITE_ERR;
+        if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(edk->provider_info.buffer, edk->provider_info.len))) goto WRITE_ERR;
 
         if (!aws_byte_buf_write_be16(&output, (uint16_t)edk->ciphertext.len)) goto WRITE_ERR;
-        if (!aws_byte_buf_write_from_whole_buffer(&output, edk->ciphertext)) goto WRITE_ERR;
+        if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(edk->ciphertext.buffer, edk->ciphertext.len))) goto WRITE_ERR;
     }
 
     if (!aws_byte_buf_write_u8(

--- a/source/materials.c
+++ b/source/materials.c
@@ -58,6 +58,8 @@ struct aws_cryptosdk_dec_materials *aws_cryptosdk_dec_materials_new(
     if (!dec_mat) return NULL;
     dec_mat->alloc                          = alloc;
     dec_mat->unencrypted_data_key.buffer    = NULL;
+    dec_mat->unencrypted_data_key.len       = 0;
+    dec_mat->unencrypted_data_key.capacity  = 0;
     dec_mat->unencrypted_data_key.allocator = NULL;
     dec_mat->alg                            = alg;
     dec_mat->signctx                        = NULL;

--- a/source/session.c
+++ b/source/session.c
@@ -221,7 +221,6 @@ int aws_cryptosdk_session_process(
 
         struct aws_byte_buf remaining_space =
             aws_byte_buf_from_empty_array(output.buffer + output.len, output.capacity - output.len);
-
         switch (session->state) {
             case ST_CONFIG:
                 if (!session->cmm) {
@@ -258,7 +257,6 @@ int aws_cryptosdk_session_process(
         }
 
         made_progress = (remaining_space.len) || (input.ptr != old_inp) || (prior_state != session->state);
-
         output.len += remaining_space.len;
     } while (result == AWS_OP_SUCCESS && made_progress);
 

--- a/tests/decrypt.c
+++ b/tests/decrypt.c
@@ -21,6 +21,7 @@
 
 #include <aws/common/common.h>
 #include <aws/common/error.h>
+#include <aws/cryptosdk/cryptosdk.h>
 #include <aws/cryptosdk/default_cmm.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/session.h>
@@ -48,16 +49,13 @@ size_t ct_size, pt_size;
         return 1;                                                  \
     } while (0)
 
-int test_decrypt() {
-    aws_cryptosdk_load_error_strings();
-
+int test_decrypt(struct aws_allocator *alloc) {
     uint8_t *output_buf = malloc(pt_size);
     if (!output_buf) {
         fprintf(stderr, "out of memory\n");
         exit(1);
     }
 
-    struct aws_allocator *alloc           = aws_default_allocator();
     struct aws_cryptosdk_keyring *kr      = NULL;
     struct aws_cryptosdk_session *session = NULL;
     struct aws_cryptosdk_cmm *cmm         = NULL;
@@ -158,7 +156,9 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    int result = test_decrypt();
+    struct aws_allocator *alloc = aws_default_allocator();
+    aws_cryptosdk_register_error_info();
+    int result = test_decrypt(alloc);
 
     free(ciphertext);
     free(plaintext);

--- a/tests/decryption_vectors.c
+++ b/tests/decryption_vectors.c
@@ -23,6 +23,7 @@
 #include <aws/common/common.h>
 #include <aws/common/encoding.h>
 #include <aws/common/error.h>
+#include <aws/cryptosdk/cryptosdk.h>
 #include <aws/cryptosdk/default_cmm.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/session.h>
@@ -423,7 +424,7 @@ void decrypt_test_vector(
 }
 
 int main() {
-    aws_cryptosdk_load_error_strings();
+    aws_cryptosdk_register_error_info();
 
     // clang-format off
     decrypt_test_vector(ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256, "ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256 hello empty final frame", "SGVsbG8sIHdvcmxkIQ==", "AYABFO37IzpEmc0FwZTvdUKZNmwAAAABAAh6ZXJvLWtleQANcHJvdmlkZXIgaW5mbwABAAIAAAAADAAAAA0AAAAAAAAAAAAAAACNU9yvQgmpDkhnXnIQNxa2AAAAAQAAAAAAAAAAAAAAASUlloU74HOz+Y1YlYf6Raw/tn/7oSD3tUsfzC8W/////wAAAAIAAAAAAAAAAAAAAAIAAAAAeSAQ6uk0/Gbj1GQb7AXKTw==");

--- a/tests/integration/t_encrypt_compat.c
+++ b/tests/integration/t_encrypt_compat.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <aws/cryptosdk/cryptosdk.h>
 #include <aws/cryptosdk/default_cmm.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/private/cipher.h>
@@ -289,7 +290,8 @@ static int test_framesize(size_t plaintext_sz, size_t framesize, bool early_size
 }
 
 int main() {
-    aws_cryptosdk_load_error_strings();
+    struct aws_allocator *alloc = aws_default_allocator();
+    aws_cryptosdk_init(alloc);
 
     curl_init();
 
@@ -316,5 +318,6 @@ int main() {
     }
     curl_clean_up();
 
+    aws_cryptosdk_clean_up();
     return final_result;
 }

--- a/tests/unit/runner.c
+++ b/tests/unit/runner.c
@@ -20,6 +20,8 @@
 
 #include <aws/common/error.h>
 #include <aws/cryptosdk/error.h>
+#include <aws/cryptosdk/cryptosdk.h>
+
 
 int pass_fn() {
     return 0;
@@ -101,7 +103,7 @@ static void enable_cases(const char *specifier) {
 }
 
 int main(int argc, char **argv) {
-    aws_cryptosdk_load_error_strings();
+    aws_cryptosdk_init(NULL);
 
     int ret;
     assemble_test_cases(argc < 2);

--- a/tests/unit/t_header.c
+++ b/tests/unit/t_header.c
@@ -95,8 +95,8 @@ static const uint8_t test_header_1[] = {
 uint8_t test_header_1_aad_key[]                      = { 0x01, 0x02, 0x03, 0x04 };
 uint8_t test_header_1_aad_value[]                    = { 0x01, 0x00, 0x01, 0x00, 0x01 };
 struct aws_cryptosdk_hdr_aad test_header_1_aad_tbl[] = {
-    { .key   = { .len = sizeof(test_header_1_aad_key), .buffer = test_header_1_aad_key },
-      .value = { .len = sizeof(test_header_1_aad_value), .buffer = test_header_1_aad_value } },
+    { .key   = { .capacity = sizeof(test_header_1_aad_key), .len = sizeof(test_header_1_aad_key), .buffer = test_header_1_aad_key },
+      .value = { .capacity = sizeof(test_header_1_aad_value), .len = sizeof(test_header_1_aad_value), .buffer = test_header_1_aad_value } },
     { { 0 } }
 };
 
@@ -105,9 +105,9 @@ uint8_t test_header_1_edk_provider_info[]        = { 0x01, 0x02, 0x03, 0x04 };
 uint8_t test_header_1_edk_enc_data_key[]         = { 0x11, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x88 };
 struct aws_cryptosdk_edk test_header_1_edk_tbl[] = {
     { { 0 } },
-    { .provider_id   = { .len = sizeof(test_header_1_edk_provider_id), .buffer = test_header_1_edk_provider_id },
-      .provider_info = { .len = sizeof(test_header_1_edk_provider_info), .buffer = test_header_1_edk_provider_info },
-      .ciphertext    = { .len = sizeof(test_header_1_edk_enc_data_key), .buffer = test_header_1_edk_enc_data_key } },
+    { .provider_id   = { .capacity = sizeof(test_header_1_edk_provider_id), .len = sizeof(test_header_1_edk_provider_id), .buffer = test_header_1_edk_provider_id },
+      .provider_info = { .capacity = sizeof(test_header_1_edk_provider_info), .len = sizeof(test_header_1_edk_provider_info), .buffer = test_header_1_edk_provider_info },
+      .ciphertext    = { .capacity = sizeof(test_header_1_edk_enc_data_key), .len = sizeof(test_header_1_edk_enc_data_key), .buffer = test_header_1_edk_enc_data_key } },
     { { 0 } }
 };
 
@@ -155,8 +155,8 @@ static struct aws_cryptosdk_hdr test_header_1_hdr() {
     struct aws_cryptosdk_hdr test_header_1_hdr = {
         .alg_id     = ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
         .frame_len  = 0x1000,
-        .iv         = { .buffer = test_header_1_iv_arr, .len = sizeof(test_header_1_iv_arr) },
-        .auth_tag   = { .buffer = test_header_1_auth_tag_arr, .len = sizeof(test_header_1_auth_tag_arr) },
+        .iv         = aws_byte_buf_from_array(test_header_1_iv_arr, sizeof(test_header_1_iv_arr)),
+        .auth_tag   = aws_byte_buf_from_array(test_header_1_auth_tag_arr, sizeof(test_header_1_auth_tag_arr)),
         .message_id = { 0x11,
                         0x22,
                         0x33,
@@ -313,8 +313,8 @@ struct aws_cryptosdk_hdr test_header_2_hdr() {
     struct aws_cryptosdk_hdr hdr = {
         .alg_id = ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256,
         .frame_len = 0x1000,
-        .iv = {.buffer = test_header_1_iv_arr, .len = sizeof(test_header_1_iv_arr)},
-        .auth_tag = {.buffer = test_header_1_auth_tag_arr, .len = sizeof(test_header_1_auth_tag_arr)},
+        .iv         = aws_byte_buf_from_array(test_header_1_iv_arr, sizeof(test_header_1_iv_arr)),
+        .auth_tag   = aws_byte_buf_from_array(test_header_1_auth_tag_arr, sizeof(test_header_1_auth_tag_arr)),
         .message_id = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
         .auth_len = sizeof(test_header_2) - 29 // not used by aws_cryptosdk_hdr_size/write
     };
@@ -559,11 +559,15 @@ int header_size() {
         struct aws_cryptosdk_edk edk;
         TEST_ASSERT_SUCCESS(aws_array_list_get_at(&hdr.edk_list, &edk, i));
 
-        edk.ciphertext.len    = SIZE_MAX >> 1;
-        edk.provider_id.len   = SIZE_MAX >> 1;
-        edk.provider_info.len = SIZE_MAX >> 1;
+        edk.ciphertext.len          = SIZE_MAX >> 1;
+        edk.provider_id.len         = SIZE_MAX >> 1;
+        edk.provider_info.len       = SIZE_MAX >> 1;
 
         TEST_ASSERT_SUCCESS(aws_array_list_set_at(&hdr.edk_list, &edk, i));
+
+        edk.ciphertext.len          = 0;
+        edk.provider_id.len         = 0;
+        edk.provider_info.len       = 0;
     }
 
     TEST_ASSERT_INT_EQ(aws_cryptosdk_hdr_size(&hdr), 0);

--- a/tests/unit/t_raw_rsa_keyring_decrypt.c
+++ b/tests/unit/t_raw_rsa_keyring_decrypt.c
@@ -25,6 +25,9 @@ static struct aws_cryptosdk_edk good_edk() {
  */
 static struct aws_cryptosdk_edk empty_edk() {
     struct aws_cryptosdk_edk edk = { { 0 } };
+    aws_byte_buf_init(&edk.ciphertext, aws_default_allocator(), 0);
+    aws_byte_buf_init(&edk.provider_id, aws_default_allocator(), 0);
+    aws_byte_buf_init(&edk.provider_info, aws_default_allocator(), 0);
     return edk;
 }
 static struct aws_cryptosdk_edk wrong_provider_id_edk() {
@@ -67,6 +70,7 @@ static struct aws_cryptosdk_edk enc_data_key_too_small_edk() {
 static struct aws_cryptosdk_edk enc_data_key_too_large_edk() {
     struct aws_cryptosdk_edk edk = good_edk();
     edk.ciphertext.len *= 2;
+    edk.ciphertext.capacity *= 2;
     return edk;
 }
 
@@ -89,6 +93,7 @@ static struct aws_byte_buf unencrypted_data_key = { 0 };
 
 static int set_up_all_the_things(enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode, bool use_correct_private_key) {
     alloc = aws_default_allocator();
+    aws_byte_buf_init(&unencrypted_data_key, alloc, 0);
     kr    = (use_correct_private_key ? raw_rsa_keyring_tv_new : raw_rsa_keyring_tv_new_with_wrong_key)(
         alloc, rsa_padding_mode);
     TEST_ASSERT_ADDR_NOT_NULL(kr);


### PR DESCRIPTION
Fixes #448 and fixes #450

I built aws-sdk-cpp against tag 1.7.163. I was able to compile and get tests passing for this branch. tag 1.7.163 does not contain the new aws-c-common init functions, and so I've commented those out. This PR addresses the aws_byte_buf preconditions that were causing runtime and compile time failures.

There are a couple changes in this PR that seem very hacky, and need review.

```bash
Running tests...
Test project /home/ec2-user/encryption-sdk/changes/build
Start  1: t_cpputils.test
1/21 Test  #1: t_cpputils.test ..................   Passed    0.01 sec
Start  2: t_kms_keyring.test
2/21 Test  #2: t_kms_keyring.test ...............   Passed    0.04 sec
Start  3: cipher
3/21 Test  #3: cipher ...........................   Passed   10.30 sec
Start  4: header
4/21 Test  #4: header ...........................   Passed    0.01 sec
Start  5: materials
5/21 Test  #5: materials ........................   Passed    0.01 sec
Start  6: enc_ctx
6/21 Test  #6: enc_ctx ..........................   Passed    0.02 sec
Start  7: encrypt
7/21 Test  #7: encrypt ..........................   Passed    1.51 sec
Start  8: hkdf
8/21 Test  #8: hkdf .............................   Passed    0.00 sec
Start  9: raw_aes_keyring
9/21 Test  #9: raw_aes_keyring ..................   Passed    0.00 sec
Start 10: raw_rsa_keyring
10/21 Test #10: raw_rsa_keyring ..................   Passed    0.02 sec
Start 11: multi_keyring
11/21 Test #11: multi_keyring ....................   Passed    0.00 sec
Start 12: signature
12/21 Test #12: signature ........................   Passed    5.99 sec
Start 13: trailing_sig
13/21 Test #13: trailing_sig .....................   Passed    0.02 sec
Start 14: local_cache
14/21 Test #14: local_cache ......................   Passed    0.05 sec
Start 15: caching_cmm
15/21 Test #15: caching_cmm ......................   Passed    0.09 sec
Start 16: keyring_trace
16/21 Test #16: keyring_trace ....................   Passed    0.00 sec
Start 17: decrypt_aes128_hkdf
17/21 Test #17: decrypt_aes128_hkdf ..............   Passed    0.00 sec
Start 18: decrypt_aes128_hkdf_bad_header
18/21 Test #18: decrypt_aes128_hkdf_bad_header ...   Passed    0.00 sec
Start 19: decrypt_hello
19/21 Test #19: decrypt_hello ....................   Passed    0.00 sec
Start 20: decrypt_hello_tiny
20/21 Test #20: decrypt_hello_tiny ...............   Passed    0.00 sec
Start 21: decryption_vectors
21/21 Test #21: decryption_vectors ...............   Passed   12.58 sec

100% tests passed, 0 tests failed out of 21

Total Test time (real) =  30.66 sec
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

