### PR TITLE
Proof harnesses for aws_cryptosdk_sig_verify_{start, finish}

### DIFF
--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -42,7 +42,12 @@ HARNESS_NAME ?= $(ENTRY).c
 
 ################################################################
 # Default CBMC flags
+
+#debugability
 CBMC_VERBOSITY ?= ""
+CBMCFLAGS += --flush
+
+#error checking
 CBMCFLAGS += --bounds-check
 CBMCFLAGS += --div-by-zero-check
 CBMCFLAGS += --float-overflow-check
@@ -293,6 +298,16 @@ report: cbmc.log property.xml coverage.xml
 	--result cbmc.log \
 	--srcdir $(SRCDIR) \
 	--srcexclude "(./verification|./tests|./tools|./lib/third_party)"
+
+propertyreport: cbmc.log property.xml 
+	$(VIEWER) \
+	--goto $(ENTRY).goto \
+	--htmldir html \
+	--property property.xml \
+	--result cbmc.log \
+	--srcdir $(SRCDIR) \
+	--srcexclude "(./verification|./tests|./tools|./lib/third_party)"
+
 
 clean:
 	$(RM) *.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
@@ -19,9 +19,6 @@ include ../Makefile.local_default
 
 UNWINDSET +=
 
-# Added check for memory leak
-CBMCFLAGS += --memory-leak-check
-
 ENTRY = aws_cryptosdk_sig_verify_finish_harness
 
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET +=
+
+# Added check for memory leak
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_verify_finish_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/Makefile
@@ -21,14 +21,14 @@ UNWINDSET +=
 
 ENTRY = aws_cryptosdk_sig_verify_finish_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
@@ -44,13 +44,4 @@ void aws_cryptosdk_sig_verify_finish_harness() {
 
     /* operation under verification */
     aws_cryptosdk_sig_verify_finish(ctx, signature);
-
-    /* clean up (necessary because we are checking for memory leaks) */
-    free(signature);
-    if (pkey_references > 2) {
-        evp_pkey_unconditional_free(pkey);
-        ec_key_unconditional_free(keypair);  // pkey holds a reference to keypair, have to free that as well
-    } else if (keypair_references > 2) {     // pkey was freed but keypair was not
-        ec_key_unconditional_free(keypair);
-    }
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_verify_finish_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx = can_fail_malloc(sizeof(struct aws_cryptosdk_sig_ctx));
+    struct aws_string *signature      = ensure_string_is_allocated_nondet_length();
+
+    /* assumptions */
+    __CPROVER_assume(ctx);
+    ensure_sig_ctx_has_allocated_members(ctx);
+    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+    __CPROVER_assume(ctx->alloc);
+    __CPROVER_assume(!ctx->is_sign);
+    assert(aws_string_is_valid(signature));
+
+    /* saving state */
+    EC_KEY *keypair        = ctx->keypair;
+    int keypair_references = ec_key_get_reference_count(keypair);
+    EVP_PKEY *pkey         = ctx->pkey;
+    int pkey_references    = evp_pkey_get_reference_count(pkey);
+
+    /* operation under verification */
+    aws_cryptosdk_sig_verify_finish(ctx, signature);
+
+    /* clean up (necessary because we are checking for memory leaks) */
+    free(signature);
+    if (pkey_references > 2) {
+        evp_pkey_unconditional_free(pkey);
+        ec_key_unconditional_free(keypair);  // pkey holds a reference to keypair, have to free that as well
+    } else if (keypair_references > 2) {     // pkey was freed but keypair was not
+        ec_key_unconditional_free(keypair);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  * this file except in compliance with the License. A copy of the License is

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/aws_cryptosdk_sig_verify_finish_harness.c
@@ -15,13 +15,12 @@
 
 #include <aws/cryptosdk/cipher.h>
 #include <cbmc_invariants.h>
+#include <cipher_openssl.h>
 #include <ec_utils.h>
 #include <evp_utils.h>
 #include <make_common_data_structures.h>
 #include <proof_allocators.h>
 #include <proof_helpers/proof_allocators.h>
-
-#include <cipher_openssl.h>
 
 void aws_cryptosdk_sig_verify_finish_harness() {
     /* arguments */

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 goto: aws_cryptosdk_sig_verify_finish_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_sig_verify_finish_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_finish/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-goto: aws_cryptosdk_sig_verify_finish_harness.goto
 expected: "SUCCESSFUL"
+goto: aws_cryptosdk_sig_verify_finish_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
@@ -1,0 +1,45 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += strcmp.0:11, aws_base64_decode.0:16
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_verify_start_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES +=	$(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
@@ -20,7 +20,7 @@ include ../Makefile.local_default
 UNWINDSET += strcmp.0:11, aws_base64_decode.0:16
 
 # Added check for memory leaks
-CBMCFLAGS += --memory-leak-check
+#CBMCFLAGS += --memory-leak-check
 
 ENTRY = aws_cryptosdk_sig_verify_start_harness
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
@@ -19,21 +19,18 @@ include ../Makefile.local_default
 
 UNWINDSET += strcmp.0:11, aws_base64_decode.0:16
 
-# Added check for memory leaks
-#CBMCFLAGS += --memory-leak-check
-
 ENTRY = aws_cryptosdk_sig_verify_start_harness
 
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
-DEPENDENCIES +=	$(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/Makefile
@@ -17,17 +17,21 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 
-UNWINDSET += strcmp.0:11, aws_base64_decode.0:16
+UNWINDSET += strcmp.0:11
 
 ENTRY = aws_cryptosdk_sig_verify_start_harness
+
+ABSTRACTIONS += $(SRCDIR)/helper-stubs/aws_base64_decode.c
 
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/memset_override_no_op.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/encoding.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/string.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
@@ -36,6 +40,8 @@ DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
+
+REMOVE_FUNCTION_BODY += --remove-function-body aws_base64_decode
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_allocators.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_verify_start_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_string *pub_key  = ensure_string_is_allocated_bounded_length(MAX_PUBKEY_SIZE);
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+
+    /* assumptions */
+    __CPROVER_assume(props);
+    assert(aws_string_is_valid(pub_key));
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_verify_start(&ctx, alloc, pub_key, props) == AWS_OP_SUCCESS) {
+        /* assertions */
+        assert((!props->impl->curve_name && !ctx) || (aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx) && !ctx->is_sign));
+    }
+
+    /* assertions */
+    assert(aws_string_is_valid(pub_key));
+
+    /* clean up */
+    if (ctx) {
+        EVP_PKEY_free(ctx->pkey);
+        EVP_MD_CTX_free(ctx->ctx);
+        EC_KEY_free(ctx->keypair);
+    }
+    aws_mem_release(alloc, ctx);
+    free(pub_key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
@@ -45,6 +45,7 @@ void aws_cryptosdk_sig_verify_start_harness() {
     assert(aws_string_is_valid(pub_key));
 
     /* clean up */
+    /*
     if (ctx) {
         EVP_PKEY_free(ctx->pkey);
         EVP_MD_CTX_free(ctx->ctx);
@@ -52,4 +53,5 @@ void aws_cryptosdk_sig_verify_start_harness() {
     }
     aws_mem_release(alloc, ctx);
     free(pub_key);
+    */
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  * this file except in compliance with the License. A copy of the License is

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/aws_cryptosdk_sig_verify_start_harness.c
@@ -15,13 +15,12 @@
 
 #include <aws/cryptosdk/cipher.h>
 #include <cbmc_invariants.h>
+#include <cipher_openssl.h>
 #include <ec_utils.h>
 #include <evp_utils.h>
 #include <make_common_data_structures.h>
 #include <proof_allocators.h>
 #include <proof_helpers/proof_allocators.h>
-
-#include <cipher_openssl.h>
 
 void aws_cryptosdk_sig_verify_start_harness() {
     /* arguments */
@@ -43,15 +42,4 @@ void aws_cryptosdk_sig_verify_start_harness() {
 
     /* assertions */
     assert(aws_string_is_valid(pub_key));
-
-    /* clean up */
-    /*
-    if (ctx) {
-        EVP_PKEY_free(ctx->pkey);
-        EVP_MD_CTX_free(ctx->ctx);
-        EC_KEY_free(ctx->keypair);
-    }
-    aws_mem_release(alloc, ctx);
-    free(pub_key);
-    */
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_decode.0:16;--object-bits;8"
+goto: aws_cryptosdk_sig_verify_start_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
@@ -1,4 +1,4 @@
 jobos: ubuntu16
-cbmcflags: "--memory-leak-check;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_decode.0:16;--object-bits;8"
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_decode.0:16;--object-bits;8"
 goto: aws_cryptosdk_sig_verify_start_harness.goto
 expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_decode.0:16;--object-bits;8"
+cbmcflags: "--flush;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11;--object-bits;8"
 expected: "SUCCESSFUL"
 goto: aws_cryptosdk_sig_verify_start_harness.goto
 jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_verify_start/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;strcmp.0:11,,aws_base64_decode.0:16;--object-bits;8"
-goto: aws_cryptosdk_sig_verify_start_harness.goto
 expected: "SUCCESSFUL"
+goto: aws_cryptosdk_sig_verify_start_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/source/openssl/objects_override.c
+++ b/.cbmc-batch/source/openssl/objects_override.c
@@ -13,9 +13,10 @@
  * permissions and limitations under the License.
  */
 
+#include <assert.h>
 #include <openssl/objects.h>
-
 #include <proof_helpers/nondet.h>
+#include <string.h>
 
 /*
  * Description: OBJ_txt2nid() returns NID corresponding to text string <s>. s can be a long name, a short name or the
@@ -23,13 +24,14 @@
  */
 int OBJ_txt2nid(const char *s) {
     // Currently these are the only values used in the ESDK
-    assert(!s || strcmp(s, "prime256v1") == 0 || strcmp(s, "secp384r1") == 0);
-
     if (!s) {
         return NID_undef;
     } else if (strcmp(s, "prime256v1") == 0) {
         return NID_X9_62_prime256v1;
-    } else {  // s is "secp384r1"
+    } else if (strcmp(s, "secp384r1") == 0) {
         return NID_secp384r1;
+    } else {
+        __CPROVER_assert(0, "s had unexpected value");
     }
+    return nondet_int();
 }

--- a/.cbmc-batch/stubs/aws_base64_decode.c
+++ b/.cbmc-batch/stubs/aws_base64_decode.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/encoding.h>
+#include <proof_helpers/nondet.h>
+
+/**
+ * Stub for base64 decode.  Doesn't actually write the values, hence a lot faster.  Safe as long as output buffer was
+ * already unconstrained.
+ */
+int aws_base64_decode(const struct aws_byte_cursor *AWS_RESTRICT to_decode, struct aws_byte_buf *AWS_RESTRICT output) {
+    size_t decoded_length = 0;
+
+    if (AWS_UNLIKELY(aws_base64_compute_decoded_len(to_decode, &decoded_length))) {
+        return AWS_OP_ERR;
+    }
+
+    if (output->capacity < decoded_length) {
+        return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
+    }
+
+    if (nondet_bool()) {
+        return aws_raise_error(AWS_ERROR_INVALID_BASE64_STR);
+    }
+
+    output->len = decoded_length;
+    return AWS_OP_SUCCESS;
+}

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -682,16 +682,24 @@ int aws_cryptosdk_sig_verify_start(
     struct aws_allocator *alloc,
     const struct aws_string *pub_key,
     const struct aws_cryptosdk_alg_properties *props) {
+    AWS_PRECONDITION(pctx);
+    AWS_PRECONDITION(alloc);
+    AWS_PRECONDITION(aws_string_is_valid(pub_key));
+    AWS_PRECONDITION(props);
     EC_KEY *key                       = NULL;
     struct aws_cryptosdk_sig_ctx *ctx = NULL;
 
     *pctx = NULL;
 
     if (!props->impl->curve_name) {
+        AWS_POSTCONDITION(!*pctx);
+        AWS_POSTCONDITION(aws_string_is_valid(pub_key));
         return AWS_OP_SUCCESS;
     }
 
     if (load_pubkey(&key, props, pub_key)) {
+        AWS_POSTCONDITION(!*pctx);
+        AWS_POSTCONDITION(aws_string_is_valid(pub_key));
         return AWS_OP_ERR;
     }
 
@@ -726,6 +734,9 @@ int aws_cryptosdk_sig_verify_start(
     ctx->is_sign = false;
     *pctx        = ctx;
 
+    AWS_POSTCONDITION(aws_cryptosdk_sig_ctx_is_valid(*pctx));
+    AWS_POSTCONDITION(!(*pctx)->is_sign);
+    AWS_POSTCONDITION(aws_string_is_valid(pub_key));
     return AWS_OP_SUCCESS;
 
 oom:
@@ -736,6 +747,8 @@ rethrow:
         aws_cryptosdk_sig_abort(ctx);
     }
 
+    AWS_POSTCONDITION(!*pctx);
+    AWS_POSTCONDITION(aws_string_is_valid(pub_key));
     return AWS_OP_ERR;
 }
 
@@ -760,7 +773,10 @@ int aws_cryptosdk_sig_update(struct aws_cryptosdk_sig_ctx *ctx, const struct aws
 }
 
 int aws_cryptosdk_sig_verify_finish(struct aws_cryptosdk_sig_ctx *ctx, const struct aws_string *signature) {
-    assert(!ctx->is_sign);
+    AWS_PRECONDITION(aws_cryptosdk_sig_ctx_is_valid(ctx));
+    AWS_PRECONDITION(ctx->alloc);
+    AWS_PRECONDITION(!ctx->is_sign);
+    AWS_PRECONDITION(aws_string_is_valid(signature));
     bool ok = EVP_DigestVerifyFinal(ctx->ctx, aws_string_bytes(signature), signature->len) == 1;
 
     aws_cryptosdk_sig_abort(ctx);

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -706,9 +706,7 @@ int aws_cryptosdk_sig_verify_start(
     };
 
     if (load_pubkey(&ctx->keypair, props, pub_key)) {
-        AWS_POSTCONDITION(!*pctx);
-        AWS_POSTCONDITION(aws_string_is_valid(pub_key));
-        return AWS_OP_ERR;
+        goto rethrow;
     }
 
     if (!(ctx->pkey = EVP_PKEY_new())) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replaces https://github.com/aws/aws-encryption-sdk-c/pull/418

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

