### PR TITLE
Adds a proof harness for aws_cryptosdk_keyring_base_init

### DIFF
--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -18,6 +18,7 @@
 #include <aws/cryptosdk/private/framefmt.h>
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_base_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_base_init/Makefile
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_keyring_base_init_harness
+
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_priv_xlate_order
+
+UNWINDSET +=
+
+###########
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_base_init/aws_cryptosdk_keyring_base_init_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_base_init/aws_cryptosdk_keyring_base_init_harness.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/materials.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_base_init_harness() {
+    /* Non-deterministic inputs. */
+    struct aws_cryptosdk_keyring *keyring   = can_fail_malloc(sizeof(*keyring));
+    struct aws_cryptosdk_keyring_vt *vtable = can_fail_malloc(sizeof(*vtable));
+
+    /* Pre-conditions. */
+    __CPROVER_assume(keyring != NULL);
+    __CPROVER_assume(IMPLIES(vtable != NULL, aws_cryptosdk_keyring_vt_is_valid(vtable)));
+
+    /* Operation under verification. */
+    aws_cryptosdk_keyring_base_init(keyring, vtable);
+
+    /* Post-conditions. */
+    assert(aws_cryptosdk_keyring_is_valid(keyring));
+    assert(IMPLIES(vtable != NULL, aws_cryptosdk_keyring_vt_is_valid(vtable)));
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_base_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_base_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_keyring_base_init_harness.goto
+jobos: ubuntu16


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_keyring_base_init` function;
- Adds preconditions in `aws_cryptosdk_keyring_base_init` function.
- Adds validity function for `aws_cryptosdk_keyring_vt` and `aws_cryptosdk_keyring` structures.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

