### PR TITLE
Use __CPROVER_havoc_object instead of __CPROVER_array_copy.

### DIFF
--- a/.cbmc-batch/source/openssl/ec_override.c
+++ b/.cbmc-batch/source/openssl/ec_override.c
@@ -488,8 +488,5 @@ void write_unconstrained_data(unsigned char *out, size_t len) {
 
     // Currently we ignore the len parameter and just fill the entire buffer with unconstrained data.
     // This is fine because it is strictly more general behavior than writing only len bytes.
-
-    char start;  // Unconstrained first byte
-    __CPROVER_array_copy(
-        out, &start);  // Writes start into the buffer and fills the remaining positions with unconstrained values
+    __CPROVER_havoc_object(out);
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current code uses `__CPROVER_array_copy` to havoc an object. Use the self-documenting `__CPROVER_havoc_object` instead.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

