### PR TITLE
Adds proofs for aws_cryptosdk_aes_gcm and aws_cryptosdk_aes_gcm_decrypt

### DIFF
--- a/.cbmc-batch/include/openssl/err.h
+++ b/.cbmc-batch/include/openssl/err.h
@@ -21,4 +21,6 @@
 
 void ERR_print_errors_fp(FILE *fp);
 
+signed int ERR_get_error(void);
+
 #endif

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -58,6 +58,10 @@ int EVP_CipherInit_ex(
     int enc);
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr);
 void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx);
+int EVP_EncryptInit_ex(
+    EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv);
+int EVP_DecryptInit_ex(
+    EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, ENGINE *impl, const unsigned char *key, const unsigned char *iv);
 int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
 int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);

--- a/.cbmc-batch/jobs/Makefile.aws_byte_buf
+++ b/.cbmc-batch/jobs/Makefile.aws_byte_buf
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 ##########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
+# if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -299,7 +299,7 @@ report: cbmc.log property.xml coverage.xml
 	--srcdir $(SRCDIR) \
 	--srcexclude "(./verification|./tests|./tools|./lib/third_party)"
 
-propertyreport: cbmc.log property.xml 
+propertyreport: cbmc.log property.xml
 	$(VIEWER) \
 	--goto $(ENTRY).goto \
 	--htmldir html \

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/Makefile
@@ -1,4 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is
@@ -12,36 +12,36 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults
+# if Makefile.local exists, use it. This provides a way to override the defaults 
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+include ../Makefile.string
 
-UNWINDSET += strcmp.0:11
 
-ENTRY = aws_cryptosdk_sig_verify_start_harness
+UNWINDSET += flush_openssl_errors.0:1
 
-ABSTRACTIONS += $(SRCDIR)/helper-stubs/aws_base64_decode.c
+CBMCFLAGS += 
 
+ENTRY = aws_cryptosdk_aes_gcm_decrypt_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
-DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/memset_override_no_op.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/encoding.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/string.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
-
-REMOVE_FUNCTION_BODY += --remove-function-body aws_base64_decode
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/aws_cryptosdk_aes_gcm_decrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/aws_cryptosdk_aes_gcm_decrypt_harness.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+#define KEY_LEN 256
+
+void aws_cryptosdk_aes_gcm_decrypt_harness() {
+    struct aws_byte_buf plain;
+    struct aws_byte_cursor cipher;
+    struct aws_byte_cursor tag;
+    struct aws_byte_cursor iv;
+    struct aws_byte_cursor aad;
+    struct aws_string *key;
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&plain, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&plain);
+    __CPROVER_assume(aws_byte_buf_is_valid(&plain));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&cipher, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cipher));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&tag, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&tag);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&tag));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&iv, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&iv);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&iv));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&aad, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&aad);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&aad));
+
+    key = ensure_string_is_allocated_bounded_length(KEY_LEN);
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cipher = cipher;
+    struct store_byte_from_buffer old_byte_from_cipher;
+    save_byte_from_array(cipher.ptr, cipher.len, &old_byte_from_cipher);
+
+    struct aws_byte_cursor old_tag = tag;
+    struct store_byte_from_buffer old_byte_from_tag;
+    save_byte_from_array(tag.ptr, tag.len, &old_byte_from_tag);
+
+    struct aws_byte_cursor old_iv = iv;
+    struct store_byte_from_buffer old_byte_from_iv;
+    save_byte_from_array(iv.ptr, iv.len, &old_byte_from_iv);
+
+    struct aws_byte_cursor old_aad = aad;
+    struct store_byte_from_buffer old_byte_from_aad;
+    save_byte_from_array(aad.ptr, aad.len, &old_byte_from_aad);
+
+    if (aws_cryptosdk_aes_gcm_decrypt(&plain, cipher, tag, iv, aad, key) == AWS_OP_SUCCESS) {
+        assert(plain.len == cipher.len);
+    }
+    assert(aws_byte_buf_is_valid(&plain));
+    if (cipher.len != 0) {
+        assert_byte_from_buffer_matches(cipher.ptr, &old_byte_from_cipher);
+    }
+    if (tag.len != 0) {
+        assert_byte_from_buffer_matches(tag.ptr, &old_byte_from_tag);
+    }
+    if (iv.len != 0) {
+        assert_byte_from_buffer_matches(iv.ptr, &old_byte_from_iv);
+    }
+    if (aad.len != 0) {
+        assert_byte_from_buffer_matches(aad.ptr, &old_byte_from_aad);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;flush_openssl_errors.0:1;--object-bits;8"
+goto: aws_cryptosdk_aes_gcm_decrypt_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/Makefile
@@ -1,4 +1,4 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is
@@ -12,36 +12,36 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults
+# if Makefile.local exists, use it. This provides a way to override the defaults 
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+include ../Makefile.string
 
-UNWINDSET += strcmp.0:11
 
-ENTRY = aws_cryptosdk_sig_verify_start_harness
+UNWINDSET += flush_openssl_errors.0:1
 
-ABSTRACTIONS += $(SRCDIR)/helper-stubs/aws_base64_decode.c
+CBMCFLAGS += 
 
+ENTRY = aws_cryptosdk_aes_gcm_encrypt_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
-DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/memset_override_no_op.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/encoding.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/string.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
-DEPENDENCIES += $(SRCDIR)/helper-src/openssl/objects_override.goto
-
-REMOVE_FUNCTION_BODY += --remove-function-body aws_base64_decode
 
 ###########
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/aws_cryptosdk_aes_gcm_encrypt_harness.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+#define KEY_LEN 256
+
+void aws_cryptosdk_aes_gcm_encrypt_harness() {
+    struct aws_byte_buf cipher;
+    struct aws_byte_buf tag;
+    struct aws_byte_cursor plain;
+    struct aws_byte_cursor iv;
+    struct aws_byte_cursor aad;
+    struct aws_string *key;
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&cipher, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_buf_is_valid(&cipher));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&tag, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&tag);
+    __CPROVER_assume(aws_byte_buf_is_valid(&tag));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&plain, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&plain);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&plain));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&iv, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&iv);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&iv));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&aad, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&aad);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&aad));
+
+    /* save current state of the data structure */
+
+    struct aws_byte_cursor old_plain = plain;
+    struct store_byte_from_buffer old_byte_from_plain;
+    save_byte_from_array(plain.ptr, plain.len, &old_byte_from_plain);
+
+    struct aws_byte_cursor old_iv = iv;
+    struct store_byte_from_buffer old_byte_from_iv;
+    save_byte_from_array(iv.ptr, iv.len, &old_byte_from_iv);
+
+    struct aws_byte_cursor old_aad = aad;
+    struct store_byte_from_buffer old_byte_from_aad;
+    save_byte_from_array(aad.ptr, aad.len, &old_byte_from_aad);
+
+    key = ensure_string_is_allocated_bounded_length(KEY_LEN);
+
+    if (aws_cryptosdk_aes_gcm_encrypt(&cipher, &tag, plain, iv, aad, key) == AWS_OP_SUCCESS) {
+        assert(cipher.len == plain.len);
+    }
+
+    assert(aws_byte_buf_is_valid(&cipher));
+    if (plain.len != 0) {
+        assert_byte_from_buffer_matches(plain.ptr, &old_byte_from_plain);
+    }
+    if (iv.len != 0) {
+        assert_byte_from_buffer_matches(iv.ptr, &old_byte_from_iv);
+    }
+    if (aad.len != 0) {
+        assert_byte_from_buffer_matches(aad.ptr, &old_byte_from_aad);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_encrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;flush_openssl_errors.0:1;--object-bits;8"
+goto: aws_cryptosdk_aes_gcm_encrypt_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/source/openssl/err_override.c
+++ b/.cbmc-batch/source/openssl/err_override.c
@@ -18,3 +18,7 @@
 void ERR_print_errors_fp(FILE *fp) {
     assert(fp == stderr);
 }
+
+signed int ERR_get_error() {
+    return 0;
+}

--- a/.cbmc-batch/source/openssl/objects_override.c
+++ b/.cbmc-batch/source/openssl/objects_override.c
@@ -24,6 +24,8 @@
  */
 int OBJ_txt2nid(const char *s) {
     // Currently these are the only values used in the ESDK
+    assert(!s || strcmp(s, "prime256v1") == 0 || strcmp(s, "secp384r1") == 0);
+
     if (!s) {
         return NID_undef;
     } else if (strcmp(s, "prime256v1") == 0) {


### PR DESCRIPTION
*Description of changes:*

This PR replaces https://github.com/aws/aws-encryption-sdk-c/pull/436.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

