### PR TITLE
Adds proof harnesses for cipher functions

### DIFF
--- a/.cbmc-batch/include/openssl/err.h
+++ b/.cbmc-batch/include/openssl/err.h
@@ -23,4 +23,6 @@ void ERR_print_errors_fp(FILE *fp);
 
 signed int ERR_get_error(void);
 
+unsigned long ERR_peek_last_error(void);
+
 #endif

--- a/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is
@@ -11,13 +11,11 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
 # if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
-#include ../Makefile.string
 
 MAX_BUFFER_SIZE = 4
 UNWINDSET += __CPROVER_file_local_cipher_c_flush_openssl_errors.0:2
@@ -44,7 +42,5 @@ REMOVE_FUNCTION_BODY += --remove-function-body nondet_compare
 REMOVE_FUNCTION_BODY += --remove-function-body aws_raise_error_private
 REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha256
 REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha384
-
-###########
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/Makefile
@@ -1,0 +1,50 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+#include ../Makefile.string
+
+MAX_BUFFER_SIZE = 4
+UNWINDSET += __CPROVER_file_local_cipher_c_flush_openssl_errors.0:2
+UNWINDSET += aws_cryptosdk_decrypt_body.0:$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
+UNWINDSET += strlen.0:37
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_decrypt_body_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
+
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_EncryptUpdate
+REMOVE_FUNCTION_BODY += --remove-function-body nondet_compare
+REMOVE_FUNCTION_BODY += --remove-function-body aws_raise_error_private
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha256
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha384
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/Makefile
@@ -17,9 +17,12 @@ sinclude ../Makefile.local
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 
+# Use a smaller bound for buffer so the proof runs on a reasonable time
+# Expected runtime is 2min for this bound
 MAX_BUFFER_SIZE = 4
-UNWINDSET += __CPROVER_file_local_cipher_c_flush_openssl_errors.0:2
+
 UNWINDSET += aws_cryptosdk_decrypt_body.0:$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
+# This bound must be 37 because it process a string of fixed size in update_frame_aad
 UNWINDSET += strlen.0:37
 
 CBMCFLAGS +=
@@ -37,10 +40,10 @@ DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
 
-REMOVE_FUNCTION_BODY += --remove-function-body EVP_EncryptUpdate
-REMOVE_FUNCTION_BODY += --remove-function-body nondet_compare
 REMOVE_FUNCTION_BODY += --remove-function-body aws_raise_error_private
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_EncryptUpdate
 REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha256
 REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha384
+REMOVE_FUNCTION_BODY += --remove-function-body nondet_compare
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/aws_cryptosdk_decrypt_body_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/aws_cryptosdk_decrypt_body_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/aws_cryptosdk_decrypt_body_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/aws_cryptosdk_decrypt_body_harness.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_decrypt_body_harness() {
+    /* Non-deterministic inputs. */
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_byte_buf outp;
+    struct aws_byte_cursor inp;
+    uint8_t *message_id;
+    uint32_t seqno;
+    uint8_t *iv;
+    struct content_key *content_key;
+    uint8_t *tag;
+    int body_frame_type;
+
+    /* Assumptions. */
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+    __CPROVER_assume(props != NULL);
+    __CPROVER_assume(
+        props->impl->cipher_ctor == EVP_aes_128_gcm || props->impl->cipher_ctor == EVP_aes_192_gcm ||
+        props->impl->cipher_ctor == EVP_aes_256_gcm);
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&outp, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&outp);
+    __CPROVER_assume(aws_byte_buf_is_valid(&outp));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&inp, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&inp);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&inp));
+
+    message_id = can_fail_malloc(MAX_BUFFER_SIZE);
+
+    iv = can_fail_malloc(props->iv_len);
+    __CPROVER_assume(iv != NULL);
+
+    tag = can_fail_malloc(props->tag_len);
+
+    /* Operation under verification. */
+    if (aws_cryptosdk_decrypt_body(props, &outp, &inp, message_id, seqno, iv, content_key, tag, body_frame_type) ==
+        AWS_OP_SUCCESS) {
+        /* TODO */
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_cipher_c_flush_openssl_errors.0:2,aws_cryptosdk_decrypt_body.0:5,strlen.0:37;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_decrypt_body_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_decrypt_body/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_cipher_c_flush_openssl_errors.0:2,aws_cryptosdk_decrypt_body.0:5,strlen.0:37;--object-bits;8"
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_decrypt_body.0:5,strlen.0:37;--object-bits;8"
 expected: "SUCCESSFUL"
 goto: aws_cryptosdk_decrypt_body_harness.goto
 jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is
@@ -17,10 +17,9 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
-#include ../Makefile.string
 
 MAX_BUFFER_SIZE = 4
-UNWINDSET += aws_cryptosdk_encrypt_body.0:$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
+UNWINDSET += aws_cryptosdk_encrypt_body.0:14#$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
 UNWINDSET += strlen.0:37
 
 CBMCFLAGS +=

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/Makefile
@@ -1,0 +1,48 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+#include ../Makefile.string
+
+MAX_BUFFER_SIZE = 4
+UNWINDSET += aws_cryptosdk_encrypt_body.0:$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
+UNWINDSET += strlen.0:37
+
+CBMCFLAGS +=
+
+ENTRY = aws_cryptosdk_encrypt_body_harness
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
+
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_DecryptUpdate
+REMOVE_FUNCTION_BODY += --remove-function-body nondet_compare
+REMOVE_FUNCTION_BODY += --remove-function-body aws_raise_error_private
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha256
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha384
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/Makefile
@@ -11,15 +11,18 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
 # if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 
+# Use a smaller bound for buffer so the proof runs on a reasonable time
+# Expected runtime is 2min for this bound
 MAX_BUFFER_SIZE = 4
-UNWINDSET += aws_cryptosdk_encrypt_body.0:14#$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
+
+UNWINDSET += aws_cryptosdk_encrypt_body.0:$(shell echo $$((1 + $(MAX_BUFFER_SIZE))))
+# This bound must be 37 because it process a string of fixed size in update_frame_aad
 UNWINDSET += strlen.0:37
 
 CBMCFLAGS +=
@@ -36,12 +39,10 @@ DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
 
-REMOVE_FUNCTION_BODY += --remove-function-body EVP_DecryptUpdate
-REMOVE_FUNCTION_BODY += --remove-function-body nondet_compare
 REMOVE_FUNCTION_BODY += --remove-function-body aws_raise_error_private
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_DecryptUpdate
 REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha256
 REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha384
-
-###########
+REMOVE_FUNCTION_BODY += --remove-function-body nondet_compare
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/aws_cryptosdk_encrypt_body_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/aws_cryptosdk_encrypt_body_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/aws_cryptosdk_encrypt_body_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/aws_cryptosdk_encrypt_body_harness.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_encrypt_body_harness() {
+    /* Non-deterministic inputs. */
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_byte_buf outp;
+    struct aws_byte_cursor inp;
+    uint8_t *message_id;
+    uint32_t seqno;
+    uint8_t *iv;
+    struct content_key *content_key;
+    uint8_t *tag;
+    int body_frame_type;
+
+    /* Assumptions. */
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+    __CPROVER_assume(props != NULL);
+    __CPROVER_assume(
+        props->impl->cipher_ctor == EVP_aes_128_gcm || props->impl->cipher_ctor == EVP_aes_192_gcm ||
+        props->impl->cipher_ctor == EVP_aes_256_gcm);
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&outp, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&outp);
+    __CPROVER_assume(aws_byte_buf_is_valid(&outp));
+
+    __CPROVER_assume(aws_byte_cursor_is_bounded(&inp, MAX_BUFFER_SIZE));
+    ensure_byte_cursor_has_allocated_buffer_member(&inp);
+    __CPROVER_assume(aws_byte_cursor_is_valid(&inp));
+
+    message_id = can_fail_malloc(MAX_BUFFER_SIZE);
+
+    iv = can_fail_malloc(props->iv_len);
+    __CPROVER_assume(iv != NULL);
+
+    tag = can_fail_malloc(props->tag_len);
+
+    /* Operation under verification. */
+    if (aws_cryptosdk_encrypt_body(props, &outp, &inp, message_id, seqno, iv, content_key, tag, body_frame_type) ==
+        AWS_OP_SUCCESS) {
+        /* TODO */
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/aws_cryptosdk_encrypt_body_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/aws_cryptosdk_encrypt_body_harness.c
@@ -19,40 +19,50 @@
 void aws_cryptosdk_encrypt_body_harness() {
     /* Non-deterministic inputs. */
     enum aws_cryptosdk_alg_id alg_id;
-    struct aws_byte_buf outp;
-    struct aws_byte_cursor inp;
-    uint8_t *message_id;
-    uint32_t seqno;
-    uint8_t *iv;
-    struct content_key *content_key;
-    uint8_t *tag;
-    int body_frame_type;
-
-    /* Assumptions. */
     struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
-    __CPROVER_assume(props != NULL);
-    __CPROVER_assume(
-        props->impl->cipher_ctor == EVP_aes_128_gcm || props->impl->cipher_ctor == EVP_aes_192_gcm ||
-        props->impl->cipher_ctor == EVP_aes_256_gcm);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
+    struct aws_byte_buf outp;
     __CPROVER_assume(aws_byte_buf_is_bounded(&outp, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(&outp);
     __CPROVER_assume(aws_byte_buf_is_valid(&outp));
 
+    struct aws_byte_cursor inp;
     __CPROVER_assume(aws_byte_cursor_is_bounded(&inp, MAX_BUFFER_SIZE));
     ensure_byte_cursor_has_allocated_buffer_member(&inp);
     __CPROVER_assume(aws_byte_cursor_is_valid(&inp));
 
-    message_id = can_fail_malloc(MAX_BUFFER_SIZE);
+    uint8_t *message_id = can_fail_malloc(MAX_BUFFER_SIZE);
 
-    iv = can_fail_malloc(props->iv_len);
+    uint32_t seqno;
+
+    uint8_t *iv = can_fail_malloc(props->iv_len);
     __CPROVER_assume(iv != NULL);
 
-    tag = can_fail_malloc(props->tag_len);
+    struct content_key *content_key;
+
+    uint8_t *tag = can_fail_malloc(props->tag_len);
+
+    int body_frame_type;
+
+    /* save current state of outp */
+    struct aws_byte_cursor old_inp = inp;
+    struct aws_byte_buf old_outp   = outp;
+    struct store_byte_from_buffer old_byte;
+    save_byte_from_array(outp.buffer, outp.len, &old_byte);
 
     /* Operation under verification. */
     if (aws_cryptosdk_encrypt_body(props, &outp, &inp, message_id, seqno, iv, content_key, tag, body_frame_type) ==
         AWS_OP_SUCCESS) {
-        /* TODO */
+        assert(inp.len == old_outp.capacity - old_outp.len);
+        assert(outp.len >= old_outp.len && outp.len <= old_outp.len + inp.len);
+    } else {
+        assert(inp.len == old_inp.len);
+        assert(outp.len == old_outp.len || outp.len == 0);
     }
+
+    /* Post-conditions. */
+    assert(aws_cryptosdk_alg_properties_is_valid(props));
+    assert(aws_byte_buf_is_valid(&outp));
+    assert(aws_byte_cursor_is_valid(&inp));
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_encrypt_body.0:5,strlen.0:37;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_encrypt_body_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_encrypt_body.0:14,strlen.0:37;--object-bits;8"
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_encrypt_body.0:5,strlen.0:37;--object-bits;8"
 expected: "SUCCESSFUL"
 goto: aws_cryptosdk_encrypt_body_harness.goto
 jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_encrypt_body/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_encrypt_body.0:5,strlen.0:37;--object-bits;8"
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_encrypt_body.0:14,strlen.0:37;--object-bits;8"
 expected: "SUCCESSFUL"
 goto: aws_cryptosdk_encrypt_body_harness.goto
 jobos: ubuntu16

--- a/.cbmc-batch/source/openssl/err_override.c
+++ b/.cbmc-batch/source/openssl/err_override.c
@@ -22,3 +22,8 @@ void ERR_print_errors_fp(FILE *fp) {
 signed int ERR_get_error() {
     return 0;
 }
+
+unsigned long ERR_peek_last_error() {
+    unsigned long err;
+    return err;
+}

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -646,7 +646,9 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl) {
     assert(ctx != NULL);
     if (ctx->padding == true) {
         *outl = ctx->data_remaining;
-        assert(AWS_MEM_IS_WRITABLE(out, ctx->data_remaining));
+        if(ctx->data_remaining != 0) {
+          assert(AWS_MEM_IS_WRITABLE(out, ctx->data_remaining));
+        }
     }
     ctx->data_processed = true;
     int rv;

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -601,8 +601,11 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
         ctx->data_remaining = inl - out_size;
     }
     /*
-     * This check is redundant with the following AWS_MEM_IS_WRITABLE;
-     * however, it is necessary to properly emulate the function behaviour.
+     * This check is redundant with the following AWS_MEM_IS_WRITABLE.
+     * AWS_MEM_IS_WRITABLE is a macro for __CPROVER_w_ok primitive, which
+     * should return true if out is writable upt to out_size bytes;
+     * however, AWS_MEM_IS_WRITABLE has been replaced by a simple nullness check for now.
+     * Thus, we also include an additional check using __CPROVER_OBJECT_SIZE.
      */
     assert(__CPROVER_OBJECT_SIZE(out) >= out_size);
     assert(AWS_MEM_IS_WRITABLE(out, out_size));
@@ -636,8 +639,11 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
         ctx->data_remaining = inl - out_size;
     }
     /*
-     * This check is redundant with the following AWS_MEM_IS_WRITABLE;
-     * however, it is necessary to properly emulate the function behaviour.
+     * This check is redundant with the following AWS_MEM_IS_WRITABLE.
+     * AWS_MEM_IS_WRITABLE is a macro for __CPROVER_w_ok primitive, which
+     * should return true if out is writable upt to out_size bytes;
+     * however, AWS_MEM_IS_WRITABLE has been replaced by a simple nullness check for now.
+     * Thus, we also include an additional check using __CPROVER_OBJECT_SIZE.
      */
     assert(__CPROVER_OBJECT_SIZE(out) >= out_size);
     assert(AWS_MEM_IS_WRITABLE(out, out_size));
@@ -656,9 +662,7 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl) {
     assert(ctx != NULL);
     if (ctx->padding == true) {
         *outl = ctx->data_remaining;
-        if (ctx->data_remaining != 0) {
-            assert(AWS_MEM_IS_WRITABLE(out, ctx->data_remaining));
-        }
+        assert(AWS_MEM_IS_WRITABLE(out, ctx->data_remaining));
     }
     ctx->data_processed = true;
     int rv;

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -595,14 +595,16 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
     size_t out_size;
     __CPROVER_assume(out_size >= 0);
     if (ctx->cipher) {
-        __CPROVER_assume(out_size <= inl + DEFAULT_BLOCK_SIZE - 1);
+        __CPROVER_assume(out_size <= inl - 1);
     } else {
         __CPROVER_assume(out_size <= inl);
         ctx->data_remaining = inl - out_size;
     }
-    if (__CPROVER_OBJECT_SIZE(out) < out_size) {
-        return 0;
-    }
+    /*
+     * This check is redundant with the following AWS_MEM_IS_WRITABLE;
+     * however, it is necessary to properly emulate the function behaviour.
+     */
+    assert(__CPROVER_OBJECT_SIZE(out) >= out_size);
     assert(AWS_MEM_IS_WRITABLE(out, out_size));
     *outl = out_size;
     return rv;
@@ -627,15 +629,17 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
     __CPROVER_assume(out_size >= 0);
     if (ctx->cipher) {
         if (ctx->padding) {
-            __CPROVER_assume(out_size <= inl + DEFAULT_BLOCK_SIZE);
+            __CPROVER_assume(out_size <= inl);
         }
     } else {
         __CPROVER_assume(out_size <= inl);
         ctx->data_remaining = inl - out_size;
     }
-    if (__CPROVER_OBJECT_SIZE(out) < out_size) {
-        return 0;
-    }
+    /*
+     * This check is redundant with the following AWS_MEM_IS_WRITABLE;
+     * however, it is necessary to properly emulate the function behaviour.
+     */
+    assert(__CPROVER_OBJECT_SIZE(out) >= out_size);
     assert(AWS_MEM_IS_WRITABLE(out, out_size));
     *outl = out_size;
     return rv;

--- a/.cbmc-batch/source/openssl/evp_override.c
+++ b/.cbmc-batch/source/openssl/evp_override.c
@@ -600,6 +600,9 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
         __CPROVER_assume(out_size <= inl);
         ctx->data_remaining = inl - out_size;
     }
+    if (__CPROVER_OBJECT_SIZE(out) < out_size) {
+        return 0;
+    }
     assert(AWS_MEM_IS_WRITABLE(out, out_size));
     *outl = out_size;
     return rv;
@@ -630,6 +633,9 @@ int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const 
         __CPROVER_assume(out_size <= inl);
         ctx->data_remaining = inl - out_size;
     }
+    if (__CPROVER_OBJECT_SIZE(out) < out_size) {
+        return 0;
+    }
     assert(AWS_MEM_IS_WRITABLE(out, out_size));
     *outl = out_size;
     return rv;
@@ -646,8 +652,8 @@ int EVP_EncryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl) {
     assert(ctx != NULL);
     if (ctx->padding == true) {
         *outl = ctx->data_remaining;
-        if(ctx->data_remaining != 0) {
-          assert(AWS_MEM_IS_WRITABLE(out, ctx->data_remaining));
+        if (ctx->data_remaining != 0) {
+            assert(AWS_MEM_IS_WRITABLE(out, ctx->data_remaining));
         }
     }
     ctx->data_processed = true;

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -380,10 +380,8 @@ int aws_cryptosdk_encrypt_body(
          * just in case.
          */
         if (!aws_byte_cursor_advance_nospec(&incurs, in_len).ptr) goto out;
-#pragma CPROVER check push
-#pragma CPROVER check disable "conversion"
-        outbuf.len += ct_len;
-#pragma CPROVER check pop
+
+        if (aws_add_size_checked(outbuf.len, ct_len, &outbuf.len)) goto out;
 
         if (outbuf.capacity < outbuf.len) {
             /* Somehow we ran over the output buffer. abort() to limit the damage. */
@@ -400,7 +398,6 @@ out:
         *outp = outbuf;
         return AWS_OP_SUCCESS;
     } else {
-        struct aws_byte_buf debug = *outp;
         aws_byte_buf_secure_zero(outp);
         return aws_raise_error(result);
     }
@@ -443,10 +440,8 @@ int aws_cryptosdk_decrypt_body(
          * just in case.
          */
         if (!aws_byte_cursor_advance_nospec(&incurs, in_len).ptr) goto out;
-#pragma CPROVER check push
-#pragma CPROVER check disable "conversion"
-        outcurs.len += pt_len;
-#pragma CPROVER check pop
+
+        if (aws_add_size_checked(outcurs.len, pt_len, &outcurs.len)) goto out;
 
         if (outcurs.len > outcurs.capacity) {
             /* Somehow we ran over the output buffer. abort() to limit the damage. */

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -416,6 +416,10 @@ int aws_cryptosdk_decrypt_body(
     const struct content_key *key,
     const uint8_t *tag,
     int body_frame_type) {
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(props));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(outp));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(inp));
+    AWS_PRECONDITION(iv != NULL);
     if (inp->len != outp->capacity - outp->len) {
         return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
     }
@@ -439,7 +443,11 @@ int aws_cryptosdk_decrypt_body(
          * just in case.
          */
         if (!aws_byte_cursor_advance_nospec(&incurs, in_len).ptr) goto out;
+#pragma CPROVER check push
+#pragma CPROVER check disable "conversion"
         outcurs.len += pt_len;
+#pragma CPROVER check pop
+
         if (outcurs.len > outcurs.capacity) {
             /* Somehow we ran over the output buffer. abort() to limit the damage. */
             abort();

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -319,6 +319,10 @@ int aws_cryptosdk_encrypt_body(
     const struct content_key *key,
     uint8_t *tag,
     int body_frame_type) {
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(props));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(outp));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(inp));
+    AWS_PRECONDITION(iv != NULL);
     if (inp->len != outp->capacity) {
         return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
     }
@@ -376,7 +380,10 @@ int aws_cryptosdk_encrypt_body(
          * just in case.
          */
         if (!aws_byte_cursor_advance_nospec(&incurs, in_len).ptr) goto out;
+#pragma CPROVER check push
+#pragma CPROVER check disable "conversion"
         outbuf.len += ct_len;
+#pragma CPROVER check pop
 
         if (outbuf.capacity < outbuf.len) {
             /* Somehow we ran over the output buffer. abort() to limit the damage. */
@@ -393,6 +400,7 @@ out:
         *outp = outbuf;
         return AWS_OP_SUCCESS;
     } else {
+        struct aws_byte_buf debug = *outp;
         aws_byte_buf_secure_zero(outp);
         return aws_raise_error(result);
     }

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -320,7 +320,10 @@ int aws_cryptosdk_encrypt_body(
     uint8_t *tag,
     int body_frame_type) {
     AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(props));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(outp));
+    AWS_PRECONDITION(
+        aws_byte_buf_is_valid(outp) ||
+        /* This happens when outp comes from a frame, which input plaintext_size was 0. */
+        (outp->len == 0 && outp->capacity == 0 && outp->buffer));
     AWS_PRECONDITION(aws_byte_cursor_is_valid(inp));
     AWS_PRECONDITION(iv != NULL);
     if (inp->len != outp->capacity) {


### PR DESCRIPTION
*Issue #, if available:*
N/A.

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_encrypt_body` function;
- Adds a proof harness for `aws_cryptosdk_decrypt_body` function;
- Improves stubs for `EVP_EncryptUpdate` and `EVP_DecryptUpdate`functions from OpenSSL;
- Adds a stubs for `ERR_peek_last_error` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

