### PR TITLE
Adds a proof harness for aws_cryptosdk_keyring_retain

### DIFF
--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <aws/common/atomics.h>
 #include <aws/common/common.h>
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/materials.h>

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/Makefile
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+CBMCFLAGS +=
+
+# aws_atomic_fetch_add_explicit receives a volatile input, which is always model
+# as non-deterministic in CBMC; thus, we need a deterministic stub for it
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_fetch_add_explicit.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_fetch_add_explicit
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_load_int.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_load_int
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_priv_xlate_order.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_priv_xlate_order
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/atomics.c
+
+ENTRY = aws_cryptosdk_keyring_retain_harness
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/Makefile
@@ -16,6 +16,8 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 
+# Expect runtime for this proof is 10sec
+
 CBMCFLAGS +=
 
 # aws_atomic_fetch_add_explicit receives a volatile input, which is always model

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/aws_cryptosdk_keyring_retain_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/aws_cryptosdk_keyring_retain_harness.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/materials.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_keyring_retain_harness() {
+    /* Non-deterministic inputs. */
+    const struct aws_cryptosdk_keyring_vt vtable = { .vt_size    = sizeof(struct aws_cryptosdk_keyring_vt),
+                                                     .name       = ensure_c_str_is_allocated(SIZE_MAX),
+                                                     .destroy    = nondet_voidp(),
+                                                     .on_encrypt = nondet_voidp(),
+                                                     .on_decrypt = nondet_voidp() };
+    struct aws_cryptosdk_keyring keyring;
+    ensure_cryptosdk_keyring_has_allocated_members(&keyring, &vtable);
+
+    /* Pre-conditions. */
+    __CPROVER_assume(aws_cryptosdk_keyring_is_valid(&keyring));
+    __CPROVER_assume(aws_atomic_var_is_valid(&keyring.refcount));
+    __CPROVER_assume(aws_atomic_load_int(&keyring.refcount) < SIZE_MAX);
+
+    /* Save previous reference count. */
+    size_t prev_refcount = *((size_t *)AWS_ATOMIC_VAR_PTRVAL(&keyring.refcount));
+
+    /* Operation under verification. */
+    aws_cryptosdk_keyring_retain(&keyring);
+
+    /* Post-conditions. */
+    assert(aws_cryptosdk_keyring_is_valid(&keyring));
+    size_t new = *((size_t *)AWS_ATOMIC_VAR_PTRVAL(&keyring.refcount));
+    assert(new > prev_refcount);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/aws_cryptosdk_keyring_retain_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/aws_cryptosdk_keyring_retain_harness.c
@@ -39,6 +39,6 @@ void aws_cryptosdk_keyring_retain_harness() {
 
     /* Post-conditions. */
     assert(aws_cryptosdk_keyring_is_valid(&keyring));
-    size_t new = aws_atomic_load_int(&keyring.refcount);
-    assert(new > prev_refcount);
+    size_t new_refcount = aws_atomic_load_int(&keyring.refcount);
+    assert(new_refcount > prev_refcount);
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/aws_cryptosdk_keyring_retain_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/aws_cryptosdk_keyring_retain_harness.c
@@ -32,13 +32,13 @@ void aws_cryptosdk_keyring_retain_harness() {
     __CPROVER_assume(aws_atomic_load_int(&keyring.refcount) < SIZE_MAX);
 
     /* Save previous reference count. */
-    size_t prev_refcount = *((size_t *)AWS_ATOMIC_VAR_PTRVAL(&keyring.refcount));
+    size_t prev_refcount = aws_atomic_load_int(&keyring.refcount);
 
     /* Operation under verification. */
     aws_cryptosdk_keyring_retain(&keyring);
 
     /* Post-conditions. */
     assert(aws_cryptosdk_keyring_is_valid(&keyring));
-    size_t new = *((size_t *)AWS_ATOMIC_VAR_PTRVAL(&keyring.refcount));
+    size_t new = aws_atomic_load_int(&keyring.refcount);
     assert(new > prev_refcount);
 }

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_retain/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_keyring_retain_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/stubs/aws_atomic_fetch_add_explicit.c
+++ b/.cbmc-batch/stubs/aws_atomic_fetch_add_explicit.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Takes the existing list, and simply returns it. If the list originally nondeterminstic,
+ * this is sound (although it may lead to spurious proof failures if the code under test required the sorted property).
+ */
+
+#include <aws/common/atomics.h>
+
+size_t aws_atomic_fetch_add_explicit(struct aws_atomic_var *var, size_t n, enum aws_memory_order order) {
+    size_t rval = *((size_t *)AWS_ATOMIC_VAR_PTRVAL(var));
+    *((size_t *)AWS_ATOMIC_VAR_PTRVAL(var)) += n;
+    return rval;
+}

--- a/.cbmc-batch/stubs/aws_atomic_fetch_add_explicit.c
+++ b/.cbmc-batch/stubs/aws_atomic_fetch_add_explicit.c
@@ -13,13 +13,12 @@
  * limitations under the License.
  */
 
-/**
- * Takes the existing list, and simply returns it. If the list originally nondeterminstic,
- * this is sound (although it may lead to spurious proof failures if the code under test required the sorted property).
- */
-
 #include <aws/common/atomics.h>
 
+/**
+ *  For sequential proofs, we directly access the atomic value.
+ *  Adds n to *var, and returns the previous value of *var (ignoring order).
+ */
 size_t aws_atomic_fetch_add_explicit(struct aws_atomic_var *var, size_t n, enum aws_memory_order order) {
     size_t rval = *((size_t *)AWS_ATOMIC_VAR_PTRVAL(var));
     *((size_t *)AWS_ATOMIC_VAR_PTRVAL(var)) += n;

--- a/.cbmc-batch/stubs/aws_atomic_load_int.c
+++ b/.cbmc-batch/stubs/aws_atomic_load_int.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Takes the existing list, and simply returns it. If the list originally nondeterminstic,
+ * this is sound (although it may lead to spurious proof failures if the code under test required the sorted property).
+ */
+
+#include <aws/common/atomics.h>
+
+/*
+ * For sequential proofs, we directly access the atomic value,
+ * so we can correctly propagate it through CBMC assumptions.
+ */
+size_t aws_atomic_load_int(const struct aws_atomic_var *var) {
+    return *((size_t *)(var->value));
+}

--- a/.cbmc-batch/stubs/aws_atomic_priv_xlate_order.c
+++ b/.cbmc-batch/stubs/aws_atomic_priv_xlate_order.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Takes the existing list, and simply returns it. If the list originally nondeterminstic,
+ * this is sound (although it may lead to spurious proof failures if the code under test required the sorted property).
+ */
+
+#include <aws/common/atomics.h>
+
+/* The use of this stubs improves coverage results while keeping safety guarantees. */
+int aws_atomic_priv_xlate_order(enum aws_memory_order order) {
+    assert(
+        order == aws_memory_order_relaxed || order == aws_memory_order_acquire || order == aws_memory_order_release ||
+        order == aws_memory_order_acq_rel || order == aws_memory_order_seq_cst);
+    int nondet_order;
+    return nondet_order;
+}

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -355,7 +355,7 @@ struct aws_cryptosdk_cmm_vt {
  * Putting this here for now, until we get it merged into the atomics.h in c-common
  */
 AWS_CRYPTOSDK_STATIC_INLINE bool aws_atomic_var_is_valid(const struct aws_atomic_var *var) {
-    return AWS_OBJECT_PTR_IS_WRITABLE(var);
+    return AWS_OBJECT_PTR_IS_WRITABLE(var) && AWS_OBJECT_PTR_IS_WRITABLE((size_t *)aws_atomic_load_ptr(var));
 }
 
 /**
@@ -512,7 +512,7 @@ AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_keyring_vt_is_valid(const struct 
  */
 AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_keyring_is_valid(const struct aws_cryptosdk_keyring *keyring) {
     return AWS_OBJECT_PTR_IS_READABLE(keyring) && aws_atomic_var_is_valid(&keyring->refcount) &&
-           aws_atomic_load_int(&keyring->refcount) > 0 && aws_atomic_load_int(&keyring->refcount) <= SIZE_MAX &&
+           (aws_atomic_load_int(&keyring->refcount) > 0) && (aws_atomic_load_int(&keyring->refcount) <= SIZE_MAX) &&
            (keyring->vtable == NULL || aws_cryptosdk_keyring_vt_is_valid(keyring->vtable));
 }
 
@@ -544,6 +544,9 @@ AWS_CRYPTOSDK_STATIC_INLINE void aws_cryptosdk_keyring_release(struct aws_crypto
  */
 AWS_CRYPTOSDK_STATIC_INLINE struct aws_cryptosdk_keyring *aws_cryptosdk_keyring_retain(
     struct aws_cryptosdk_keyring *keyring) {
+    AWS_PRECONDITION(aws_cryptosdk_keyring_is_valid(keyring));
+    AWS_PRECONDITION(aws_atomic_var_is_valid(&keyring->refcount));
+    AWS_PRECONDITION(aws_atomic_load_int(&keyring->refcount) < SIZE_MAX);
     aws_cryptosdk_private_refcount_up(&keyring->refcount);
     return keyring;
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

This PR depends on https://github.com/aws/aws-encryption-sdk-c/pull/513.

*Issue #, if available:*
N/A.

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_keyring_retain` function;
- Adds preconditions in `aws_cryptosdk_keyring_retain` function;
- Adds a stub for `aws_atomic_fetch_add_explicit`;
- Adds a stub for `aws_atomic_load_int`;
- Adds a stub for `aws_atomic_priv_xlate_order`;
- Improves the validity check for `aws_atomic_var`;
- Improves the validity check for `aws_cryptosdk_keyring`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

