### PR TITLE
CBMC Proof for aws_cryptosdk_enc_materials_destroy

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_destroy/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_destroy/Makefile
@@ -1,0 +1,72 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+include ../Makefile.string
+
+#########
+# Local vars
+
+# gets full coverage, runtime for property is 9min. 
+MAX_NUM_ITEMS ?= 1
+DEFINES += -DMAX_NUM_ITEMS=$(MAX_NUM_ITEMS)
+
+#########
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_hash_table_no_slots_override.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_string_destroy_override.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/error.c
+ABSTRACTIONS += $(SRCDIR)/helper-src/openssl/bn_override.c
+ABSTRACTIONS += $(SRCDIR)/helper-src/openssl/ec_override.c
+ABSTRACTIONS += $(SRCDIR)/helper-src/openssl/evp_override.c
+
+# Enable after https://github.com/diffblue/cbmc/issues/5344 is fixed
+#AWS_DEEP_CHECKS = 1
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/math.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/edk.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/atomics.c
+
+ENTRY = aws_cryptosdk_enc_materials_destroy_harness
+
+
+UNWINDSET += aws_cryptosdk_edk_list_clear.0:$(call addone,$(MAX_NUM_ITEMS)) 
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_bounded.0:$(call addone,$(MAX_NUM_ITEMS))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_valid.0:$(call addone,$(MAX_NUM_ITEMS))
+UNWINDSET += aws_cryptosdk_edk_list_is_bounded.0:$(call addone,$(MAX_NUM_ITEMS))
+UNWINDSET += aws_cryptosdk_edk_list_is_valid.0:$(call addone,$(MAX_NUM_ITEMS)) 
+UNWINDSET += aws_cryptosdk_keyring_trace_clear.0:$(call addone,$(MAX_NUM_ITEMS))
+UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(MAX_NUM_ITEMS))
+UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_list_elements.0:$(call addone,$(MAX_NUM_ITEMS))
+UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_members.0:$(call addone,$(MAX_NUM_ITEMS))
+UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_NUM_ITEMS))
+
+###########
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_destroy/aws_cryptosdk_enc_materials_destroy_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_destroy/aws_cryptosdk_enc_materials_destroy_harness.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/materials.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <cbmc_invariants.h>
+#include <cipher_openssl.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/cryptosdk/make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+// Stub this until https://github.com/diffblue/cbmc/issues/5344 is fixed
+// Original function is here:
+// https://github.com/aws/aws-encryption-sdk-c/blob/master/source/edk.c#L44
+void aws_cryptosdk_edk_list_clean_up(struct aws_array_list *encrypted_data_keys) {
+    assert(aws_cryptosdk_edk_list_is_valid(encrypted_data_keys));
+    aws_array_list_clean_up(encrypted_data_keys);
+}
+
+void aws_cryptosdk_enc_materials_destroy_harness() {
+    struct aws_cryptosdk_enc_materials *materials = can_fail_malloc(sizeof(*materials));
+    if (materials) {
+        materials->alloc = can_fail_allocator();
+        __CPROVER_assume(aws_allocator_is_valid(materials->alloc));
+
+        // Set up the signctx
+        materials->signctx = can_fail_malloc(sizeof(*materials->signctx));
+        if (materials->signctx) {
+            ensure_sig_ctx_has_allocated_members(materials->signctx);
+            __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(materials->signctx));
+        }
+
+        // Set up the unencrypted_data_key
+        __CPROVER_assume(aws_byte_buf_is_bounded(&materials->unencrypted_data_key, MAX_NUM_ITEMS));
+        ensure_byte_buf_has_allocated_buffer_member(&materials->unencrypted_data_key);
+
+        // Set up the edk_list
+        /* edk_list Precondition: We have a valid list */
+        __CPROVER_assume(aws_cryptosdk_edk_list_is_bounded(&materials->encrypted_data_keys, MAX_NUM_ITEMS));
+        ensure_cryptosdk_edk_list_has_allocated_list(&materials->encrypted_data_keys);
+        __CPROVER_assume(aws_cryptosdk_edk_list_is_valid(&materials->encrypted_data_keys));
+
+        // Stub until https://github.com/diffblue/cbmc/issues/5344 is fixed
+        /* edk_list Precondition: The list has valid list elements */
+        /*
+        __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_bounded(&materials->encrypted_data_keys, MAX_STRING_LEN));
+        ensure_cryptosdk_edk_list_has_allocated_list_elements(&materials->encrypted_data_keys);
+        __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_valid(&materials->encrypted_data_keys));
+        */
+        // Set up the keyring trace
+        __CPROVER_assume(aws_array_list_is_bounded(
+            &materials->keyring_trace, MAX_NUM_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+        __CPROVER_assume(materials->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+        ensure_array_list_has_allocated_data_member(&materials->keyring_trace);
+        __CPROVER_assume(aws_array_list_is_valid(&materials->keyring_trace));
+        ensure_trace_has_allocated_records(&materials->keyring_trace, MAX_STRING_LEN);
+        __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&materials->keyring_trace));
+
+        __CPROVER_assume(aws_cryptosdk_enc_materials_is_valid(materials));
+    }
+
+    // Run the function under test.
+    // This frees all materials, and hence there are no post-conditions to check
+    aws_cryptosdk_enc_materials_destroy(materials);
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_destroy/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_materials_destroy/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_edk_list_clear.0:2,aws_cryptosdk_edk_list_elements_are_bounded.0:2,aws_cryptosdk_edk_list_elements_are_valid.0:2,aws_cryptosdk_edk_list_is_bounded.0:2,aws_cryptosdk_edk_list_is_valid.0:2,aws_cryptosdk_keyring_trace_clear.0:2,aws_cryptosdk_keyring_trace_is_valid.0:2,ensure_cryptosdk_edk_list_has_allocated_list_elements.0:2,ensure_cryptosdk_edk_list_has_allocated_members.0:2,ensure_trace_has_allocated_records.0:2;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_enc_materials_destroy_harness.goto
+jobos: ubuntu16

--- a/source/materials.c
+++ b/source/materials.c
@@ -42,6 +42,8 @@ struct aws_cryptosdk_enc_materials *aws_cryptosdk_enc_materials_new(
 }
 
 void aws_cryptosdk_enc_materials_destroy(struct aws_cryptosdk_enc_materials *enc_mat) {
+    AWS_PRECONDITION(enc_mat == NULL || aws_cryptosdk_enc_materials_is_valid(enc_mat));
+
     if (enc_mat) {
         aws_cryptosdk_sig_abort(enc_mat->signctx);
         aws_byte_buf_clean_up_secure(&enc_mat->unencrypted_data_key);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-encryption-sdk-c/issues/529

*Description of changes:*
Adds a proof for `aws_cryptosdk_enc_materials_destroy`.  This proof had to stub one function: this will go away once https://github.com/diffblue/cbmc/issues/5344 is fixed


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

