### PR TITLE
Adds a proof harness for aws_cryptosdk_keyring_release

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_release/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_release/Makefile
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+# Expect runtime for this proof is 8 seconds
+
+CBMCFLAGS +=
+
+# aws_atomic_fetch_sub_explicit receives a volatile input, which is always model
+# as non-deterministic in CBMC; thus, we need a deterministic stub for it
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_fetch_sub_explicit.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_fetch_sub_explicit
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_load_int.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_load_int
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_priv_xlate_order.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_priv_xlate_order
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_keyring_release_harness
+
+REMOVE_FUNCTION_BODY += --remove-function-body hash_proof_destroy_noop
+REMOVE_FUNCTION_BODY += --remove-function-body aws_raise_error_private
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_release/aws_cryptosdk_keyring_release_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_release/aws_cryptosdk_keyring_release_harness.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/materials.h>
+#include <make_common_data_structures.h>
+
+void destroy(struct aws_cryptosdk_keyring *keyring) {
+    assert(keyring != NULL);
+    free(keyring);
+}
+
+void aws_cryptosdk_keyring_release_harness() {
+    /* Non-deterministic inputs. */
+    const struct aws_cryptosdk_keyring_vt vtable = { .vt_size    = sizeof(struct aws_cryptosdk_keyring_vt),
+                                                     .name       = ensure_c_str_is_allocated(SIZE_MAX),
+                                                     .destroy    = nondet_bool() ? destroy : NULL,
+                                                     .on_encrypt = nondet_voidp(),
+                                                     .on_decrypt = nondet_voidp() };
+    struct aws_cryptosdk_keyring *keyring        = can_fail_malloc(sizeof(struct aws_cryptosdk_keyring));
+
+    /* Pre-conditions. */
+    if (keyring != NULL) {
+        ensure_cryptosdk_keyring_has_allocated_members(keyring, &vtable);
+        __CPROVER_assume(aws_cryptosdk_keyring_is_valid(keyring));
+        __CPROVER_assume(keyring->vtable != NULL);
+    }
+
+    /* Operation under verification. */
+    aws_cryptosdk_keyring_release(keyring);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_release/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_release/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_keyring_release_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/stubs/aws_atomic_fetch_sub_explicit.c
+++ b/.cbmc-batch/stubs/aws_atomic_fetch_sub_explicit.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/atomics.h>
+
+/**
+ *  For sequential proofs, we directly access the atomic value.
+ *  Subtracts n from *var, and returns the previous value of *var (ignoring order).
+ */
+size_t aws_atomic_fetch_sub_explicit(struct aws_atomic_var *var, size_t n, enum aws_memory_order order) {
+    size_t rval = *((size_t *)AWS_ATOMIC_VAR_PTRVAL(var));
+    *((size_t *)AWS_ATOMIC_VAR_PTRVAL(var)) -= n;
+    return rval;
+}

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -533,6 +533,7 @@ AWS_CRYPTOSDK_STATIC_INLINE void aws_cryptosdk_keyring_base_init(
  * Decrements the reference count on the keyring; if the new reference count is zero, the keyring is destroyed.
  */
 AWS_CRYPTOSDK_STATIC_INLINE void aws_cryptosdk_keyring_release(struct aws_cryptosdk_keyring *keyring) {
+    AWS_PRECONDITION(!keyring || (aws_cryptosdk_keyring_is_valid(keyring) && keyring->vtable != NULL));
     if (keyring && aws_cryptosdk_private_refcount_down(&keyring->refcount)) {
         AWS_CRYPTOSDK_PRIVATE_VF_CALL_NO_RETURN(destroy, keyring);
     }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

This PR depends on https://github.com/aws/aws-encryption-sdk-c/pull/513 and https://github.com/aws/aws-encryption-sdk-c/pull/515.

*Issue #, if available:*
N/A.

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_keyring_release` function;
- Adds preconditions in `aws_cryptosdk_keyring_release` function;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

