### PR TITLE
PR #418 Rebase: Proof harnesses for aws_cryptosdk_sig_verify_{start, finish} 

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET +=
+
+# Added check for memory leak
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_verify_finish_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
@@ -24,21 +24,21 @@ CBMCFLAGS += --memory-leak-check
 
 ENTRY = aws_cryptosdk_sig_verify_finish_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
-DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
@@ -1,0 +1,41 @@
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_verify_finish_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx = can_fail_malloc(sizeof(struct aws_cryptosdk_sig_ctx));
+    struct aws_string *signature      = ensure_string_is_allocated_nondet_length();
+
+    /* assumptions */
+    __CPROVER_assume(ctx);
+    ensure_sig_ctx_has_allocated_members(ctx);
+    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+    __CPROVER_assume(ctx->alloc);
+    __CPROVER_assume(!ctx->is_sign);
+    assert(aws_string_is_valid(signature));
+
+    /* saving state */
+    EC_KEY *keypair        = ctx->keypair;
+    int keypair_references = ec_key_get_reference_count(keypair);
+    EVP_PKEY *pkey         = ctx->pkey;
+    int pkey_references    = evp_pkey_get_reference_count(pkey);
+
+    /* operation under verification */
+    aws_cryptosdk_sig_verify_finish(ctx, signature);
+
+    /* clean up (necessary because we are checking for memory leaks) */
+    free(signature);
+    if (pkey_references > 2) {
+        evp_pkey_unconditional_free(pkey);
+        ec_key_unconditional_free(keypair);  // pkey holds a reference to keypair, have to free that as well
+    } else if (keypair_references > 2) {     // pkey was freed but keypair was not
+        ec_key_unconditional_free(keypair);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <aws/cryptosdk/cipher.h>
 #include <cbmc_invariants.h>
 #include <ec_utils.h>

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_sig_verify_finish_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += strcmp.0:11, aws_base64_decode.0:16
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_verify_start_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
@@ -24,21 +24,21 @@ CBMCFLAGS += --memory-leak-check
 
 ENTRY = aws_cryptosdk_sig_verify_start_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
-DEPENDENCIES +=	$(SRCDIR)/helper-src/cbmc_invariants.goto
-DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+DEPENDENCIES +=	$(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <aws/cryptosdk/cipher.h>
 #include <cbmc_invariants.h>
 #include <ec_utils.h>

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
@@ -1,0 +1,40 @@
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_verify_start_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_string *pub_key  = ensure_string_is_allocated_bounded_length(MAX_PUBKEY_SIZE);
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assumptions */
+    __CPROVER_assume(props);
+    assert(aws_string_is_valid(pub_key));
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_verify_start(&ctx, alloc, pub_key, props) == AWS_OP_SUCCESS) {
+        /* assertions */
+        assert((!props->impl->curve_name && !ctx) || (aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx) && !ctx->is_sign));
+    }
+
+    /* assertions */
+    assert(aws_string_is_valid(pub_key));
+
+    /* clean up */
+    if (ctx) {
+        EVP_PKEY_free(ctx->pkey);
+        EVP_MD_CTX_free(ctx->ctx);
+        EC_KEY_free(ctx->keypair);
+    }
+    aws_mem_release(alloc, ctx);
+    free(pub_key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_decode.0:16;--object-bits;8"
+goto: aws_cryptosdk_sig_verify_start_harness.goto
+expected: "SUCCESSFUL"

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -670,16 +670,24 @@ int aws_cryptosdk_sig_verify_start(
     struct aws_allocator *alloc,
     const struct aws_string *pub_key,
     const struct aws_cryptosdk_alg_properties *props) {
+    AWS_PRECONDITION(pctx);
+    AWS_PRECONDITION(alloc);
+    AWS_PRECONDITION(aws_string_is_valid(pub_key));
+    AWS_PRECONDITION(props);
     EC_KEY *key                       = NULL;
     struct aws_cryptosdk_sig_ctx *ctx = NULL;
 
     *pctx = NULL;
 
     if (!props->impl->curve_name) {
+        AWS_POSTCONDITION(!*pctx);
+        AWS_POSTCONDITION(aws_string_is_valid(pub_key));
         return AWS_OP_SUCCESS;
     }
 
     if (load_pubkey(&key, props, pub_key)) {
+        AWS_POSTCONDITION(!*pctx);
+        AWS_POSTCONDITION(aws_string_is_valid(pub_key));
         return AWS_OP_ERR;
     }
 
@@ -714,6 +722,9 @@ int aws_cryptosdk_sig_verify_start(
     ctx->is_sign = false;
     *pctx        = ctx;
 
+    AWS_POSTCONDITION(aws_cryptosdk_sig_ctx_is_valid(*pctx));
+    AWS_POSTCONDITION(!(*pctx)->is_sign);
+    AWS_POSTCONDITION(aws_string_is_valid(pub_key));
     return AWS_OP_SUCCESS;
 
 oom:
@@ -724,6 +735,8 @@ rethrow:
         aws_cryptosdk_sig_abort(ctx);
     }
 
+    AWS_POSTCONDITION(!*pctx);
+    AWS_POSTCONDITION(aws_string_is_valid(pub_key));
     return AWS_OP_ERR;
 }
 

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -761,7 +761,10 @@ int aws_cryptosdk_sig_update(struct aws_cryptosdk_sig_ctx *ctx, const struct aws
 }
 
 int aws_cryptosdk_sig_verify_finish(struct aws_cryptosdk_sig_ctx *ctx, const struct aws_string *signature) {
-    assert(!ctx->is_sign);
+    AWS_PRECONDITION(aws_cryptosdk_sig_ctx_is_valid(ctx));
+    AWS_PRECONDITION(ctx->alloc);
+    AWS_PRECONDITION(!ctx->is_sign);
+    AWS_PRECONDITION(aws_string_is_valid(signature));
     bool ok = EVP_DigestVerifyFinal(ctx->ctx, aws_string_bytes(signature), signature->len) == 1;
 
     aws_cryptosdk_sig_abort(ctx);


### PR DESCRIPTION
*Description of changes:* Rebased https://github.com/aws/aws-encryption-sdk-c/pull/418 to work with current master. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

