### PR TITLE
aws_cryptosdk_enc_ctx<init|clear|clean_up> CBMC proofs.

### DIFF
--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -80,8 +80,6 @@ COMMON_REPO_NAME ?= aws-c-common-for-cryptosdk-proofs
 COMMONDIR ?= $(BASEDIR)/$(COMMON_REPO_NAME)
 COMMON_HELPERDIR ?= $(COMMONDIR)/.cbmc-batch
 
-HARNESS_NAME ?= $(ENTRY)_harness.c
-
 ################################################################
 # Setup include directory order
 # Helper-inc must go first, so it can override other includes.
@@ -123,9 +121,6 @@ REMOVE_FUNCTION_BODY += --remove-function-body s_default_realloc
 ABSTRACTIONS += $(LINKFARM)/c-common-helper-stubs/abort_override_assert_false.c
 REMOVE_FUNCTION_BODY += --remove-function-body abort
 ################################################################
-
-REMOVE_FUNCTION_BODY += $(ADDITIONAL_REMOVE_FUNCTION_BODY)
-DEPENDENT_GOTOS = $(patsubst %.c,%.goto,$(DEPENDENCIES))
 
 REMOVE_FUNCTION_BODY += $(ADDITIONAL_REMOVE_FUNCTION_BODY)
 DEPENDENT_GOTOS = $(patsubst %.c,%.goto,$(DEPENDENCIES))
@@ -205,6 +200,7 @@ else
 		2>&1 | tee $(ENTRY)2.log ; exit $${PIPESTATUS[0]}
 endif
 
+
 # ABSTRACTIONS is a list of function stubs to use. If a function body
 # is missing and is not abstracted, then it returnes a non
 # deterministic value.
@@ -216,7 +212,6 @@ else
 	$(GOTO_CC) --function $(ENTRY) $(ABSTRACTIONS) $< $(INC) $(DEFINES) -o $@ \
 		2>&1 | tee $(ENTRY)2.log ; exit $${PIPESTATUS[0]}
 endif
-
 
 ## Temporarily skipped steps
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up-NULL/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up-NULL/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+MAX_TABLE_SIZE ?= 4
+
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
+
+#A table has 10 words for the struct, plus 3 words for each entry
+TABLE_SIZE_IN_WORDS=$(shell echo $$(($$((3 * $(MAX_TABLE_SIZE))) + 10)))
+
+UNWINDSET += aws_hash_table_clear.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+UNWINDSET += memset_override_0_impl.0:$(shell echo $$((1 + $(TABLE_SIZE_IN_WORDS))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_enc_ctx_clean_up_null_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/memset_override_0.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up-NULL/aws_cryptosdk_enc_ctx_clean_up_null_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up-NULL/aws_cryptosdk_enc_ctx_clean_up_null_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <aws/cryptosdk/enc_ctx.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+/**
+ * Checks aws_cryptosdk_enc_ctx_clean_up for the case where
+ * the hash-table has a NULL implementation
+ */
+void aws_cryptosdk_enc_ctx_clean_up_null_harness() {
+    struct aws_hash_table map;
+    map.p_impl = NULL;
+
+    aws_cryptosdk_enc_ctx_clean_up(&map);
+    assert(map.p_impl == NULL);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up-NULL/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up-NULL/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_hash_table_clear.0:5,memset_override_0_impl.0:23;--object-bits;8"
+goto: aws_cryptosdk_enc_ctx_clean_up_null_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+MAX_TABLE_SIZE ?= 4
+
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
+
+#A table has 10 words for the struct, plus 3 words for each entry
+TABLE_SIZE_IN_WORDS=$(shell echo $$(($$((3 * $(MAX_TABLE_SIZE))) + 10)))
+
+UNWINDSET += aws_hash_table_clear.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+UNWINDSET += memset_override_0_impl.0:$(shell echo $$((1 + $(TABLE_SIZE_IN_WORDS))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_enc_ctx_clean_up_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/memset_override_0.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up/aws_cryptosdk_enc_ctx_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up/aws_cryptosdk_enc_ctx_clean_up_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <aws/cryptosdk/enc_ctx.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+/**
+ * Prove the aws_cryptosdk_enc_ctx_clean_up function for the case
+ * where the map has an implentation.  The case where the map.p_impl is
+ * null is handled by a seperate proof.
+ * Ideally, these would be one proof, but __CPROVER_allocated_memory() only
+ * makes sense for non-null hash-table implementations, and CBMC
+ * doesn't work well with __CPROVER_allocated_memory() inside a conditional
+ */
+void aws_cryptosdk_enc_ctx_clean_up_harness() {
+    struct aws_hash_table map;
+    ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+    ensure_hash_table_has_valid_destroy_functions(&map);
+    map.p_impl->alloc = can_fail_allocator();
+
+    struct hash_table_state *state = map.p_impl;
+    size_t empty_slot_idx;
+    size_t size_in_bytes = sizeof(struct hash_table_state) + sizeof(struct hash_table_entry) * state->size;
+    __CPROVER_allocated_memory(state, size_in_bytes);  // tell CBMC to keep the buffer live after the free
+
+    __CPROVER_assume(aws_hash_table_has_an_empty_slot(&map, &empty_slot_idx));
+    aws_cryptosdk_enc_ctx_clean_up(&map);
+    assert(map.p_impl == NULL);
+    assert_all_zeroes(&state->slots[0], state->size * sizeof(state->slots[0]));
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clean_up/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_hash_table_clear.0:5,memset_override_0_impl.0:23;--object-bits;8"
+goto: aws_cryptosdk_enc_ctx_clean_up_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clear/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clear/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+MAX_TABLE_SIZE ?= 4
+
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
+
+#A table has 10 words for the struct, plus 3 words for each entry
+TABLE_SIZE_IN_WORDS=$(shell echo $$(($$((3 * $(MAX_TABLE_SIZE))) + 10)))
+
+UNWINDSET += aws_hash_table_clear.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+UNWINDSET += memset_override_0_impl.0:$(shell echo $$((1 + $(TABLE_SIZE_IN_WORDS))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_enc_ctx_clear_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/memset_override_0.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clear/aws_cryptosdk_enc_ctx_clear_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clear/aws_cryptosdk_enc_ctx_clear_harness.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <aws/cryptosdk/enc_ctx.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void aws_cryptosdk_enc_ctx_clear_harness() {
+    struct aws_hash_table map;
+    ensure_allocated_hash_table(&map, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(&map));
+    ensure_hash_table_has_valid_destroy_functions(&map);
+
+    size_t empty_slot_idx;
+    __CPROVER_assume(aws_hash_table_has_an_empty_slot(&map, &empty_slot_idx));
+    aws_cryptosdk_enc_ctx_clear(&map);
+    assert(aws_hash_table_is_valid(&map));
+    struct hash_table_state *impl = map.p_impl;
+    assert_all_zeroes(&impl->slots[0], impl->size * sizeof(impl->slots[0]));
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clear/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clear/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_hash_table_clear.0:5,memset_override_0_impl.0:23;--object-bits;8"
+goto: aws_cryptosdk_enc_ctx_clear_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/Makefile
@@ -24,7 +24,7 @@ ENTRY = aws_cryptosdk_enc_ctx_init_harness
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
-DEPENDENCIES += $(SRCDIR)/helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is
@@ -13,15 +13,19 @@
 
 
 #########
-# if Makefile.local exists, use it. This provides a way to override the defaults
+# if Makefile.local exists, use it. This provides a way to override the defaults 
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 
-ENTRY = MultiKeyringNew_harness
+######### 
+ENTRY = aws_cryptosdk_enc_ctx_init_harness
 
-DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/multi_keyring.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
 DEPENDENCIES += $(SRCDIR)/helper-src/proof_allocators.c
+
+###########
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/aws_cryptosdk_enc_ctx_init_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/aws_cryptosdk_enc_ctx_init_harness.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/enc_ctx.h>
+#include <proof_helpers/proof_allocators.h>
+
+// This is a memory safety proof for aws_cryptosdk_multi_keyring() defined in
+// https://github.com/aws/aws-encryption-sdk-c/blob/master/source/multi_keyring.c
+void aws_cryptosdk_enc_ctx_init_harness() {
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_hash_table enc_ctx;
+
+    aws_cryptosdk_enc_ctx_init(alloc, &enc_ctx);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_enc_ctx_init_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_new/Makefile
@@ -22,6 +22,6 @@ ENTRY = MultiKeyringNew_harness
 
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/multi_keyring.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
-DEPENDENCIES += $(SRCDIR)/helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
 
 include ../Makefile.common

--- a/include/aws/cryptosdk/enc_ctx.h
+++ b/include/aws/cryptosdk/enc_ctx.h
@@ -52,7 +52,9 @@ int aws_cryptosdk_enc_ctx_init(struct aws_allocator *alloc, struct aws_hash_tabl
  * This is equivalent to aws_hash_table_clear, but provided as an alias for clarity.
  */
 AWS_CRYPTOSDK_STATIC_INLINE void aws_cryptosdk_enc_ctx_clear(struct aws_hash_table *enc_ctx) {
+    AWS_PRECONDITION(aws_hash_table_is_valid(enc_ctx));
     aws_hash_table_clear(enc_ctx);
+    AWS_PRECONDITION(aws_hash_table_is_valid(enc_ctx));
 }
 
 /**
@@ -60,7 +62,13 @@ AWS_CRYPTOSDK_STATIC_INLINE void aws_cryptosdk_enc_ctx_clear(struct aws_hash_tab
  * This is equivalent to aws_hash_table_clean_up, but provided as an alias for clarity.
  */
 AWS_CRYPTOSDK_STATIC_INLINE void aws_cryptosdk_enc_ctx_clean_up(struct aws_hash_table *enc_ctx) {
+    AWS_PRECONDITION(enc_ctx != NULL);
+    AWS_PRECONDITION(
+        enc_ctx->p_impl == NULL || aws_hash_table_is_valid(enc_ctx),
+        "Input aws_hash_table [map] must be valid or hash_table_state pointer [map->p_impl] must be NULL, in case "
+        "aws_hash_table_clean_up was called twice.");
     aws_hash_table_clean_up(enc_ctx);
+    AWS_POSTCONDITION(enc_ctx->p_impl == NULL);
 }
 
 /**

--- a/reformat.sh
+++ b/reformat.sh
@@ -20,8 +20,7 @@ echo "Checking version number"
 VER=$(clang-format --version|cut -f3 -d' '|cut -f1 -d'.')
 if [ $VER -ge 8 ];then
   set -euxo pipefail
-  find {.,aws-encryption-sdk-cpp}/{include,source,tests} examples -name '*.h' -or -name '*.c' -or -name '*.cpp' | xargs clang-format -i
+find {.,aws-encryption-sdk-cpp}/{include,source,tests} .cbmc-batch examples -name '*.h' -or -name '*.c' -or -name '*.cpp' | xargs clang-format -i
 else
   echo "clang-format version 8 or greater is needed to read the format file."
 fi
-

--- a/source/enc_ctx.c
+++ b/source/enc_ctx.c
@@ -12,22 +12,31 @@
  * implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/private/enc_ctx.h>
 #include <aws/cryptosdk/private/utils.h>
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/common.h>
+#include <aws/common/hash_table.h>
 
 int aws_cryptosdk_enc_ctx_init(struct aws_allocator *alloc, struct aws_hash_table *enc_ctx) {
+    AWS_PRECONDITION(alloc);
+    AWS_PRECONDITION(enc_ctx);
     size_t initial_size = 10;  // arbitrary starting point, will resize as necessary
-    return aws_hash_table_init(
-        enc_ctx,
-        alloc,
-        initial_size,
-        aws_hash_string,
-        aws_hash_callback_string_eq,
-        aws_hash_callback_string_destroy,
-        aws_hash_callback_string_destroy);
+    if (aws_hash_table_init(
+            enc_ctx,
+            alloc,
+            initial_size,
+            aws_hash_string,
+            aws_hash_callback_string_eq,
+            aws_hash_callback_string_destroy,
+            aws_hash_callback_string_destroy) == AWS_OP_ERR) {
+        return AWS_OP_ERR;
+    }
+
+    AWS_SUCCEED_WITH_POSTCONDITION(aws_hash_table_is_valid(enc_ctx));
 }
 
 int aws_cryptosdk_enc_ctx_size(size_t *size, const struct aws_hash_table *enc_ctx) {


### PR DESCRIPTION
*Description of changes:*
Supercedes https://github.com/aws/aws-encryption-sdk-c/pull/403

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

