### PR TITLE
Adds a proof harness for aws_cryptosdk_multi_keyring_add_child

### DIFF
--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -15,6 +15,7 @@
 
 #include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/materials.h>
 #include <aws/cryptosdk/private/framefmt.h>
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
@@ -36,4 +37,6 @@ enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id
 void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len);
 void ensure_trace_has_allocated_records(struct aws_array_list *trace, size_t max_len);
 
-void ensure_cryptosdk_keyring_has_allocated_members(struct aws_cryptosdk_keyring *keyring);
+/* Non-deterministically allocates a aws_cryptosdk_keyring structure */
+void ensure_cryptosdk_keyring_has_allocated_members(
+    struct aws_cryptosdk_keyring *keyring, const struct aws_cryptosdk_keyring_vt *vtable);

--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -35,3 +35,5 @@ enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id
 
 void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len);
 void ensure_trace_has_allocated_records(struct aws_array_list *trace, size_t max_len);
+
+void ensure_cryptosdk_keyring_has_allocated_members(struct aws_cryptosdk_keyring *keyring);

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/Makefile
@@ -18,13 +18,13 @@ include ../Makefile.local_default
 
 ENTRY = aws_cryptosdk_multi_keyring_add_child_harness
 
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/array_list.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
-DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/multi_keyring.c
-
-REMOVE_FUNCTION_BODY += --remove-function-body aws_last_error
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+ENTRY = aws_cryptosdk_multi_keyring_add_child_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/array_list.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/multi_keyring.c
+
+REMOVE_FUNCTION_BODY += --remove-function-body aws_last_error
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/aws_cryptosdk_multi_keyring_add_child_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/aws_cryptosdk_multi_keyring_add_child_harness.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/materials.h>
+#include <aws/cryptosdk/multi_keyring.h>
+#include "proof_helpers/proof_allocators.h"
+
+void aws_cryptosdk_multi_keyring_add_child_harness() {
+    /* Non-deterministic inputs. */
+    struct aws_allocator *alloc = can_fail_allocator();
+    struct aws_cryptosdk_keyring generator;
+    aws_cryptosdk_keyring_base_init(&generator, NULL);
+    struct multi_keyring *multi = aws_cryptosdk_multi_keyring_new(alloc, &generator);
+
+    struct aws_cryptosdk_keyring child;
+    aws_cryptosdk_keyring_base_init(&child, NULL);
+
+    /* Assumptions. */
+    __CPROVER_assume(aws_cryptosdk_keyring_is_valid(multi));
+    __CPROVER_assume(aws_cryptosdk_keyring_is_valid(&child));
+
+    /* Operation under verification. */
+    if (aws_cryptosdk_multi_keyring_add_child(multi, &child) == AWS_OP_SUCCESS) {
+        /* TODO */
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/aws_cryptosdk_multi_keyring_add_child_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/aws_cryptosdk_multi_keyring_add_child_harness.c
@@ -33,6 +33,10 @@ void aws_cryptosdk_multi_keyring_add_child_harness() {
 
     /* Operation under verification. */
     if (aws_cryptosdk_multi_keyring_add_child(multi, &child) == AWS_OP_SUCCESS) {
-        /* TODO */
+        assert(aws_array_list_length(&multi->children) > 0);
     }
+
+    /* Post-conditions. */
+    assert(aws_cryptosdk_keyring_is_valid(multi));
+    assert(aws_cryptosdk_keyring_is_valid(&child));
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_multi_keyring_add_child/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_multi_keyring_add_child_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -13,19 +13,19 @@
  * limitations under the License.
  */
 
-#include <openssl/ec.h>
-#include <openssl/evp.h>
-
 #include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/keyring_trace.h>
+#include <aws/cryptosdk/materials.h>
 #include <aws/cryptosdk/private/hkdf.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <aws/cryptosdk/private/multi_keyring.h>
 #include <cipher_openssl.h>
 #include <ec_utils.h>
 #include <evp_utils.h>
-#include <make_common_data_structures.h>
 
-#include <aws/cryptosdk/keyring_trace.h>
-#include <aws/cryptosdk/private/keyring_trace.h>
-#include <proof_helpers/cryptosdk/make_common_data_structures.h>
+#include <openssl/ec.h>
+#include <openssl/evp.h>
+
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 
@@ -147,8 +147,8 @@ enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id
     }
 }
 
-void ensure_cryptosdk_keyring_has_allocated_members(struct aws_cryptosdk_keyring *keyring
-                                                    struct aws_cryptosdk_keyring_vt ) {
+void ensure_cryptosdk_keyring_has_allocated_members(
+    struct aws_cryptosdk_keyring *keyring, const struct aws_cryptosdk_keyring_vt *vtable) {
     keyring->refcount.value = can_fail_malloc(sizeof(size_t));
-    keyring->vtable         = can_fail_malloc(sizeof(struct aws_cryptosdk_keyring_vt *));
+    keyring->vtable         = nondet_bool() ? NULL : vtable;
 }

--- a/.cbmc-batch/source/make_common_data_structures.c
+++ b/.cbmc-batch/source/make_common_data_structures.c
@@ -146,3 +146,9 @@ enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id
         default: return AWS_CRYPTOSDK_NOSHA;
     }
 }
+
+void ensure_cryptosdk_keyring_has_allocated_members(struct aws_cryptosdk_keyring *keyring
+                                                    struct aws_cryptosdk_keyring_vt ) {
+    keyring->refcount.value = can_fail_malloc(sizeof(size_t));
+    keyring->vtable         = can_fail_malloc(sizeof(struct aws_cryptosdk_keyring_vt *));
+}

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -406,7 +406,7 @@ AWS_CRYPTOSDK_STATIC_INLINE void aws_cryptosdk_cmm_release(struct aws_cryptosdk_
  */
 AWS_CRYPTOSDK_STATIC_INLINE struct aws_cryptosdk_cmm *aws_cryptosdk_cmm_retain(struct aws_cryptosdk_cmm *cmm) {
     AWS_PRECONDITION(aws_cryptosdk_cmm_base_is_valid(cmm));
-    AWS_PRECONDITION(AWS_ATOMIC_VAR_INTVAL(&cmm->refcount) < SIZE_MAX);
+    AWS_PRECONDITION(aws_atomic_load_int(&cmm->refcount) < SIZE_MAX);
     aws_cryptosdk_private_refcount_up(&cmm->refcount);
     AWS_POSTCONDITION(aws_cryptosdk_cmm_base_is_valid(cmm));
     return cmm;

--- a/include/aws/cryptosdk/multi_keyring.h
+++ b/include/aws/cryptosdk/multi_keyring.h
@@ -22,6 +22,13 @@
 extern "C" {
 #endif
 
+struct multi_keyring {
+    struct aws_cryptosdk_keyring base;
+    struct aws_allocator *alloc;
+    struct aws_cryptosdk_keyring *generator;
+    struct aws_array_list children;  // list of (struct aws_cryptosdk_keyring *)
+};
+
 /**
  * @addtogroup cmm_kr_highlevel
  * @{

--- a/include/aws/cryptosdk/multi_keyring.h
+++ b/include/aws/cryptosdk/multi_keyring.h
@@ -22,13 +22,6 @@
 extern "C" {
 #endif
 
-struct multi_keyring {
-    struct aws_cryptosdk_keyring base;
-    struct aws_allocator *alloc;
-    struct aws_cryptosdk_keyring *generator;
-    struct aws_array_list children;  // list of (struct aws_cryptosdk_keyring *)
-};
-
 /**
  * @addtogroup cmm_kr_highlevel
  * @{
@@ -94,6 +87,12 @@ struct aws_cryptosdk_keyring *aws_cryptosdk_multi_keyring_new(
  */
 AWS_CRYPTOSDK_API
 int aws_cryptosdk_multi_keyring_add_child(struct aws_cryptosdk_keyring *multi, struct aws_cryptosdk_keyring *child);
+
+/**
+ * Constant time check of data-structure invariants for struct multi_keyring.
+ */
+AWS_CRYPTOSDK_API
+bool aws_cryptosdk_multi_keyring_is_valid(struct aws_cryptosdk_keyring *multi);
 
 /** @} */  // doxygen group cmm_kr_highlevel
 

--- a/include/aws/cryptosdk/private/multi_keyring.h
+++ b/include/aws/cryptosdk/private/multi_keyring.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef AWS_CRYPTOSDK_PRIVATE_MULTI_KEYRING_H
+#define AWS_CRYPTOSDK_PRIVATE_MULTI_KEYRING_H
+
+#include <aws/cryptosdk/multi_keyring.h>
+
+struct multi_keyring {
+    struct aws_cryptosdk_keyring base;
+    struct aws_allocator *alloc;
+    struct aws_cryptosdk_keyring *generator;
+    struct aws_array_list children;  // list of (struct aws_cryptosdk_keyring *)
+};
+
+#endif  // AWS_CRYPTOSDK_PRIVATE_MULTI_KEYRING_H

--- a/source/materials.c
+++ b/source/materials.c
@@ -146,12 +146,3 @@ int aws_cryptosdk_keyring_on_decrypt(
     }
     return ret;
 }
-
-bool aws_cryptosdk_keyring_vt_is_valid(const struct aws_cryptosdk_keyring_vt *vtable) {
-    return vtable != NULL && vtable->vt_size == sizeof(struct aws_cryptosdk_keyring_vt);
-}
-
-bool aws_cryptosdk_keyring_is_valid(const struct aws_cryptosdk_keyring *keyring) {
-    return keyring != NULL && aws_atomic_var_is_valid(&keyring->refcount) &&
-           (keyring->vtable == NULL || aws_cryptosdk_keyring_vt_is_valid(keyring->vtable));
-}

--- a/source/materials.c
+++ b/source/materials.c
@@ -146,3 +146,12 @@ int aws_cryptosdk_keyring_on_decrypt(
     }
     return ret;
 }
+
+bool aws_cryptosdk_keyring_vt_is_valid(const struct aws_cryptosdk_keyring_vt *vtable) {
+    return vtable != NULL && vtable->vt_size == sizeof(struct aws_cryptosdk_keyring_vt);
+}
+
+bool aws_cryptosdk_keyring_is_valid(const struct aws_cryptosdk_keyring *keyring) {
+    return keyring != NULL && aws_atomic_var_is_valid(&keyring->refcount) &&
+           (keyring->vtable == NULL || aws_cryptosdk_keyring_vt_is_valid(keyring->vtable));
+}

--- a/source/multi_keyring.c
+++ b/source/multi_keyring.c
@@ -17,13 +17,6 @@
 #include <aws/cryptosdk/materials.h>
 #include <aws/cryptosdk/multi_keyring.h>
 
-struct multi_keyring {
-    struct aws_cryptosdk_keyring base;
-    struct aws_allocator *alloc;
-    struct aws_cryptosdk_keyring *generator;
-    struct aws_array_list children;  // list of (struct aws_cryptosdk_keyring *)
-};
-
 static int call_on_encrypt_on_list(
     const struct aws_array_list *keyrings,
     struct aws_allocator *request_alloc,

--- a/source/multi_keyring.c
+++ b/source/multi_keyring.c
@@ -174,6 +174,8 @@ struct aws_cryptosdk_keyring *aws_cryptosdk_multi_keyring_new(
 }
 
 int aws_cryptosdk_multi_keyring_add_child(struct aws_cryptosdk_keyring *multi, struct aws_cryptosdk_keyring *child) {
+    AWS_PRECONDITION(aws_cryptosdk_keyring_is_valid(multi));
+    AWS_PRECONDITION(aws_cryptosdk_keyring_is_valid(child));
     struct multi_keyring *self = (struct multi_keyring *)multi;
 
     aws_cryptosdk_keyring_retain(child);


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_multi_keyring_add_child` function;
- Adds preconditions in `aws_cryptosdk_multi_keyring_add_child` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

