### PR TITLE
Make reformat script fail if clang >= 8 not found. Apply it.

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_deserialize/aws_cryptosdk_enc_ctx_deserialize_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_deserialize/aws_cryptosdk_enc_ctx_deserialize_harness.c
@@ -62,5 +62,4 @@ void aws_cryptosdk_enc_ctx_deserialize_harness() {
     int rval = aws_cryptosdk_enc_ctx_deserialize(can_fail_allocator(), &map, &cursor);
     assert(aws_hash_table_is_valid(&map));
     assert(aws_byte_cursor_is_valid(&cursor));
-
 }

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -346,7 +346,7 @@ AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_cmm_vtable_is_valid(const struct 
  */
 AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_cmm_base_is_valid(const struct aws_cryptosdk_cmm *cmm) {
     return AWS_OBJECT_PTR_IS_WRITABLE(cmm) && aws_atomic_var_is_valid(&cmm->refcount) &&
-        aws_atomic_load_int(&cmm->refcount) > 0 && aws_atomic_load_int(&cmm->refcount) <= SIZE_MAX &&
+           aws_atomic_load_int(&cmm->refcount) > 0 && aws_atomic_load_int(&cmm->refcount) <= SIZE_MAX &&
            aws_cryptosdk_cmm_vtable_is_valid(cmm->vtable);
 }
 

--- a/reformat.sh
+++ b/reformat.sh
@@ -19,8 +19,9 @@
 echo "Checking version number"
 VER=$(clang-format --version|cut -f3 -d' '|cut -f1 -d'.')
 if [ $VER -ge 8 ];then
-  set -euxo pipefail
-find {.,aws-encryption-sdk-cpp}/{include,source,tests} .cbmc-batch examples -name '*.h' -or -name '*.c' -or -name '*.cpp' | xargs clang-format -i
+    set -euxo pipefail
+    find {.,aws-encryption-sdk-cpp}/{include,source,tests} .cbmc-batch examples -name '*.h' -or -name '*.c' -or -name '*.cpp' | xargs clang-format -i
 else
-  echo "clang-format version 8 or greater is needed to read the format file."
+    echo "clang-format version 8 or greater is needed to read the format file."
+    exit 1
 fi

--- a/source/header.c
+++ b/source/header.c
@@ -102,10 +102,8 @@ void aws_cryptosdk_hdr_clean_up(struct aws_cryptosdk_hdr *hdr) {
         // Idempotent cleanup
         return;
     }
-    if(hdr->iv.allocator)
-        aws_byte_buf_clean_up(&hdr->iv);
-    if(hdr->auth_tag.allocator)
-        aws_byte_buf_clean_up(&hdr->auth_tag);
+    if (hdr->iv.allocator) aws_byte_buf_clean_up(&hdr->iv);
+    if (hdr->auth_tag.allocator) aws_byte_buf_clean_up(&hdr->auth_tag);
 
     aws_cryptosdk_edk_list_clean_up(&hdr->edk_list);
     aws_cryptosdk_enc_ctx_clean_up(&hdr->enc_ctx);
@@ -289,11 +287,11 @@ int aws_cryptosdk_hdr_size(const struct aws_cryptosdk_hdr *hdr) {
 
     return bytes == SIZE_MAX ? 0 : bytes;
 }
-static void init_aws_byte_buf_raw(struct aws_byte_buf *buf){
+static void init_aws_byte_buf_raw(struct aws_byte_buf *buf) {
     buf->allocator = NULL;
-    buf->buffer = NULL;
-    buf->len = 0;
-    buf->capacity = 0;
+    buf->buffer    = NULL;
+    buf->len       = 0;
+    buf->capacity  = 0;
 }
 int aws_cryptosdk_hdr_write(
     const struct aws_cryptosdk_hdr *hdr, size_t *bytes_written, uint8_t *outbuf, size_t outlen) {
@@ -329,13 +327,19 @@ int aws_cryptosdk_hdr_write(
         const struct aws_cryptosdk_edk *edk = vp_edk;
 
         if (!aws_byte_buf_write_be16(&output, (uint16_t)edk->provider_id.len)) goto WRITE_ERR;
-        if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(edk->provider_id.buffer, edk->provider_id.len))) goto WRITE_ERR;
+        if (!aws_byte_buf_write_from_whole_cursor(
+                &output, aws_byte_cursor_from_array(edk->provider_id.buffer, edk->provider_id.len)))
+            goto WRITE_ERR;
 
         if (!aws_byte_buf_write_be16(&output, (uint16_t)edk->provider_info.len)) goto WRITE_ERR;
-        if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(edk->provider_info.buffer, edk->provider_info.len))) goto WRITE_ERR;
+        if (!aws_byte_buf_write_from_whole_cursor(
+                &output, aws_byte_cursor_from_array(edk->provider_info.buffer, edk->provider_info.len)))
+            goto WRITE_ERR;
 
         if (!aws_byte_buf_write_be16(&output, (uint16_t)edk->ciphertext.len)) goto WRITE_ERR;
-        if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(edk->ciphertext.buffer,edk->ciphertext.len))) goto WRITE_ERR;
+        if (!aws_byte_buf_write_from_whole_cursor(
+                &output, aws_byte_cursor_from_array(edk->ciphertext.buffer, edk->ciphertext.len)))
+            goto WRITE_ERR;
     }
 
     if (!aws_byte_buf_write_u8(
@@ -347,8 +351,11 @@ int aws_cryptosdk_hdr_write(
     if (!aws_byte_buf_write_u8(&output, (uint8_t)hdr->iv.len)) goto WRITE_ERR;
     if (!aws_byte_buf_write_be32(&output, hdr->frame_len)) goto WRITE_ERR;
 
-    if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(hdr->iv.buffer, hdr->iv.len))) goto WRITE_ERR;
-    if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(hdr->auth_tag.buffer, hdr->auth_tag.len))) goto WRITE_ERR;
+    if (!aws_byte_buf_write_from_whole_cursor(&output, aws_byte_cursor_from_array(hdr->iv.buffer, hdr->iv.len)))
+        goto WRITE_ERR;
+    if (!aws_byte_buf_write_from_whole_cursor(
+            &output, aws_byte_cursor_from_array(hdr->auth_tag.buffer, hdr->auth_tag.len)))
+        goto WRITE_ERR;
 
     *bytes_written = output.len;
     return AWS_OP_SUCCESS;

--- a/source/session_decrypt.c
+++ b/source/session_decrypt.c
@@ -226,7 +226,7 @@ int aws_cryptosdk_priv_try_decrypt_body(
     }
 
     // Before we go further, do we have enough room to place the plaintext?
-    struct aws_byte_buf output = {.buffer = 0, .len = 0, .capacity = 0, .allocator = NULL};
+    struct aws_byte_buf output = { .buffer = 0, .len = 0, .capacity = 0, .allocator = NULL };
     if (!aws_byte_buf_advance(poutput, &output, session->output_size_estimate)) {
         *pinput = input_rollback;
         // No progress due to not enough plaintext output space.
@@ -234,8 +234,9 @@ int aws_cryptosdk_priv_try_decrypt_body(
     }
 
     // We have everything we need, try to decrypt
-    struct aws_byte_cursor ciphertext_cursor = aws_byte_cursor_from_array(frame.ciphertext.buffer, frame.ciphertext.len);
-    int rv                                   = aws_cryptosdk_decrypt_body(
+    struct aws_byte_cursor ciphertext_cursor =
+        aws_byte_cursor_from_array(frame.ciphertext.buffer, frame.ciphertext.len);
+    int rv = aws_cryptosdk_decrypt_body(
         session->alg_props,
         &output,
         &ciphertext_cursor,

--- a/tests/unit/t_raw_aes_keyring_decrypt.c
+++ b/tests/unit/t_raw_aes_keyring_decrypt.c
@@ -172,8 +172,7 @@ int decrypt_data_key_test_vectors() {
 
             if (corrupt_enc_ctx) {
                 TEST_ASSERT_ADDR_NULL(unencrypted_data_key.buffer);
-            }else if(unencrypted_data_key.buffer){
-
+            } else if (unencrypted_data_key.buffer) {
                 struct aws_byte_buf known_answer = aws_byte_buf_from_array(tv->data_key, tv->data_key_len);
                 TEST_ASSERT(aws_byte_buf_eq(&unencrypted_data_key, &known_answer));
                 TEST_ASSERT_SUCCESS(raw_aes_keyring_tv_trace_updated_properly(


### PR DESCRIPTION
*Description of changes:*
What it says in the title.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

