### PR TITLE
Proof harnesses for aws_cryptosdk_sig_get_{privkey, pubkey}

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_get_privkey/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_get_privkey/Makefile
@@ -1,0 +1,44 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+## At the moment this is not used in the Makefile.common of encryption-sdk
+UNWINDSET +=
+
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_get_privkey_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/string.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/asn1_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_get_privkey/aws_cryptosdk_sig_get_privkey_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_get_privkey/aws_cryptosdk_sig_get_privkey_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_get_privkey_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx = can_fail_malloc(sizeof(struct aws_cryptosdk_sig_ctx));
+    struct aws_allocator *alloc       = can_fail_allocator();
+    struct aws_string *priv_key;
+
+    /* assumptions */
+    __CPROVER_assume(ctx);
+    ensure_sig_ctx_has_allocated_members(ctx);
+    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+    __CPROVER_assume(ctx->is_sign);  // context has to be in signing mode, otherwise private key is NULL
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_get_privkey(ctx, alloc, &priv_key) == AWS_OP_SUCCESS) {
+        assert(aws_string_is_valid(priv_key));
+    } else {
+        assert(!priv_key);
+    }
+
+    /* assertions */
+    assert(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+
+    /* clean up */
+    EVP_MD_CTX_free(ctx->ctx);
+    evp_pkey_unconditional_free(ctx->pkey);
+    ec_key_unconditional_free(ctx->keypair);
+    free(ctx);
+    free(priv_key);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_get_privkey/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_get_privkey/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--memory-leak-check;--flush;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_sig_get_privkey_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_get_pubkey/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_get_pubkey/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+UNWINDSET += aws_base64_encode.0:22 # computed according to MAX_PUBKEY_SIZE and the implementation of aws_base64_encode
+# Added check for memory leaks
+CBMCFLAGS += --memory-leak-check
+
+ENTRY = aws_cryptosdk_sig_get_pubkey_harness
+
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/encoding.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.goto
+DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_get_pubkey/aws_cryptosdk_sig_get_pubkey_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_get_pubkey/aws_cryptosdk_sig_get_pubkey_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <cbmc_invariants.h>
+#include <ec_utils.h>
+#include <evp_utils.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+
+#include <cipher_openssl.h>
+
+void aws_cryptosdk_sig_get_pubkey_harness() {
+    /* arguments */
+    struct aws_cryptosdk_sig_ctx *ctx = can_fail_malloc(sizeof(struct aws_cryptosdk_sig_ctx));
+    struct aws_allocator *alloc       = can_fail_allocator();
+    struct aws_string *pubkey;
+
+    /* assumptions */
+    __CPROVER_assume(ctx);
+    ensure_sig_ctx_has_allocated_members(ctx);
+    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+
+    /* operation under verification */
+    if (aws_cryptosdk_sig_get_pubkey(ctx, alloc, &pubkey) == AWS_OP_SUCCESS) {
+        assert(aws_string_is_valid(pubkey));
+    } else {
+        assert(!pubkey);
+    }
+
+    /* assertions */
+    assert(aws_cryptosdk_sig_ctx_is_valid_cbmc(ctx));
+
+    /* clean up */
+    EVP_MD_CTX_free(
+        ctx->ctx);  // If the EVP_MD_CTX contains a reference to the EVP_PKEY, this decrements the reference count
+    evp_pkey_unconditional_free(ctx->pkey);
+    ec_key_unconditional_free(ctx->keypair);
+    free(ctx);
+    free(pubkey);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_sig_get_pubkey/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sig_get_pubkey/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--memory-leak-check;--flush;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_base64_encode.0:22;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_sig_get_pubkey_harness.goto
+jobos: ubuntu16

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -313,11 +313,19 @@ err:
 
 int aws_cryptosdk_sig_get_pubkey(
     const struct aws_cryptosdk_sig_ctx *ctx, struct aws_allocator *alloc, struct aws_string **pub_key_buf) {
-    return serialize_pubkey(alloc, ctx->keypair, pub_key_buf);
+    AWS_PRECONDITION(aws_cryptosdk_sig_ctx_is_valid(ctx));
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(pub_key_buf));
+    int rv = serialize_pubkey(alloc, ctx->keypair, pub_key_buf);
+    AWS_POSTCONDITION(aws_cryptosdk_sig_ctx_is_valid(ctx));
+    AWS_POSTCONDITION((rv == AWS_OP_SUCCESS) ? aws_string_is_valid(*pub_key_buf) : !*pub_key_buf);
+    return rv;
 }
 
 int aws_cryptosdk_sig_get_privkey(
     const struct aws_cryptosdk_sig_ctx *ctx, struct aws_allocator *alloc, struct aws_string **priv_key) {
+    AWS_PRECONDITION(aws_cryptosdk_sig_ctx_is_valid(ctx));
+    AWS_PRECONDITION(ctx->is_sign);
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_READABLE(priv_key));
     /*
      * When serializing private keys we use this ad-hoc format:
      *
@@ -418,6 +426,8 @@ err:
     // There is no error path that results in a non-NULL priv_key, so we don't need to
     // clean that up.
 
+    AWS_POSTCONDITION(AWS_OBJECT_PTR_IS_READABLE(priv_key));
+    AWS_POSTCONDITION(rv == AWS_OP_SUCCESS ? aws_string_is_valid(*priv_key) : !*priv_key);
     return rv;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replaces https://github.com/aws/aws-encryption-sdk-c/pull/410

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

