### PR TITLE
Adds a proof harness for aws_cryptosdk_keyring_on_encrypt

### DIFF
--- a/.cbmc-batch/include/make_common_data_structures.h
+++ b/.cbmc-batch/include/make_common_data_structures.h
@@ -32,6 +32,12 @@ void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ct
 /* Allocates the members of the context and ensures that internal pointers are pointing to the correct objects. */
 void ensure_sig_ctx_has_allocated_members(struct aws_cryptosdk_sig_ctx *ctx);
 
+bool aws_cryptosdk_edk_list_is_bounded(
+    const struct aws_array_list *const list, const size_t max_initial_item_allocation);
+bool aws_cryptosdk_edk_list_elements_are_bounded(const struct aws_array_list *const list, const size_t max_item_size);
+void ensure_cryptosdk_edk_list_has_allocated_list(struct aws_array_list *list);
+void ensure_cryptosdk_edk_list_has_allocated_list_elements(struct aws_array_list *list);
+
 /* Makes internal function from cipher.c accessible for CBMC */
 enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id alg_id);
 

--- a/.cbmc-batch/jobs/Makefile.aws_array_list
+++ b/.cbmc-batch/jobs/Makefile.aws_array_list
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 ##########
-# if Makefile.local exists, use it. This provides a way to override the defaults 
+# if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_encrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_encrypt/Makefile
@@ -1,0 +1,84 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_array_list
+include ../Makefile.aws_byte_buf
+
+# Expect runtime for this proof is 3min with these local variables
+MAX_TABLE_SIZE ?= 2
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
+
+NUM_ELEMS = 1
+DEFINES += -DNUM_ELEMS=$(NUM_ELEMS)
+
+DEFINES += -DARRAY_LIST_TYPE="struct aws_cryptosdk_keyring_trace_record"
+DEFINES += -DAWS_NO_STATIC_IMPL
+DEFINES += -DARRAY_LIST_TYPE_HEADER=\"aws/cryptosdk/keyring_trace.h\"
+
+CBMCFLAGS +=
+
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/error.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_array_list_defined_type.c
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_load_int.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_load_int
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_priv_xlate_order.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_priv_xlate_order
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/array_list.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/atomics.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/math.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/string.c
+
+DEPENDENCIES += $(SRCDIR)/c-common-src/array_list.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/math.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/string.c
+
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/edk.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
+
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_keyring_on_encrypt_harness
+
+addone = $(shell echo $$(( $(1) + 1)))
+
+# memcmp is invoked to compare two aws_byte_buf objetcs,
+# so the upper bound limit is the size of aws_byte_buf + 1
+UNWINDSET += memcmp.0:33
+UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(MAX_ITEM_SIZE))
+UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_ITEM_SIZE))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_bounded.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_valid.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += aws_cryptosdk_edk_list_is_bounded.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += aws_cryptosdk_edk_list_is_valid.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_list_elements.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_members.0:$(call addone,$(NUM_ELEMS))
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_encrypt/aws_cryptosdk_keyring_on_encrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_encrypt/aws_cryptosdk_keyring_on_encrypt_harness.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/common/hash_table.h>
+
+#include <aws/cryptosdk/edk.h>
+#include <aws/cryptosdk/materials.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+
+#include <make_common_data_structures.h>
+
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+/**
+ * Stub for the virtual function on_encrypt of a aws_cryptosdk_keyring_vt structure.
+ * Must implement if used for encryption.
+ * It should be as nondeterministic as possible to increase coverage on the operation under
+ * verfication; thus, it also triggers states with errors.
+ *
+ * When the buffer for the unencrypted data key is not NULL at the time of the call, it
+ * must not be changed by callee. All buffers for EDKs pushed onto the list must be in a
+ * valid state, which means either that they are set to all zeroes or that they have been
+ * initialized using one of the byte buffer initialization functions. This assures proper
+ * clean up and serialization.
+ */
+int on_encrypt(
+    struct aws_cryptosdk_keyring *keyring,
+    struct aws_allocator *request_alloc,
+    struct aws_byte_buf *unencrypted_data_key,
+    struct aws_array_list *keyring_trace,
+    struct aws_array_list *edks,
+    const struct aws_hash_table *enc_ctx,
+    enum aws_cryptosdk_alg_id alg) {
+    /* Check validity for all inputs to avoid memory-safety violations. */
+    assert(aws_cryptosdk_keyring_is_valid(keyring));
+    assert(aws_allocator_is_valid(request_alloc));
+    assert(aws_byte_buf_is_valid(unencrypted_data_key));
+    assert(aws_cryptosdk_keyring_trace_is_valid(keyring_trace));
+    assert(aws_cryptosdk_edk_list_is_valid(edks));
+    assert(aws_cryptosdk_edk_list_elements_are_valid(edks));
+    assert((enc_ctx == NULL) || aws_hash_table_is_valid(enc_ctx));
+
+    if (unencrypted_data_key->buffer == NULL) {
+        const struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg);
+        if (props != NULL) {
+            __CPROVER_assume(aws_byte_buf_is_bounded(unencrypted_data_key, props->data_key_len));
+            ensure_byte_buf_has_allocated_buffer_member(unencrypted_data_key);
+            /*
+             * This satisfies the post-condition that if this keyring
+             * generated data key, it must be the right length.
+             * The nondeterminism increases coverage.
+             */
+            if (nondet_bool()) unencrypted_data_key->len = props->data_key_len;
+            unencrypted_data_key->allocator = request_alloc;
+            __CPROVER_assume(aws_byte_buf_is_valid(unencrypted_data_key));
+        }
+    } else {
+        /*
+         * If the buffer is not NULL, the byte buffer must not have been modified;
+         * however, this allocation modifies the buffer and increases coverage.
+         */
+        if (nondet_bool()) ensure_byte_buf_has_allocated_buffer_member(unencrypted_data_key);
+    }
+    int ret;
+    return ret;
+}
+
+void aws_cryptosdk_keyring_on_encrypt_harness() {
+    /* Non-deterministic inputs. */
+    const struct aws_cryptosdk_keyring_vt vtable = { .vt_size    = sizeof(struct aws_cryptosdk_keyring_vt),
+                                                     .name       = ensure_c_str_is_allocated(SIZE_MAX),
+                                                     .destroy    = nondet_voidp(),
+                                                     .on_encrypt = nondet_bool() ? NULL : on_encrypt,
+                                                     .on_decrypt = nondet_voidp() };
+    struct aws_cryptosdk_keyring keyring;
+    ensure_cryptosdk_keyring_has_allocated_members(&keyring, &vtable);
+    __CPROVER_assume(aws_cryptosdk_keyring_is_valid(&keyring));
+    __CPROVER_assume(keyring.vtable != NULL);
+
+    struct aws_allocator *request_alloc = can_fail_allocator();
+    __CPROVER_assume(aws_allocator_is_valid(request_alloc));
+
+    struct aws_array_list keyring_trace;
+    __CPROVER_assume(
+        aws_array_list_is_bounded(&keyring_trace, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+    __CPROVER_assume(keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&keyring_trace);
+    __CPROVER_assume(aws_array_list_is_valid(&keyring_trace));
+    ensure_trace_has_allocated_records(&keyring_trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&keyring_trace));
+
+    struct aws_byte_buf unencrypted_data_key;
+    if (nondet_bool()) {
+        /* The caller could send an empty unencrypted_data_key. */
+        unencrypted_data_key.buffer = NULL;
+    } else {
+        ensure_byte_buf_has_allocated_buffer_member(&unencrypted_data_key);
+    }
+    __CPROVER_assume(aws_byte_buf_is_valid(&unencrypted_data_key));
+
+    struct aws_array_list edks;
+    __CPROVER_assume(aws_cryptosdk_edk_list_is_bounded(&edks, NUM_ELEMS));
+    ensure_cryptosdk_edk_list_has_allocated_list(&edks);
+    __CPROVER_assume(aws_cryptosdk_edk_list_is_valid(&edks));
+    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_bounded(&edks, SIZE_MAX));
+    ensure_cryptosdk_edk_list_has_allocated_list_elements(&edks);
+    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_valid(&edks));
+
+    struct aws_hash_table *enc_ctx = can_fail_malloc(sizeof(*enc_ctx));
+    if (enc_ctx != NULL) {
+        ensure_allocated_hash_table(enc_ctx, MAX_TABLE_SIZE);
+        __CPROVER_assume(aws_hash_table_is_valid(enc_ctx));
+        ensure_hash_table_has_valid_destroy_functions(enc_ctx);
+        size_t empty_slot_idx;
+        __CPROVER_assume(aws_hash_table_has_an_empty_slot(enc_ctx, &empty_slot_idx));
+    }
+
+    enum aws_cryptosdk_alg_id alg;
+
+    /* Operation under verification. */
+    if (aws_cryptosdk_keyring_on_encrypt(
+            &keyring, request_alloc, &unencrypted_data_key, &keyring_trace, &edks, enc_ctx, alg) == AWS_OP_SUCCESS) {
+        assert(aws_byte_buf_is_valid(&unencrypted_data_key));
+    }
+
+    /* Post-conditions. */
+    assert(aws_cryptosdk_keyring_is_valid(&keyring));
+    assert(aws_allocator_is_valid(request_alloc));
+    assert(aws_cryptosdk_keyring_trace_is_valid(&keyring_trace));
+    assert(aws_cryptosdk_edk_list_is_valid(&edks));
+    assert(aws_cryptosdk_edk_list_elements_are_valid(&edks));
+    if (enc_ctx != NULL) assert(aws_hash_table_is_valid(enc_ctx));
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_encrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_encrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:33,aws_cryptosdk_keyring_trace_is_valid.0:3,ensure_trace_has_allocated_records.0:3,aws_cryptosdk_edk_list_elements_are_bounded.0:2,aws_cryptosdk_edk_list_elements_are_valid.0:2,aws_cryptosdk_edk_list_is_bounded.0:2,aws_cryptosdk_edk_list_is_valid.0:2,ensure_cryptosdk_edk_list_has_allocated_list_elements.0:2,ensure_cryptosdk_edk_list_has_allocated_members.0:2;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_keyring_on_encrypt_harness.goto
+jobos: ubuntu16

--- a/source/materials.c
+++ b/source/materials.c
@@ -93,6 +93,13 @@ int aws_cryptosdk_keyring_on_encrypt(
     struct aws_array_list *edks,
     const struct aws_hash_table *enc_ctx,
     enum aws_cryptosdk_alg_id alg) {
+    AWS_PRECONDITION(aws_allocator_is_valid(request_alloc));
+    AWS_PRECONDITION(aws_cryptosdk_keyring_is_valid(keyring) && (keyring->vtable != NULL));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(unencrypted_data_key));
+    AWS_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(keyring_trace));
+    AWS_PRECONDITION(aws_cryptosdk_edk_list_is_valid(edks) && aws_cryptosdk_edk_list_elements_are_valid(edks));
+    AWS_PRECONDITION(enc_ctx == NULL || aws_hash_table_is_valid(enc_ctx));
+
     /* Shallow copy of byte buffer: does NOT duplicate key bytes */
     const struct aws_byte_buf precall_data_key_buf = *unencrypted_data_key;
 
@@ -109,7 +116,7 @@ int aws_cryptosdk_keyring_on_encrypt(
     /* Postcondition: If this keyring generated data key, it must be the right length. */
     if (!precall_data_key_buf.buffer && unencrypted_data_key->buffer) {
         const struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg);
-        if (unencrypted_data_key->len != props->data_key_len) {
+        if (props == NULL || (unencrypted_data_key->len != props->data_key_len)) {
             return aws_raise_error(AWS_CRYPTOSDK_ERR_BAD_STATE);
         }
     }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
https://github.com/aws/aws-encryption-sdk-c/issues/539 (related, but it does not fixed it.)

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_keyring_on_encrypt` function;
- Adds preconditions in `aws_cryptosdk_keyring_on_encrypt` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

