### PR TITLE
Bump aws-cpp-sdk dependency to version 1.7.231 for CodeBuild (non-Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For best results when doing a build with KMS integration, do not install aws-c-c
 Build and install the AWS SDK for C++, which will build and install aws-c-common for you (see the C++ SDK dependancies
  [here](https://github.com/aws/aws-sdk-cpp/blob/master/third-party/CMakeLists.txt#L18)). If
 you install aws-c-common before building the AWS SDK for C++, this will fool the AWS SDK for
-C++ install logic, and you will be forced to install several other dependencies manually. Version 1.7.163 of the 
+C++ install logic, and you will be forced to install several other dependencies manually. Version 1.7.231 of the 
 AWS SDK for C++ is supported by version v1.0.1 of the AWS Encryption SDK for C.
 
 You need to compile both the AWS Encryption SDK for C and its dependencies as either all
@@ -172,7 +172,7 @@ aws-c-common for you.
 Do a KMS-only build of the AWS SDK for C++. If you want to use the AWS SDK for C++ for
 other AWS services, you can omit the `-DBUILD_ONLY="kms"` argument, but the build will take much longer.
 
-    git clone -b v1.7.163 https://github.com/aws/aws-sdk-cpp.git
+    git clone -b v1.7.231 https://github.com/aws/aws-sdk-cpp.git
     mkdir build-aws-sdk-cpp && cd build-aws-sdk-cpp
     cmake -G Xcode -DBUILD_SHARED_LIBS=ON -DBUILD_ONLY="kms" -DENABLE_UNITY_BUILD=ON ../aws-sdk-cpp 
     xcodebuild -target install ; cd ..

--- a/codebuild/bin/codebuild-test.sh
+++ b/codebuild/bin/codebuild-test.sh
@@ -62,6 +62,6 @@ env
 # Run the full test suite without valgrind, and as a shared library
 run_test '/deps/install;/deps/shared/install' -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=ON
 # Also run the test suite as a debug build (probing for -DNDEBUG issues), and as a static library
-run_test '/deps/install;/deps/shared/install' -DCMAKE_BUILD_TYPE=Debug
+run_test '/deps/install;/deps/shared/install' -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF
 # Run a lighter weight test suite under valgrind
-run_test '/deps/install;/deps/static/install' -DCMAKE_BUILD_TYPE=RelWithDebInfo -DREDUCE_TEST_ITERATIONS=TRUE -DVALGRIND_TEST_SUITE=ON
+run_test '/deps/install;/deps/static/install' -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DREDUCE_TEST_ITERATIONS=TRUE -DVALGRIND_TEST_SUITE=ON

--- a/codebuild/common-windows.bat
+++ b/codebuild/common-windows.bat
@@ -15,7 +15,7 @@ set ROOT_SRC_DIR=%cd%
 rmdir/s/q \build
 mkdir \build
 cd \build
-git clone -b 1.7.163 https://github.com/aws/aws-sdk-cpp.git || goto error
+git clone -b 1.7.231 https://github.com/aws/aws-sdk-cpp.git || goto error
 mkdir build-aws-sdk-cpp
 cd build-aws-sdk-cpp
 cmake %* -DCMAKE_INSTALL_PREFIX=c:/deps -DCMAKE_BUILD_TYPE="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_ONLY="kms" -DENABLE_UNITY_BUILD=ON ../aws-sdk-cpp || goto error

--- a/codebuild/osx.sh
+++ b/codebuild/osx.sh
@@ -17,7 +17,7 @@
 set +ex
 
 OS=$(uname -s)
-AWS_SDK_CPP_VER="1.7.163"  #github versioned branch
+AWS_SDK_CPP_VER="1.7.231"  #github versioned branch
 BUILDROOT="/var/tmp/build-$(date +%s)"
 OPENSSL_VER="openssl@1.1" #note this is a brew label, not an exact version reference
 BUILDROOT="/var/tmp/build-$(date +%Y%m%d)"
@@ -46,7 +46,6 @@ build_cpp(){
     # This target runs the cpp tests, but doesn't appear to run the other dependancy tests.
     xcodebuild -target ALL_BUILD 
     xcodebuild -target install
-
 }
 
 build_csdk(){

--- a/codebuild/windows-msvc-2015-x86.yml
+++ b/codebuild/windows-msvc-2015-x86.yml
@@ -16,5 +16,5 @@ version: 0.2
 phases:
   build:
     commands:
-      - .\codebuild\common-windows.bat -G "Visual Studio 14 2015"
+      - .\codebuild\common-windows.bat -DBUILD_SHARED_LIBS=OFF -G "Visual Studio 14 2015"
       - .\codebuild\common-windows.bat -DBUILD_SHARED_LIBS=ON -G "Visual Studio 14 2015"

--- a/codebuild/windows-msvc-2015.yml
+++ b/codebuild/windows-msvc-2015.yml
@@ -16,6 +16,6 @@ version: 0.2
 phases:
   build:
     commands:
-      - .\codebuild\common-windows.bat -G "Visual Studio 14 2015 Win64"
+      - .\codebuild\common-windows.bat -DBUILD_SHARED_LIBS=OFF -G "Visual Studio 14 2015 Win64"
       - .\codebuild\common-windows.bat -DBUILD_SHARED_LIBS=ON -G "Visual Studio 14 2015 Win64"
 

--- a/codebuild/windows-msvc-2017.yml
+++ b/codebuild/windows-msvc-2017.yml
@@ -16,5 +16,5 @@ version: 0.2
 phases:
   build:
     commands:
-      - .\codebuild\common-windows.bat -G "Visual Studio 15 2017 Win64"
+      - .\codebuild\common-windows.bat -DBUILD_SHARED_LIBS=OFF -G "Visual Studio 15 2017 Win64"
       - .\codebuild\common-windows.bat --trace-expand -DBUILD_SHARED_LIBS=ON -G "Visual Studio 15 2017 Win64"


### PR DESCRIPTION
*Issue #450 *

*Description of changes:*
Version bump of dependency for platforms that install aws-cpp-sdk on every build.  The linux custom docker images contain a pre-installed aws-sdk-cpp and will be covered with a separate PR.

Also included, a CMake failure without explicit definition of the shared_libs flag.

- [x] Windows
- [x] macOS

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

