### PR TITLE
Fixes for broken keyring_trace proofs

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/aws_cryptosdk_keyring_trace_add_record_c_str_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_c_str/aws_cryptosdk_keyring_trace_add_record_c_str_harness.c
@@ -13,6 +13,11 @@
  * permissions and limitations under the License.
  */
 
+/*
+ * Expected Runtime: 2 minutes, 30 seconds
+ * Expected Coverage: 92%
+ */
+
 #include <aws/common/array_list.h>
 #include <aws/common/string.h>
 #include <aws/cryptosdk/private/keyring_trace.h>
@@ -25,8 +30,8 @@ void aws_cryptosdk_keyring_trace_add_record_c_str_harness() {
     /* data structure */
     struct aws_allocator *alloc = can_fail_allocator(); /* Precondition: alloc must be non-null */
     struct aws_array_list trace;
-    const char *c_str_namespace = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
-    const char *c_str_name      = ensure_c_str_is_allocated(MAX_BUFFER_SIZE);
+    const char *c_str_namespace = ensure_c_str_is_allocated(MAX_STRING_LEN);
+    const char *c_str_name      = ensure_c_str_is_allocated(MAX_STRING_LEN);
     uint32_t flags;
 
     __CPROVER_assume(

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/Makefile
@@ -16,10 +16,10 @@
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
-include ../Makefile.string 
+include ../Makefile.string
 include ../Makefile.aws_array_list
 
-CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),aws_cryptosdk_keyring_trace_clear.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
 
 CBMCFLAGS +=
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/aws_cryptosdk_keyring_trace_clean_up_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clean_up/aws_cryptosdk_keyring_trace_clean_up_harness.c
@@ -13,6 +13,11 @@
  * permissions and limitations under the License.
  */
 
+/*
+ * Expected Runtime: 2 minutes, 30 seconds
+ * Expected Coverage: 88%
+ */
+
 #include <aws/cryptosdk/private/keyring_trace.h>
 #include <make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
@@ -22,7 +27,8 @@ void aws_cryptosdk_keyring_trace_clean_up_harness() {
     struct aws_array_list trace;
 
     /* assumptions */
-    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(
+        aws_array_list_is_bounded(&trace, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
     __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     ensure_array_list_has_allocated_data_member(&trace);
     __CPROVER_assume(aws_array_list_is_valid(&trace));
@@ -32,5 +38,5 @@ void aws_cryptosdk_keyring_trace_clean_up_harness() {
     aws_cryptosdk_keyring_trace_clean_up(&trace);
 
     /* assertions */
-    assert(aws_array_list_length(&trace) == 0);
+    assert(trace.length == 0);
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/Makefile
@@ -19,7 +19,7 @@ include ../Makefile.local_default
 include ../Makefile.string
 include ../Makefile.aws_array_list
 
-CBMC_UNWINDSET +=  --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+CBMC_UNWINDSET +=  --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),aws_cryptosdk_keyring_trace_clear.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
 
 ENTRY = aws_cryptosdk_keyring_trace_clear_harness
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/aws_cryptosdk_keyring_trace_clear_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_clear/aws_cryptosdk_keyring_trace_clear_harness.c
@@ -13,6 +13,11 @@
  * permissions and limitations under the License.
  */
 
+/*
+ * Expected Runtime: 2 minutes, 30 seconds
+ * Expected Coverage: 88%
+ */
+
 #include <aws/cryptosdk/private/keyring_trace.h>
 #include <make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
@@ -22,7 +27,8 @@ void aws_cryptosdk_keyring_trace_clear_harness() {
     struct aws_array_list trace;
 
     /* assumptions */
-    __CPROVER_assume(aws_array_list_is_bounded(&trace, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(
+        aws_array_list_is_bounded(&trace, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
     __CPROVER_assume(trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     ensure_array_list_has_allocated_data_member(&trace);
     __CPROVER_assume(aws_array_list_is_valid(&trace));

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/Makefile
@@ -19,7 +19,7 @@ include ../Makefile.local_default
 include ../Makefile.string
 include ../Makefile.aws_array_list
 
-CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE))))
+CBMC_UNWINDSET += --unwindset aws_cryptosdk_keyring_trace_is_valid.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),ensure_trace_has_allocated_records.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),aws_cryptosdk_keyring_trace_eq.0:$(shell echo $$((1 + $(MAX_ITEM_SIZE)))),memcmp.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 
 ENTRY = aws_cryptosdk_keyring_trace_eq_harness
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/aws_cryptosdk_keyring_trace_eq_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_eq/aws_cryptosdk_keyring_trace_eq_harness.c
@@ -13,6 +13,12 @@
  * permissions and limitations under the License.
  */
 
+/*
+ * Expected Runtime: 45 minutes
+ * Expected Coverage: 87%
+ * Requires more than 4 GB of memory, works with 8 GB
+ */
+
 #include <aws/cryptosdk/private/keyring_trace.h>
 #include <make_common_data_structures.h>
 #include <proof_helpers/make_common_data_structures.h>
@@ -23,14 +29,14 @@ void aws_cryptosdk_keyring_trace_eq_harness() {
     struct aws_array_list rhs;
 
     /* assumptions */
-    __CPROVER_assume(aws_array_list_is_bounded(&lhs, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(aws_array_list_is_bounded(&lhs, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
     __CPROVER_assume(lhs.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     ensure_array_list_has_allocated_data_member(&lhs);
     __CPROVER_assume(aws_array_list_is_valid(&lhs));
     ensure_trace_has_allocated_records(&lhs, MAX_STRING_LEN);
     __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&lhs));
 
-    __CPROVER_assume(aws_array_list_is_bounded(&rhs, MAX_INITIAL_ITEM_ALLOCATION, MAX_ITEM_SIZE));
+    __CPROVER_assume(aws_array_list_is_bounded(&rhs, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
     __CPROVER_assume(rhs.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     ensure_array_list_has_allocated_data_member(&rhs);
     __CPROVER_assume(aws_array_list_is_valid(&rhs));


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-encryption-sdk-c/issues/487

*Description of changes:* This PR fixes all of the completely broken keyring_trace CBMC proofs. The keyring_trace_eq proof does work, but is massive and takes 20 minutes for me to run locally, and will likely have to be refactored at some point.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

