### PR TITLE
Proofs for the keyring_trace module

### DIFF
--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -20,6 +20,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+void ensure_alg_properties_attempt_allocation(struct aws_cryptosdk_alg_properties *const alg_props);
+
 /* Allocates the members of the context and ensures that internal pointers are pointing to the correct objects. */
 void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ctx);
 

--- a/.cbmc-batch/jobs/Makefile.string
+++ b/.cbmc-batch/jobs/Makefile.string
@@ -1,0 +1,24 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+# Sufficently long to get 100% coverage on the string APIs
+# short enough that all proofs complete quickly
+MAX_STRING_LEN ?= 16
+
+DEFINES += -DMAX_STRING_LEN=$(MAX_STRING_LEN)

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+CBMCFLAGS +=
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_keyring_trace_init_harness
+
+UNWINDSET += 
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/aws_cryptosdk_keyring_trace_init_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/aws_cryptosdk_keyring_trace_init_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/cryptosdk/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_trace_init_harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_array_list trace;                        /* Precondition: trace must be non-null */
+
+    if (aws_cryptosdk_keyring_trace_init(alloc, &trace) == AWS_OP_SUCCESS) {
+        /* assertions */
+        assert(aws_array_list_is_valid(&trace));
+        assert(trace.alloc == alloc);
+        assert(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+        assert(trace.length == 0);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_keyring_trace_init_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+CBMCFLAGS +=
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_keyring_trace_record_clean_up_harness
+
+UNWINDSET += 
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/aws_cryptosdk_keyring_trace_record_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/aws_cryptosdk_keyring_trace_record_clean_up_harness.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_trace_record_clean_up_harness() {
+    /* data structure */
+    struct aws_cryptosdk_keyring_trace_record record; /* Precondition: record is non-null */
+
+    aws_cryptosdk_keyring_trace_record_clean_up(&record);
+    assert(record.flags == 0);
+    assert(record.wrapping_key_name == NULL);
+    assert(record.wrapping_key_namespace == NULL);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_keyring_trace_record_clean_up_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/Makefile
@@ -1,0 +1,38 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.string
+
+CBMC_UNWINDSET += --unwindset memcmp.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+
+CBMCFLAGS +=
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_keyring_trace_record_init_clone_harness
+
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/aws_cryptosdk_keyring_trace_record_init_clone_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/aws_cryptosdk_keyring_trace_record_init_clone_harness.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_trace_record_init_clone_harness() {
+    /* data structure */
+    struct aws_cryptosdk_keyring_trace_record source_record; /* Precondition: record is non-null */
+    struct aws_cryptosdk_keyring_trace_record dest_record;   /* Precondition: record is non-null */
+    struct aws_allocator *alloc = can_fail_allocator();      /* Precondition: alloc must be non-null */
+
+    source_record.wrapping_key_namespace = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+    source_record.wrapping_key_name      = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+
+    if (aws_cryptosdk_keyring_trace_record_init_clone(alloc, &dest_record, &source_record) == AWS_OP_SUCCESS) {
+        /* assertions */
+        assert(aws_string_eq(source_record.wrapping_key_namespace, dest_record.wrapping_key_namespace));
+        assert(aws_string_eq(source_record.wrapping_key_name, dest_record.wrapping_key_name));
+        assert(source_record.flags == dest_record.flags);
+    } else {
+        /* assertions */
+        assert(dest_record.flags == 0);
+        assert(dest_record.wrapping_key_name == NULL);
+        assert(dest_record.wrapping_key_namespace == NULL);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17;--object-bits;8"
+goto: aws_cryptosdk_keyring_trace_record_init_clone_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/Makefile
@@ -1,0 +1,38 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+UNWINDSET += 
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_serialize_frame_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/framefmt.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/cryptosdk/private/framefmt.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_serialize_frame_harness() {
+    /* data structure */
+    struct aws_cryptosdk_frame frame;
+    size_t ciphertext_size;
+    size_t plaintext_size;
+    struct aws_byte_buf ciphertext_buf;
+    struct aws_cryptosdk_alg_properties alg_props;
+
+    /* Assumptions about the function input */
+    ensure_byte_buf_has_allocated_buffer_member(&ciphertext_buf);
+    __CPROVER_assume(aws_byte_buf_is_valid(&ciphertext_buf));
+
+    ensure_alg_properties_attempt_allocation(&alg_props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(&alg_props));
+
+    /* Save the old state of the ciphertext buffer */
+    uint8_t *old_ciphertext_buffer   = ciphertext_buf.buffer;
+    size_t old_ciphertext_buffer_len = ciphertext_buf.len;
+
+    int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, &alg_props);
+    if (rval == AWS_OP_SUCCESS) {
+        assert(aws_cryptosdk_frame_is_valid(&frame));
+        assert(ciphertext_buf.buffer == old_ciphertext_buffer);
+        assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
+    } else {
+        // Assert that the ciphertext buffer is zeroed in case of failure
+        assert_all_zeroes(ciphertext_buf.buffer, ciphertext_buf.capacity);
+        assert(ciphertext_buf.len == 0);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_serialize_frame/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_serialize_frame_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/Makefile
@@ -1,0 +1,36 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+include ../Makefile.string
+
+CBMC_UNWINDSET += --unwindset memcmp.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+
+CBMCFLAGS +=
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcmp_override.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_string_dup_harness
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/aws_cryptosdk_string_dup_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/aws_cryptosdk_string_dup_harness.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/common/string.h>
+#include <aws/cryptosdk/private/utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+
+void aws_cryptosdk_string_dup_harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_string *str_a    = ensure_string_is_allocated_bounded_length(MAX_STRING_LEN);
+
+    struct aws_string *str_b = aws_cryptosdk_string_dup(alloc, str_a);
+    /* assertions */
+    aws_string_eq(str_a, str_b);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_string_dup/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_string_dup/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17;--object-bits;8"
+goto: aws_cryptosdk_string_dup_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -25,6 +25,15 @@
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 
+void ensure_alg_properties_attempt_allocation(struct aws_cryptosdk_alg_properties *const alg_props) {
+    size_t md_name_size;
+    alg_props->md_name = can_fail_malloc(md_name_size);
+    size_t cipher_name_size;
+    alg_props->cipher_name = can_fail_malloc(cipher_name_size);
+    size_t alg_name_size;
+    alg_props->alg_name = can_fail_malloc(alg_name_size);
+}
+
 void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ctx) {
     ctx->alloc      = nondet_bool() ? NULL : can_fail_allocator();
     ctx->evp_md_ctx = evp_md_ctx_nondet_alloc();

--- a/include/aws/cryptosdk/cipher.h
+++ b/include/aws/cryptosdk/cipher.h
@@ -102,6 +102,12 @@ AWS_CRYPTOSDK_API
 const struct aws_cryptosdk_alg_properties *aws_cryptosdk_alg_props(enum aws_cryptosdk_alg_id alg_id);
 
 /**
+ * Checks whether an aws_cryptosdk_alg_properties is valid and supported by the SDK.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props);
+
+/**
  * An opaque structure representing an ongoing sign or verify operation
  */
 struct aws_cryptosdk_sig_ctx;

--- a/include/aws/cryptosdk/private/framefmt.h
+++ b/include/aws/cryptosdk/private/framefmt.h
@@ -17,6 +17,7 @@
 #define AWS_CRYPTOSDK_PRIVATE_FRAMEFMT_H
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/cipher.h>
 
@@ -32,6 +33,20 @@ struct aws_cryptosdk_frame {
     /* A cursor to space for the AEAD tag in the ciphertext buffer */
     struct aws_byte_buf authtag;
 };
+
+// MAX_FRAME_SIZE = 2^32 - 1
+#define MAX_FRAME_SIZE 0xFFFFFFFF
+// MAX_FRAMES = 2^32 - 1
+#define MAX_FRAMES 0xFFFFFFFF
+// MAX_UNFRAMED_PLAINTEXT_SIZE = 2^36 - 32
+#define MAX_UNFRAMED_PLAINTEXT_SIZE 0xFFFFFFFE0ull
+
+/**
+ * Checks whether a frame struct is valid. At the moment this means
+ * that it checks the validity of the byte buffers and the fact that
+ * they should have NULL allocators.
+ */
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame);
 
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all

--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -21,7 +21,6 @@
 #include <aws/cryptosdk/session.h>
 
 #define DEFAULT_FRAME_SIZE (256 * 1024)
-#define MAX_FRAME_SIZE 0xFFFFFFFF
 
 enum session_state {
     /*** Common states ***/

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -88,6 +88,32 @@ static enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk
     }
 }
 
+static bool aws_cryptosdk_alg_properties_equal(
+    const struct aws_cryptosdk_alg_properties alg_props1, const struct aws_cryptosdk_alg_properties alg_props2) {
+    /* Note: We are not checking whether the names (md/cipher/alg) are
+     * equal */
+
+    /* Note: We are not checking whether the underlying alg_impl
+     * structs are equal. */
+    return alg_props1.data_key_len == alg_props2.data_key_len &&
+           alg_props1.content_key_len == alg_props2.content_key_len && alg_props1.iv_len == alg_props2.iv_len &&
+           alg_props1.tag_len == alg_props2.tag_len && alg_props1.signature_len == alg_props2.signature_len &&
+           alg_props1.alg_id == alg_props2.alg_id;
+}
+
+bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_properties *const alg_props) {
+    if (alg_props == NULL) {
+        return false;
+    }
+    enum aws_cryptosdk_alg_id id                             = alg_props->alg_id;
+    const struct aws_cryptosdk_alg_properties *std_alg_props = aws_cryptosdk_alg_props(id);
+    if (std_alg_props == NULL) {
+        return false;
+    }
+    return alg_props->md_name && alg_props->cipher_name && alg_props->alg_name &&
+           aws_cryptosdk_alg_properties_equal(*alg_props, *std_alg_props);
+}
+
 int aws_cryptosdk_derive_key(
     const struct aws_cryptosdk_alg_properties *props,
     struct content_key *content_key,

--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <aws/common/common.h>
 #include <aws/common/error.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/private/framefmt.h>
@@ -213,6 +214,24 @@ static inline int serde_nonframed(
     return AWS_ERROR_SUCCESS;
 }
 
+bool aws_cryptosdk_frame_is_valid(const struct aws_cryptosdk_frame *const frame) {
+    bool iv_byte_buf_valid  = aws_byte_buf_is_valid(&frame->iv);
+    bool iv_byte_buf_static = frame->iv.allocator == NULL;
+
+    bool authtag_byte_buf_valid  = aws_byte_buf_is_valid(&frame->authtag);
+    bool authtag_byte_buf_static = frame->authtag.allocator == NULL;
+
+    bool ciphertext_byte_buf_valid = aws_byte_buf_is_valid(&frame->ciphertext);
+    /* This happens when input plaintext size is 0 */
+    bool ciphertext_valid_zero =
+        frame->ciphertext.len == 0 && frame->ciphertext.buffer && frame->ciphertext.capacity == 0;
+    bool ciphertext_valid  = ciphertext_byte_buf_valid || ciphertext_valid_zero;
+    bool ciphertext_static = frame->ciphertext.allocator == NULL;
+
+    return iv_byte_buf_valid && iv_byte_buf_static && authtag_byte_buf_valid && authtag_byte_buf_static &&
+           ciphertext_valid && ciphertext_static;
+}
+
 /**
  * Performs frame-type-specific work prior to writing a frame; writes out all
  * fields except for the IV, ciphertext, and authtag, and returns their
@@ -235,14 +254,25 @@ int aws_cryptosdk_serialize_frame(
     size_t plaintext_size,
     struct aws_byte_buf *ciphertext_buf,
     const struct aws_cryptosdk_alg_properties *alg_props) {
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
     struct aws_cryptosdk_framestate state;
+
+    // The plaintext_size should be bound to prevent arithmetic
+    // overflows due to addition
+    if ((frame->type == FRAME_TYPE_SINGLE && plaintext_size > MAX_UNFRAMED_PLAINTEXT_SIZE) ||
+        (frame->type != FRAME_TYPE_SINGLE && plaintext_size > MAX_FRAME_SIZE)) {
+        // Clear the ciphertext buffer
+        aws_byte_buf_secure_zero(ciphertext_buf);
+        return aws_raise_error(AWS_CRYPTOSDK_ERR_LIMIT_EXCEEDED);
+    }
 
     // We assume that the max frame size is equal to the plaintext size. This
     // lets us avoid having to pass in a redundant argument, avoids needing to
     // take a branch in serde_framed, and does not impact the serialized
     // output.
-    state.max_frame_size  = plaintext_size;
-    state.plaintext_size  = plaintext_size;
+    state.max_frame_size = plaintext_size;
+    state.plaintext_size = plaintext_size;
+    // Currently all supported algorithms have plaintext = ciphertext size
     state.ciphertext_size = 0;
 
     state.alg_props = alg_props;
@@ -270,6 +300,7 @@ int aws_cryptosdk_serialize_frame(
         return aws_raise_error(result);
     } else {
         *ciphertext_buf = state.u.buffer;
+        AWS_POSTCONDITION(aws_cryptosdk_frame_is_valid(frame));
         return AWS_OP_SUCCESS;
     }
 }

--- a/source/keyring_trace.c
+++ b/source/keyring_trace.c
@@ -16,10 +16,16 @@
 #include <aws/cryptosdk/private/utils.h>
 
 void aws_cryptosdk_keyring_trace_record_clean_up(struct aws_cryptosdk_keyring_trace_record *record) {
+    AWS_OBJECT_PTR_IS_WRITABLE(record);
+    AWS_OBJECT_PTR_IS_WRITABLE(record->wrapping_key_name);
+    AWS_OBJECT_PTR_IS_WRITABLE(record->wrapping_key_namespace);
     aws_string_destroy(record->wrapping_key_namespace);
     aws_string_destroy(record->wrapping_key_name);
     record->flags                  = 0;
     record->wrapping_key_namespace = record->wrapping_key_name = NULL;
+    AWS_POSTCONDITION(record->flags == 0);
+    AWS_POSTCONDITION(record->wrapping_key_name == NULL);
+    AWS_POSTCONDITION(record->wrapping_key_namespace == NULL);
 }
 
 static inline int record_init_check(struct aws_cryptosdk_keyring_trace_record *record) {
@@ -83,7 +89,6 @@ int aws_cryptosdk_keyring_trace_add_record(
     struct aws_cryptosdk_keyring_trace_record record;
     int ret = record_init_from_strings(alloc, &record, wk_namespace, wk_name, flags);
     if (ret) return ret;
-
     return push_record_onto_trace(trace, &record);
 }
 
@@ -115,21 +120,44 @@ int aws_cryptosdk_keyring_trace_add_record_buf(
 
 int aws_cryptosdk_keyring_trace_init(struct aws_allocator *alloc, struct aws_array_list *trace) {
     // arbitrary starting point, list will resize as necessary
+    AWS_OBJECT_PTR_IS_WRITABLE(trace);
+    AWS_OBJECT_PTR_IS_WRITABLE(alloc);
     const int initial_size = 10;
-    return aws_array_list_init_dynamic(trace, alloc, initial_size, sizeof(struct aws_cryptosdk_keyring_trace_record));
+    int r_val =
+        aws_array_list_init_dynamic(trace, alloc, initial_size, sizeof(struct aws_cryptosdk_keyring_trace_record));
+    if (r_val == AWS_OP_SUCCESS) {
+        AWS_POSTCONDITION(aws_array_list_is_valid(trace));
+        AWS_POSTCONDITION(trace->alloc == alloc);
+        AWS_POSTCONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+        AWS_POSTCONDITION(trace->length == 0);
+    }
+    return r_val;
 }
 
 int aws_cryptosdk_keyring_trace_record_init_clone(
     struct aws_allocator *alloc,
     struct aws_cryptosdk_keyring_trace_record *dest,
     const struct aws_cryptosdk_keyring_trace_record *src) {
+    aws_allocator_is_valid(alloc);
+    AWS_OBJECT_PTR_IS_WRITABLE(dest);
+    AWS_OBJECT_PTR_IS_WRITABLE(src);
+
+    AWS_FATAL_PRECONDITION(aws_string_is_valid(src->wrapping_key_namespace));
+    AWS_FATAL_PRECONDITION(aws_string_is_valid(src->wrapping_key_name));
+
     dest->wrapping_key_namespace = aws_cryptosdk_string_dup(alloc, src->wrapping_key_namespace);
     dest->wrapping_key_name      = aws_cryptosdk_string_dup(alloc, src->wrapping_key_name);
     if (record_init_check(dest)) {
         aws_cryptosdk_keyring_trace_record_clean_up(dest);
+        AWS_POSTCONDITION(dest->flags == 0);
+        AWS_POSTCONDITION(dest->wrapping_key_name == NULL);
+        AWS_POSTCONDITION(dest->wrapping_key_namespace == NULL);
         return AWS_OP_ERR;
     }
     dest->flags = src->flags;
+    AWS_POSTCONDITION(aws_string_eq(src->wrapping_key_namespace, dest->wrapping_key_namespace));
+    AWS_POSTCONDITION(aws_string_eq(src->wrapping_key_name, dest->wrapping_key_name));
+    AWS_POSTCONDITION(src->flags == dest->flags);
     return AWS_OP_SUCCESS;
 }
 

--- a/source/utils.c
+++ b/source/utils.c
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 #include <assert.h>
+#include <aws/common/string.h>
 #include <aws/cryptosdk/private/utils.h>
 
 int aws_cryptosdk_compare_hash_elems_by_key_string(const void *elem_a, const void *elem_b) {
@@ -41,6 +42,9 @@ int aws_cryptosdk_hash_elems_array_init(
 }
 
 struct aws_string *aws_cryptosdk_string_dup(struct aws_allocator *alloc, const struct aws_string *str) {
-    if (str->allocator) return aws_string_new_from_string(alloc, str);
+    aws_allocator_is_valid(alloc);
+    if (str->allocator) {
+        return aws_string_new_from_string(alloc, str);
+    }
     return (struct aws_string *)str;
 }


### PR DESCRIPTION
*Description of changes:* This PR is a rebase and update of https://github.com/aws/aws-encryption-sdk-c/pull/402, which adds CBMC tests for the keyring_trace module. Changes were made to address comments left in that PR and adapt the code to work with the current master branch. A few comments about code style were not addressed since the requested changes would make the code style inconsistent with existing code in the C-ESDK.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

