### PR TITLE
Adds a proof harness for aws_cryptosdk_enc_materials_new

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_new/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_new/Makefile
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+include ../Makefile.string
+
+# Expected runtime 38sec
+
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/error.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_hash_table_no_slots_override.c
+ABSTRACTIONS += $(SRCDIR)/helper-src/openssl/ec_override.c
+ABSTRACTIONS += $(SRCDIR)/helper-src/openssl/bn_override.c
+ABSTRACTIONS += $(SRCDIR)/helper-src/openssl/evp_override.c
+
+AWS_DEEP_CHECKS = 1
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/math.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/edk.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/atomics.c
+
+REMOVE_FUNCTION_BODY += --remove-function-body aws_array_list_get_at_ptr
+REMOVE_FUNCTION_BODY += --remove-function-body aws_cryptosdk_edk_is_valid
+REMOVE_FUNCTION_BODY += --remove-function-body aws_cryptosdk_edk_clean_up
+REMOVE_FUNCTION_BODY += --remove-function-body aws_cryptosdk_keyring_trace_record_is_valid
+REMOVE_FUNCTION_BODY += --remove-function-body aws_cryptosdk_sig_ctx_is_valid
+
+ENTRY = aws_cryptosdk_enc_materials_new_harness
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_new/aws_cryptosdk_enc_materials_new_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_new/aws_cryptosdk_enc_materials_new_harness.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/materials.h>
+#include <cipher_openssl.h>
+#include <proof_helpers/cryptosdk/make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+void aws_cryptosdk_enc_materials_new_harness() {
+    /* Non-deterministic inputs. */
+    struct aws_allocator *alloc = nondet_bool() ? NULL : can_fail_allocator();
+    enum aws_cryptosdk_alg_id alg;
+
+    /* Pre-condition. */
+    __CPROVER_assume(aws_allocator_is_valid(alloc));
+
+    /* Operation under verification. */
+    struct aws_cryptosdk_dec_materials *enc_mat = aws_cryptosdk_enc_materials_new(alloc, alg);
+
+    /* Post-conditions. */
+    if (enc_mat != NULL) {
+        assert(aws_cryptosdk_enc_materials_is_valid(enc_mat));
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_new/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_new/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_enc_materials_new_harness.goto
+jobos: ubuntu16

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -164,6 +164,20 @@ struct aws_cryptosdk_dec_materials {
     enum aws_cryptosdk_alg_id alg;
 };
 
+AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_enc_materials_is_valid(
+    const struct aws_cryptosdk_enc_materials *materials) {
+    if (!AWS_OBJECT_PTR_IS_WRITABLE(materials)) {
+        return false;
+    }
+    bool allocator_valid            = aws_allocator_is_valid(materials->alloc);
+    bool unencrypted_data_key_valid = aws_byte_buf_is_valid(&materials->unencrypted_data_key);
+    bool keyring_trace_valid        = aws_cryptosdk_keyring_trace_is_valid(&materials->keyring_trace);
+    bool encrypted_data_keys_valid  = aws_cryptosdk_edk_list_is_valid(&materials->encrypted_data_keys);
+    bool signctx_valid = (materials->signctx == NULL) || aws_cryptosdk_sig_ctx_is_valid(materials->signctx);
+    return allocator_valid && unencrypted_data_key_valid && keyring_trace_valid && encrypted_data_keys_valid &&
+           signctx_valid;
+}
+
 AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_dec_materials_is_valid(
     const struct aws_cryptosdk_dec_materials *materials) {
     if (!AWS_OBJECT_PTR_IS_WRITABLE(materials)) {

--- a/source/materials.c
+++ b/source/materials.c
@@ -17,6 +17,7 @@
 
 struct aws_cryptosdk_enc_materials *aws_cryptosdk_enc_materials_new(
     struct aws_allocator *alloc, enum aws_cryptosdk_alg_id alg) {
+    AWS_PRECONDITION(aws_allocator_is_valid(alloc));
     struct aws_cryptosdk_enc_materials *enc_mat;
     enc_mat = aws_mem_acquire(alloc, sizeof(struct aws_cryptosdk_enc_materials));
 


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_enc_materials_new` function;
- Adds preconditions in `aws_cryptosdk_enc_materials_new` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

