### PR TITLE
Variety of keyring_trace proofs (Based on PR #420)

### DIFF
--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -15,6 +15,7 @@
 
 #include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/framefmt.h>
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 #include <stdint.h>
@@ -30,3 +31,6 @@ void ensure_sig_ctx_has_allocated_members(struct aws_cryptosdk_sig_ctx *ctx);
 
 /* Makes internal function from cipher.c accessible for CBMC */
 enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id alg_id);
+
+void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len);
+void ensure_trace_has_allocated_records(struct aws_array_list *trace, size_t max_len);

--- a/.cbmc-batch/jobs/Makefile.aws_byte_buf
+++ b/.cbmc-batch/jobs/Makefile.aws_byte_buf
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 ##########
-# if Makefile.local exists, use it. This provides a way to override the defaults
+# if Makefile.local exists, use it. This provides a way to override the defaults 
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default

--- a/.cbmc-batch/jobs/aws_cryptosdk_cmm_release/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_cmm_release/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-goto: aws_cryptosdk_cmm_release_harness.goto
 expected: "SUCCESSFUL"
+goto: aws_cryptosdk_cmm_release_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
 cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;array_list_item_generator.0:3,aws_cryptosdk_enc_ctx_serialize.0:3;--object-bits;8"
-goto: aws_cryptosdk_enc_ctx_serialize_harness.goto
 expected: "SUCCESSFUL"
+goto: aws_cryptosdk_enc_ctx_serialize_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/Makefile
@@ -12,24 +12,26 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
-sinclude ../Makefile.local
-#otherwise, use the default values
-include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_array_list
+
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((2 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),aws_string_new_from_array.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+
+ENTRY = aws_cryptosdk_keyring_trace_add_record_harness
 
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/array_list.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
-
-ENTRY = aws_cryptosdk_keyring_trace_record_clean_up_harness
-
 ###########
 
 include ../Makefile.common
-include ../Makefile.string

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/aws_cryptosdk_keyring_trace_add_record_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record/aws_cryptosdk_keyring_trace_add_record_harness.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/common/string.h>
+#include <aws/cryptosdk/keyring_trace.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <aws/cryptosdk/private/utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+
+void aws_cryptosdk_keyring_trace_add_record_harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: valid allocator */
+    __CPROVER_assume(aws_allocator_is_valid(alloc));
+    struct aws_array_list trace; /* Precondition: trace must be non-null */
+    struct aws_string *namespace =
+        ensure_string_is_allocated_bounded_length(MAX_STRING_LEN); /* Precondition: namespace must be non-null */
+    struct aws_string *name =
+        ensure_string_is_allocated_bounded_length(MAX_STRING_LEN); /* Precondition: name must be non-null */
+    uint32_t flags;
+
+    __CPROVER_assume(
+        aws_array_list_is_bounded(&trace, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
+
+    struct aws_array_list old = trace;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)trace.data, trace.current_size, &old_byte);
+
+    if (aws_cryptosdk_keyring_trace_add_record(alloc, &trace, namespace, name, flags) == AWS_OP_SUCCESS) {
+        /* assertions */
+        // TODO: we should actually perform memcpy and not memcpy_havoc
+        // to perform this validity check - assert(aws_cryptosdk_keyring_trace_is_valid(&trace));
+        assert(trace.length = old.length + 1);
+    } else {
+        /* assertions */
+        assert_array_list_equivalence(&trace, &old, &old_byte);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/Makefile
@@ -12,24 +12,31 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
-sinclude ../Makefile.local
-#otherwise, use the default values
-include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_array_list
+include ../Makefile.aws_byte_buf
+
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((2 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),aws_string_new_from_array.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_add_record_buf_harness
 
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/array_list.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
-ENTRY = aws_cryptosdk_keyring_trace_record_clean_up_harness
 
 ###########
 
 include ../Makefile.common
-include ../Makefile.string

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/aws_cryptosdk_keyring_trace_add_record_buf_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/aws_cryptosdk_keyring_trace_add_record_buf_harness.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/common/string.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <aws/cryptosdk/private/utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+
+void aws_cryptosdk_keyring_trace_add_record_buf_harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_array_list trace;
+    struct aws_byte_buf namespace;
+    struct aws_byte_buf name;
+    uint32_t flags;
+
+    __CPROVER_assume(
+        aws_array_list_is_bounded(&trace, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&namespace, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&namespace);
+    __CPROVER_assume(aws_byte_buf_is_valid(&namespace));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&name, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&name);
+    __CPROVER_assume(aws_byte_buf_is_valid(&name));
+
+    struct aws_array_list old = trace;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)trace.data, trace.current_size, &old_byte);
+
+    if (aws_cryptosdk_keyring_trace_add_record_buf(alloc, &trace, &namespace, &name, flags) == AWS_OP_SUCCESS) {
+        /* assertions */
+        // TODO: we should actually perform memcpy and not memcpy_havoc
+        // to perform this validity check - assert(aws_cryptosdk_keyring_trace_is_valid(&trace));
+        assert(trace.length = old.length + 1);
+    } else {
+        /* assertions */
+        assert_array_list_equivalence(&trace, &old, &old_byte);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/Makefile
@@ -12,24 +12,31 @@
 # limitations under the License.
 
 ###########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
-sinclude ../Makefile.local
-#otherwise, use the default values
-include ../Makefile.local_default
+include ../Makefile.aws_array_list
+include ../Makefile.aws_byte_buf
+include ../Makefile.string
+
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((2 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),aws_string_new_from_array.0:$(shell echo $$((1 + $(MAX_STRING_LEN)))),strlen.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_add_record_c_str_harness
 
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/array_list.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
-ENTRY = aws_cryptosdk_keyring_trace_record_clean_up_harness
 
 ###########
 
 include ../Makefile.common
-include ../Makefile.string

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/aws_cryptosdk_keyring_trace_add_record_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/aws_cryptosdk_keyring_trace_add_record_c_str_harness.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/common/string.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <aws/cryptosdk/private/utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+
+void aws_cryptosdk_keyring_trace_add_record_c_str_harness() {
+    /* data structure */
+    struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
+    struct aws_array_list trace;
+    const char *c_str_namespace = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    const char *c_str_name      = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    uint32_t flags;
+
+    __CPROVER_assume(
+        aws_array_list_is_bounded(&trace, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
+
+    struct aws_array_list old = trace;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array((uint8_t *)trace.data, trace.current_size, &old_byte);
+
+    if (aws_cryptosdk_keyring_trace_add_record_c_str(alloc, &trace, c_str_namespace, c_str_name, flags) ==
+        AWS_OP_SUCCESS) {
+        /* assertions */
+        // TODO: we should actually perform memcpy and not memcpy_havoc
+        // to perform this validity check - assert(aws_cryptosdk_keyring_trace_is_valid(&trace));
+        assert(trace.length = old.length + 1);
+    } else {
+        /* assertions */
+        assert_array_list_equivalence(&trace, &old, &old_byte);
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/Makefile
@@ -16,20 +16,28 @@
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
+include ../Makefile.string 
+include ../Makefile.aws_array_list
 
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_keyring_trace_clean_up_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
 
-ENTRY = aws_cryptosdk_keyring_trace_record_clean_up_harness
+
 
 ###########
 
 include ../Makefile.common
-include ../Makefile.string

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/aws_cryptosdk_keyring_trace_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/aws_cryptosdk_keyring_trace_clean_up_harness.c
@@ -13,21 +13,24 @@
  * permissions and limitations under the License.
  */
 
-#include <aws/common/array_list.h>
-#include <aws/common/string.h>
 #include <aws/cryptosdk/private/keyring_trace.h>
 #include <make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
 
-void aws_cryptosdk_keyring_trace_record_clean_up_harness() {
+void aws_cryptosdk_keyring_trace_clean_up_harness() {
     /* data structure */
-    struct aws_cryptosdk_keyring_trace_record record; /* Precondition: record is non-null */
+    struct aws_array_list trace;
 
-    ensure_record_has_allocated_members(&record, MAX_STRING_LEN);
-    __CPROVER_assume(aws_cryptosdk_keyring_trace_record_is_valid(&record));
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
 
-    aws_cryptosdk_keyring_trace_record_clean_up(&record);
-    assert(record.flags == 0);
-    assert(record.wrapping_key_name == NULL);
-    assert(record.wrapping_key_namespace == NULL);
+    aws_cryptosdk_keyring_trace_clean_up(&trace);
+
+    /* assertions */
+    assert(aws_array_list_length(&trace) == 0);
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/Makefile
@@ -16,20 +16,24 @@
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_array_list
 
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
-DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+CBMC_UNWINDSET +=  --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+
+ENTRY = aws_cryptosdk_keyring_trace_clear_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/string.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/keyring_trace.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
-
-ENTRY = aws_cryptosdk_keyring_trace_record_clean_up_harness
 
 ###########
 
 include ../Makefile.common
-include ../Makefile.string

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/aws_cryptosdk_keyring_trace_clear_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/aws_cryptosdk_keyring_trace_clear_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_trace_clear_harness() {
+    /* data structure */
+    struct aws_array_list trace;
+
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&trace);
+    __CPROVER_assume(aws_array_list_is_valid(&trace));
+    ensure_trace_has_allocated_records(&trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&trace));
+
+    /* save current state of the data structure */
+    struct aws_array_list old = trace;
+
+    aws_cryptosdk_keyring_trace_clear(&trace);
+
+    /* assertions */
+    assert(aws_array_list_is_valid(&trace));
+    assert(trace.length == 0);
+    assert(trace.alloc == old.alloc);
+    assert(trace.current_size == old.current_size);
+    assert(trace.item_size == old.item_size);
+    assert(trace.data == old.data);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/Makefile
@@ -16,20 +16,26 @@
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_array_list
+
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+
+ENTRY = aws_cryptosdk_keyring_trace_eq_harness
 
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
-DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/keyring_trace.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
-ENTRY = aws_cryptosdk_keyring_trace_record_clean_up_harness
+
 
 ###########
 
 include ../Makefile.common
-include ../Makefile.string

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/aws_cryptosdk_keyring_trace_eq_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/aws_cryptosdk_keyring_trace_eq_harness.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_trace_eq_harness() {
+    /* data structure */
+    struct aws_array_list lhs;
+    struct aws_array_list rhs;
+
+    /* assumptions */
+    __CPROVER_assume(aws_array_list_is_bounded(&lhs, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(lhs.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&lhs);
+    __CPROVER_assume(aws_array_list_is_valid(&lhs));
+    ensure_trace_has_allocated_records(&lhs, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&lhs));
+
+    __CPROVER_assume(aws_array_list_is_bounded(&rhs, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(rhs.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&rhs);
+    __CPROVER_assume(aws_array_list_is_valid(&rhs));
+    ensure_trace_has_allocated_records(&rhs, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&rhs));
+
+    /* save current state of the data structure */
+    struct aws_array_list old_lhs = lhs;
+    struct store_byte_from_buffer old_byte_from_lhs;
+    save_byte_from_array((uint8_t *)lhs.data, lhs.current_size, &old_byte_from_lhs);
+    struct aws_array_list old_rhs = rhs;
+    struct store_byte_from_buffer old_byte_from_rhs;
+    save_byte_from_array((uint8_t *)rhs.data, rhs.current_size, &old_byte_from_rhs);
+
+    if (aws_cryptosdk_keyring_trace_eq(&lhs, &rhs)) {
+        /* assertions */
+        assert(lhs.length == rhs.length);
+        size_t num_records = aws_array_list_length(&lhs);
+        size_t idx;
+        __CPROVER_assume(idx < num_records);
+        struct aws_cryptosdk_keyring_trace_record *lhs_rec;
+        struct aws_cryptosdk_keyring_trace_record *rhs_rec;
+        aws_array_list_get_at_ptr(&lhs, (void **)&lhs_rec, idx);
+        aws_array_list_get_at_ptr(&rhs, (void **)&rhs_rec, idx);
+        assert(aws_string_eq(lhs_rec->wrapping_key_namespace, rhs_rec->wrapping_key_namespace));
+        assert(aws_string_eq(lhs_rec->wrapping_key_name, rhs_rec->wrapping_key_name));
+        assert(lhs_rec->flags == rhs_rec->flags);
+    }
+    /* assertions */
+    assert(aws_array_list_is_valid(&lhs));
+    assert(aws_array_list_is_valid(&rhs));
+    assert_array_list_equivalence(&lhs, &old_lhs, &old_byte_from_lhs);
+    assert_array_list_equivalence(&rhs, &old_rhs, &old_byte_from_rhs);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-goto: aws_cryptosdk_keyring_trace_init_harness.goto
+cbmcflags: "--flush;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 expected: "SUCCESSFUL"
+goto: aws_cryptosdk_keyring_trace_init_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_clean_up/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
-goto: aws_cryptosdk_keyring_trace_record_clean_up_harness.goto
+cbmcflags: "--flush;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 expected: "SUCCESSFUL"
+goto: aws_cryptosdk_keyring_trace_record_clean_up_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_record_init_clone/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-jobos: ubuntu16
-cbmcflags: "--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17;--object-bits;8"
-goto: aws_cryptosdk_keyring_trace_record_init_clone_harness.goto
+cbmcflags: "--flush;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:17;--object-bits;8"
 expected: "SUCCESSFUL"
+goto: aws_cryptosdk_keyring_trace_record_init_clone_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -23,6 +23,8 @@
 #include <evp_utils.h>
 #include <make_common_data_structures.h>
 
+#include <aws/cryptosdk/keyring_trace.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
 #include <proof_helpers/cryptosdk/make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
@@ -34,6 +36,24 @@ void ensure_alg_properties_attempt_allocation(struct aws_cryptosdk_alg_propertie
     alg_props->cipher_name = can_fail_malloc(cipher_name_size);
     size_t alg_name_size;
     alg_props->alg_name = can_fail_malloc(alg_name_size);
+}
+
+void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len) {
+    record->wrapping_key_namespace = ensure_string_is_allocated_bounded_length(max_len);
+    record->wrapping_key_name      = ensure_string_is_allocated_bounded_length(max_len);
+    record->flags                  = malloc(sizeof(uint32_t));
+}
+
+void ensure_trace_has_allocated_records(struct aws_array_list *trace, size_t max_len) {
+    /* iterate over each record in the keyring trace */
+    size_t num_records = aws_array_list_length(trace);
+    for (size_t idx = 0; idx < num_records; ++idx) {
+        struct aws_cryptosdk_keyring_trace_record *record;
+        if (!aws_array_list_get_at_ptr(trace, (void **)&record, idx)) {
+            /* make sure each record is valid */
+            ensure_record_has_allocated_members(record, max_len);
+        }
+    }
 }
 
 void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ctx) {

--- a/include/aws/cryptosdk/keyring_trace.h
+++ b/include/aws/cryptosdk/keyring_trace.h
@@ -83,6 +83,19 @@ extern "C" {
 #endif
 
 /**
+ * Evaluates the set of properties that define the shape of all valid
+ * aws_cryptosdk_keyring_trace_record structures.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_keyring_trace_record_is_valid(struct aws_cryptosdk_keyring_trace_record *record);
+
+/**
+ * Iterates over each memeber of a keyring_trace and ensures that each is a valid record.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_keyring_trace_is_valid(const struct aws_array_list *trace);
+
+/**
  * Add a record to the trace with the specified namespace, name, and flags.
  * Makes duplicates of namespace and name strings. Will be deallocated
  * when the keyring trace object is cleared or cleaned up.

--- a/reformat.sh
+++ b/reformat.sh
@@ -17,10 +17,10 @@
 #   clang-format --style=Google -dump-config
 
 echo "Checking version number"
-VER=$(clang-format --version|cut -f3 -d' '|cut -f1 -d'.')
+VER=$(clang-format-8 --version|cut -f3 -d' '|cut -f1 -d'.')
 if [ $VER -ge 8 ];then
     set -euxo pipefail
-    find . -name '*.h' -or -name '*.c' -or -name '*.cpp' | xargs clang-format -i
+    find . -name '*.h' -or -name '*.c' -or -name '*.cpp' | xargs clang-format-8 -i
 else
     echo "clang-format version 8 or greater is needed to read the format file."
     exit 1


### PR DESCRIPTION
*Description of changes:* This PR is a rebase and update of https://github.com/aws/aws-encryption-sdk-c/pull/420/ (which itself re-implements https://github.com/aws/aws-encryption-sdk-c/pull/419/), which adds CBMC tests for a variety of keyring_trace functions. This PR was particularly troublesome, and required a lot of compromises to get running. In particular, the add_record tests require memcpy to be used instead of the stub, but also attempt to allocate a tremendous amount of memory. Additionally, due to the current issues with the AWS_OBJ_PTR_IS_READABLE/WRITEABLE macros, all of those had to be ripped out and replaced with != NULL checks. A few tests also have an early incorrect assumption which leads to them only having around 5% coverage. A list of these functions will be provided in Issue https://github.com/aws/aws-encryption-sdk-c/issues/487, but will be left untouched for the moment to be addressed later following conversations with @danielsn and @feliperodri.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

