### PR TITLE
Use GitHub Actions to publish docs

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,37 @@
+name: Documentation Builder
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - CHANGELOG.md
+
+jobs:
+  Doxygen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: gh-pages
+      - name: Setup
+        run: |
+          sudo apt update && sudo apt install -y doxygen graphviz
+          cp include/aws/cryptosdk/version.h.in include/aws/cryptosdk/version.h
+          source versions
+          SOURCE_DIR=$(pwd) doxygen doxygen/doxygen.config
+      - name: Update html folder
+        run: |
+          if [ ! -d "doxygen/html" ]; then exit 255; fi
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          rm -rf html
+          mv doxygen/html .
+      - name: Upload docs branch
+          git commit -am "GHA Doxygen"
+      - name: Push docs
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,11 @@ include(FindOpenSSL)
 
 set(PROJECT_NAME aws-encryption-sdk)
 
-# Version number of the SDK to be consumed by C code and Doxygen
-set(MAJOR 1)
-set(MINOR 1)
-set(PATCH 0)
+message(STATUS "Version number of the SDK to be consumed by C code and Doxygen")
+set(MAJOR $ENV{CESDK_MAJOR})
+set(MINOR $ENV{CESDK_MINOR})
+set(PATCH $ENV{CESDK_PATCH})
+message(STAUS "Major_minor_patch ${MAJOR}_${MINOR}_${PATCH}")
 
 # Compiler feature tests and feature flags
 set(USE_ASM TRUE

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Also, see the [API documentation](https://aws.github.io/aws-encryption-sdk-c/htm
 ## Dependencies
 
 The only direct dependencies of this code are OpenSSL 1.0.2 or higher or 1.1.0 or higher and
-[aws-c-common](https://github.com/awslabs/aws-c-common) v0.3.15. You will also need
+[aws-c-common](https://github.com/awslabs/aws-c-common) v0.4.15. You will also need
 a C compiler and CMake 3.9 or higher.
 
 To integrate with [KMS](https://aws.amazon.com/kms/) the AWS Encryption SDK for C also requires

--- a/codebuild/bin/codebuild-test.sh
+++ b/codebuild/bin/codebuild-test.sh
@@ -17,6 +17,7 @@ set -euxo pipefail
 
 PATH=$PWD/build-tools/bin:$PATH
 ROOT=$PWD
+source versions
 
 # End to end tests require valid credentials (instance role, etc..)
 # Disable for local runs.

--- a/codebuild/common-windows.bat
+++ b/codebuild/common-windows.bat
@@ -12,6 +12,7 @@ REM implied. See the License for the specific language governing permissions and
 REM limitations under the License.
 
 set ROOT_SRC_DIR=%cd%
+source versions
 rmdir/s/q \build
 mkdir \build
 cd \build

--- a/doxygen/doxygen.config
+++ b/doxygen/doxygen.config
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "AWS Encryption SDK for C"
-PROJECT_NUMBER         = v$(MAJOR).$(MINOR)
+PROJECT_NUMBER         = v$(MAJOR).$(MINOR).$(PATCH)
 PROJECT_BRIEF          =
 PROJECT_LOGO           = 
 OUTPUT_DIRECTORY       = doxygen
@@ -100,20 +100,21 @@ CITE_BIB_FILES         =
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
-QUIET                  = YES
+QUIET                  = NO
 WARNINGS               = NO
-WARN_IF_UNDOCUMENTED   = NO
-WARN_IF_DOC_ERROR      = NO
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
-WARN_LOGFILE           = 
+WARN_LOGFILE           = doxygen/output.log
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/include \
-                         @CMAKE_CURRENT_SOURCE_DIR@/aws-encryption-sdk-cpp/include \
-                         @GENERATED_INCLUDE@
+INPUT                  = $(SOURCE_DIR)/include \
+                         $(SOURCE_DIR)/aws-encryption-sdk-cpp/include \
+                         README.md \
+                         $(SOURCE_DIR)/.
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.h \
                          *.md

--- a/include/aws/cryptosdk/version.h.in
+++ b/include/aws/cryptosdk/version.h.in
@@ -16,7 +16,7 @@
 #ifndef AWS_CRYPTOSDK_VERSION_H
 #define AWS_CRYPTOSDK_VERSION_H
 
-/*! \mainpage The AWS Encryption SDK for C
+/*! The AWS Encryption SDK for C
  *
  * The AWS Encryption SDK for C is a client-side encryption library designed to make it easy for
  * everyone to encrypt and decrypt data using industry standards and best practices. It uses a

--- a/versions
+++ b/versions
@@ -1,0 +1,8 @@
+# An attempt to centralize version numbers consumable with bash.
+CESDK_MAJOR=1
+CESDK_MINOR=1
+CESDK_PATCH=0
+AWS_SDK_CPP=1.7.231
+AWS_C_COMMON=0.4.15
+AWS_CHECKSUMS=0.1.5
+AWS_C_EVENT_STREAM=0.1.4


### PR DESCRIPTION
*Description of changes:*
Automate away the creation of API docs.  Previously, the version numbers were put into versions.h as part of the build process, in order to remove the need to for a build/test cycle, moved version numbers into env variables.

Manual steps on the mac were:
```
(install all build deps)
mkdir build
cd build
cmake -G Xcode -DBUILD_SHARED_LIBS=OFF -DBUILD_DOC=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl\@1.1 ..
xcodebuild -target doc_doxygen
git checkout gh-pages
rm -rf ../html
mv html ../
cd ../html
git add .
git commit -am "Docs for version xxx"
git push origin gh-pages
(open PR)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [x] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

