### PR TITLE
Use recommended RSA padding mode

### DIFF
--- a/examples/raw_rsa_keyring.c
+++ b/examples/raw_rsa_keyring.c
@@ -133,7 +133,12 @@ int main(int argc, char **argv) {
      * was used on encryption.
      */
     struct aws_cryptosdk_keyring *keyring = aws_cryptosdk_raw_rsa_keyring_new(
-        alloc, wrapping_key_namespace, wrapping_key_name, private_key_pem, public_key_pem, AWS_CRYPTOSDK_RSA_OAEP_SHA256_MGF1);
+        alloc,
+        wrapping_key_namespace,
+        wrapping_key_name,
+        private_key_pem,
+        public_key_pem,
+        AWS_CRYPTOSDK_RSA_OAEP_SHA256_MGF1);
     if (!keyring) abort();
 
     /* The raw RSA keyring keeps its own copies of the PEM files, so we free

--- a/examples/raw_rsa_keyring.c
+++ b/examples/raw_rsa_keyring.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv) {
      * was used on encryption.
      */
     struct aws_cryptosdk_keyring *keyring = aws_cryptosdk_raw_rsa_keyring_new(
-        alloc, wrapping_key_namespace, wrapping_key_name, private_key_pem, public_key_pem, AWS_CRYPTOSDK_RSA_PKCS1);
+        alloc, wrapping_key_namespace, wrapping_key_name, private_key_pem, public_key_pem, AWS_CRYPTOSDK_RSA_OAEP_SHA256_MGF1);
     if (!keyring) abort();
 
     /* The raw RSA keyring keeps its own copies of the PEM files, so we free


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changing the example to use the recommend OAEP padding mode. We discourage the use of the PKCS#1 padding mode. It's included only for backwards compatibility.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

