### PR TITLE
Adds a proof harness for aws_cryptosdk_rsa_decrypt function

### DIFF
--- a/.cbmc-batch/include/ec_utils.h
+++ b/.cbmc-batch/include/ec_utils.h
@@ -41,6 +41,10 @@ void initialize_max_encryption_size();
 
 size_t max_encryption_size();
 
+void initialize_max_decryption_size();
+
+size_t max_decryption_size();
+
 void write_unconstrained_data(unsigned char *out, size_t len);
 
 #endif

--- a/.cbmc-batch/include/openssl/evp.h
+++ b/.cbmc-batch/include/openssl/evp.h
@@ -38,10 +38,12 @@ void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_CTX_ctrl(EVP_PKEY_CTX *ctx, int keytype, int optype, int cmd, int p1, void *p2);
 int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
 int EVP_PKEY_encrypt_init(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_decrypt_init(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_CTX_set_rsa_padding(EVP_PKEY_CTX *ctx, int pad);
 int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_CTX_set_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
+int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx, unsigned char *out, size_t *outlen, const unsigned char *in, size_t inlen);
 
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 int EVP_MD_CTX_size(const EVP_MD_CTX *ctx);

--- a/.cbmc-batch/jobs/Makefile.aws_array_list
+++ b/.cbmc-batch/jobs/Makefile.aws_array_list
@@ -1,0 +1,28 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+# Sufficently long to get full coverage on the aws_array_list APIs
+# short enough that all proofs complete quickly
+MAX_ITEM_SIZE ?= 2
+
+# Necessary to get full coverage when using functions from math.h
+MAX_INITIAL_ITEM_ALLOCATION ?= 9223372036854775808
+
+DEFINES += -DMAX_ITEM_SIZE=$(MAX_ITEM_SIZE)
+DEFINES += -DMAX_INITIAL_ITEM_ALLOCATION=$(MAX_INITIAL_ITEM_ALLOCATION)

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -308,7 +308,6 @@ propertyreport: cbmc.log property.xml
 	--srcdir $(SRCDIR) \
 	--srcexclude "(./verification|./tests|./tools|./lib/third_party)"
 
-
 clean:
 	$(RM) *.goto
 	$(RM) $(DEPENDENT_GOTOS)

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/Makefile
@@ -12,18 +12,21 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults
+# if Makefile.local exists, use it. This provides a way to override the defaults 
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
+include ../Makefile.aws_string
 
-UNWINDSET += __CPROVER_file_local_cipher_c_flush_openssl_errors.0:2
 
-CBMCFLAGS +=
+UNWINDSET += 
 
-ENTRY = aws_cryptosdk_verify_header_harness
+CBMCFLAGS += 
 
+ENTRY = aws_cryptosdk_rsa_decrypt_harness
+
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
@@ -32,8 +35,10 @@ DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/hkdf.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bio_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/aws_cryptosdk_rsa_decrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/aws_cryptosdk_rsa_decrypt_harness.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+#define KEY_LEN 256
+
+void aws_cryptosdk_rsa_decrypt_harness() {
+    struct aws_byte_buf plain;
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_byte_cursor cipher;
+    struct aws_string *key = ensure_string_is_allocated_bounded_length(KEY_LEN);
+    enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode;
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&plain, MAX_BUFFER_SIZE));
+    // ensure_byte_buf_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_buf_is_valid(&plain));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&cipher, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&cipher);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&cipher));
+
+    /* save current state of the data structure */
+    struct aws_byte_cursor old_cipher = cipher;
+    struct store_byte_from_buffer old_byte_from_cipher;
+    save_byte_from_array(cipher.ptr, cipher.len, &old_byte_from_cipher);
+
+    if (aws_cryptosdk_rsa_decrypt(&plain, alloc, cipher, key, rsa_padding_mode) == AWS_OP_SUCCESS) {
+        assert(aws_byte_buf_is_valid(&plain));
+    }
+    if (cipher.len != 0) {
+        assert_byte_from_buffer_matches(cipher.ptr, &old_byte_from_cipher);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_decrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+jobos: ubuntu16
+cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+goto: aws_cryptosdk_rsa_decrypt_harness.goto
+expected: "SUCCESSFUL"

--- a/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_rsa_encrypt/Makefile
@@ -12,16 +12,16 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
+# if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 include ../Makefile.string
 
-UNWINDSET += 
+UNWINDSET +=
 
-CBMCFLAGS += 
+CBMCFLAGS +=
 
 ENTRY = aws_cryptosdk_rsa_encrypt_harness
 

--- a/.cbmc-batch/source/openssl/ec_override.c
+++ b/.cbmc-batch/source/openssl/ec_override.c
@@ -469,6 +469,19 @@ size_t max_encryption_size() {
     return encryption_size;
 }
 
+static size_t decryption_size;
+
+void initialize_max_decryption_size() {
+    size_t size;
+    // At different times, this value is stored in a size_t, a long and an int
+    __CPROVER_assume(0 < size && size <= INT_MAX);
+    encryption_size = size;
+}
+
+size_t max_decryption_size() {
+    return encryption_size;
+}
+
 /* Writes arbitrary data into the buffer out. */
 void write_unconstrained_data(unsigned char *out, size_t len) {
     assert(AWS_MEM_IS_WRITABLE(out, len));


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

This PR overrides https://github.com/aws/aws-encryption-sdk-c/pull/438. It also depends on PR https://github.com/aws/aws-encryption-sdk-c/pull/492.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

