### PR TITLE
Adds a proof harness for aws_cryptosdk_keyring_on_decrypt

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_decrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_decrypt/Makefile
@@ -1,0 +1,84 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_array_list
+include ../Makefile.aws_byte_buf
+
+# Expect runtime for this proof is 3min with these local variables
+MAX_TABLE_SIZE ?= 2
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
+
+NUM_ELEMS = 1
+DEFINES += -DNUM_ELEMS=$(NUM_ELEMS)
+
+DEFINES += -DARRAY_LIST_TYPE="struct aws_cryptosdk_keyring_trace_record"
+DEFINES += -DAWS_NO_STATIC_IMPL
+DEFINES += -DARRAY_LIST_TYPE_HEADER=\"aws/cryptosdk/keyring_trace.h\"
+
+CBMCFLAGS +=
+
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/error.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_array_list_defined_type.c
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_load_int.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_load_int
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_atomic_load_ptr.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_atomic_load_ptr
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/array_list.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/atomics.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/math.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/string.c
+
+DEPENDENCIES += $(SRCDIR)/c-common-src/array_list.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/math.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/string.c
+
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/edk.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/keyring_trace.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/materials.c
+
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_keyring_on_decrypt_harness
+
+addone = $(shell echo $$(( $(1) + 1)))
+
+# memcmp is invoked to compare two aws_byte_buf objetcs,
+# so the upper bound limit is the size of aws_byte_buf + 1
+UNWINDSET += memcmp.0:33
+UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(MAX_ITEM_SIZE))
+UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_ITEM_SIZE))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_bounded.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_valid.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += aws_cryptosdk_edk_list_is_bounded.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += aws_cryptosdk_edk_list_is_valid.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_list_elements.0:$(call addone,$(NUM_ELEMS))
+UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_members.0:$(call addone,$(NUM_ELEMS))
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_decrypt/aws_cryptosdk_keyring_on_decrypt_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_decrypt/aws_cryptosdk_keyring_on_decrypt_harness.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/byte_buf.h>
+#include <aws/common/hash_table.h>
+
+#include <aws/cryptosdk/edk.h>
+#include <aws/cryptosdk/materials.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+
+#include <make_common_data_structures.h>
+
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+/**
+ * Stub for the virtual function on_decrypt of a aws_cryptosdk_keyring_vt structure.
+ * Must implement if used for decryption.
+ * It should be as nondeterministic as possible to increase coverage on the operation under
+ * verfication; thus, it also triggers states with errors.
+ *
+ * Implementations must properly initialize the unencrypted data key buffer when an
+ * EDK is decrypted and leave the unencrypted data key buffer pointer set to NULL
+ * when no EDK is decrypted. Implementations should return AWS_OP_SUCCESS regardless
+ * of whether the unencrypted data key is recovered, except in cases of internal errors.
+ */
+int on_decrypt(
+    struct aws_cryptosdk_keyring *keyring,
+    struct aws_allocator *request_alloc,
+    struct aws_byte_buf *unencrypted_data_key,
+    struct aws_array_list *keyring_trace,
+    struct aws_array_list *edks,
+    const struct aws_hash_table *enc_ctx,
+    enum aws_cryptosdk_alg_id alg) {
+    /* Check validity for all inputs to avoid memory-safety violations. */
+    assert(aws_cryptosdk_keyring_is_valid(keyring));
+    assert(aws_allocator_is_valid(request_alloc));
+    assert(aws_byte_buf_is_valid(unencrypted_data_key));
+    assert(aws_cryptosdk_keyring_trace_is_valid(keyring_trace));
+    assert(aws_cryptosdk_edk_list_is_valid(edks));
+    assert(aws_cryptosdk_edk_list_elements_are_valid(edks));
+    assert((enc_ctx == NULL) || aws_hash_table_is_valid(enc_ctx));
+
+    if (unencrypted_data_key->buffer == NULL) {
+        const struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg);
+        if (props != NULL) {
+            __CPROVER_assume(aws_byte_buf_is_bounded(unencrypted_data_key, props->data_key_len));
+            ensure_byte_buf_has_allocated_buffer_member(unencrypted_data_key);
+            /*
+             * This satisfies the post-condition that if data key was decrypted,
+             * its length must agree with algorithm specification.
+             * The nondeterminism increases coverage.
+             */
+            if (nondet_bool()) unencrypted_data_key->len = props->data_key_len;
+            unencrypted_data_key->allocator = request_alloc;
+            __CPROVER_assume(aws_byte_buf_is_valid(unencrypted_data_key));
+        }
+    }
+    int ret;
+    return ret;
+}
+
+void aws_cryptosdk_keyring_on_decrypt_harness() {
+    /* Non-deterministic inputs. */
+    const struct aws_cryptosdk_keyring_vt vtable = { .vt_size    = sizeof(struct aws_cryptosdk_keyring_vt),
+                                                     .name       = ensure_c_str_is_allocated(SIZE_MAX),
+                                                     .destroy    = nondet_voidp(),
+                                                     .on_encrypt = nondet_voidp(),
+                                                     .on_decrypt = nondet_bool() ? NULL : on_decrypt };
+    struct aws_cryptosdk_keyring keyring;
+    ensure_cryptosdk_keyring_has_allocated_members(&keyring, &vtable);
+    __CPROVER_assume(aws_cryptosdk_keyring_is_valid(&keyring));
+    __CPROVER_assume(keyring.vtable != NULL);
+
+    struct aws_allocator *request_alloc = can_fail_allocator();
+    __CPROVER_assume(aws_allocator_is_valid(request_alloc));
+
+    struct aws_array_list keyring_trace;
+    __CPROVER_assume(
+        aws_array_list_is_bounded(&keyring_trace, MAX_ITEM_SIZE, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+    __CPROVER_assume(keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&keyring_trace);
+    __CPROVER_assume(aws_array_list_is_valid(&keyring_trace));
+    ensure_trace_has_allocated_records(&keyring_trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&keyring_trace));
+
+    struct aws_byte_buf unencrypted_data_key;
+    if (nondet_bool()) {
+        /* The caller could send an empty unencrypted_data_key. */
+        unencrypted_data_key.buffer = NULL;
+    } else {
+        ensure_byte_buf_has_allocated_buffer_member(&unencrypted_data_key);
+    }
+    __CPROVER_assume(aws_byte_buf_is_valid(&unencrypted_data_key));
+
+    struct aws_array_list edks;
+    __CPROVER_assume(aws_cryptosdk_edk_list_is_bounded(&edks, NUM_ELEMS));
+    ensure_cryptosdk_edk_list_has_allocated_list(&edks);
+    __CPROVER_assume(aws_cryptosdk_edk_list_is_valid(&edks));
+    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_bounded(&edks, SIZE_MAX));
+    ensure_cryptosdk_edk_list_has_allocated_list_elements(&edks);
+    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_valid(&edks));
+
+    struct aws_hash_table *enc_ctx = can_fail_malloc(sizeof(*enc_ctx));
+    if (enc_ctx != NULL) {
+        ensure_allocated_hash_table(enc_ctx, MAX_TABLE_SIZE);
+        __CPROVER_assume(aws_hash_table_is_valid(enc_ctx));
+        ensure_hash_table_has_valid_destroy_functions(enc_ctx);
+        size_t empty_slot_idx;
+        __CPROVER_assume(aws_hash_table_has_an_empty_slot(enc_ctx, &empty_slot_idx));
+    }
+
+    enum aws_cryptosdk_alg_id alg;
+
+    /* Operation under verification. */
+    if (aws_cryptosdk_keyring_on_decrypt(
+            &keyring, request_alloc, &unencrypted_data_key, &keyring_trace, &edks, enc_ctx, alg) == AWS_OP_SUCCESS) {
+        assert(aws_byte_buf_is_valid(&unencrypted_data_key));
+    }
+
+    /* Post-conditions. */
+    assert(aws_cryptosdk_keyring_is_valid(&keyring));
+    assert(aws_allocator_is_valid(request_alloc));
+    assert(aws_cryptosdk_keyring_trace_is_valid(&keyring_trace));
+    assert(aws_cryptosdk_edk_list_is_valid(&edks));
+    assert(aws_cryptosdk_edk_list_elements_are_valid(&edks));
+    if (enc_ctx != NULL) assert(aws_hash_table_is_valid(enc_ctx));
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_decrypt/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_decrypt/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;memcmp.0:33,aws_cryptosdk_keyring_trace_is_valid.0:3,ensure_trace_has_allocated_records.0:3,aws_cryptosdk_edk_list_elements_are_bounded.0:2,aws_cryptosdk_edk_list_elements_are_valid.0:2,aws_cryptosdk_edk_list_is_bounded.0:2,aws_cryptosdk_edk_list_is_valid.0:2,ensure_cryptosdk_edk_list_has_allocated_list_elements.0:2,ensure_cryptosdk_edk_list_has_allocated_members.0:2;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_keyring_on_decrypt_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/stubs/aws_atomic_load_ptr.c
+++ b/.cbmc-batch/stubs/aws_atomic_load_ptr.c
@@ -16,9 +16,9 @@
 #include <aws/common/atomics.h>
 
 /*
- * For sequential proofs, we directly access the atomic value,
+ * For sequential proofs, it reads an atomic var as a pointer and returns the result,
  * so we can correctly propagate it through CBMC assumptions.
  */
-size_t aws_atomic_load_int(const struct aws_atomic_var *var) {
-    return *((size_t *)(var->value));
+void *aws_atomic_load_ptr(const struct aws_atomic_var *var) {
+    return (var->value);
 }

--- a/source/materials.c
+++ b/source/materials.c
@@ -141,6 +141,12 @@ int aws_cryptosdk_keyring_on_decrypt(
     const struct aws_array_list *edks,
     const struct aws_hash_table *enc_ctx,
     enum aws_cryptosdk_alg_id alg) {
+    AWS_PRECONDITION(aws_allocator_is_valid(request_alloc));
+    AWS_PRECONDITION(aws_cryptosdk_keyring_is_valid(keyring) && (keyring->vtable != NULL));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(unencrypted_data_key));
+    AWS_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(keyring_trace));
+    AWS_PRECONDITION(aws_cryptosdk_edk_list_is_valid(edks));
+
     /* Precondition: data key buffer must be unset. */
     if (unencrypted_data_key->buffer) return aws_raise_error(AWS_CRYPTOSDK_ERR_BAD_STATE);
     AWS_CRYPTOSDK_PRIVATE_VF_CALL(
@@ -152,7 +158,8 @@ int aws_cryptosdk_keyring_on_decrypt(
      */
     if (unencrypted_data_key->buffer) {
         const struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg);
-        if (unencrypted_data_key->len != props->data_key_len) return aws_raise_error(AWS_CRYPTOSDK_ERR_BAD_CIPHERTEXT);
+        if (props == NULL || unencrypted_data_key->len != props->data_key_len)
+            return aws_raise_error(AWS_CRYPTOSDK_ERR_BAD_CIPHERTEXT);
     }
     return ret;
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

This pull request depends on [PR #531](https://github.com/aws/aws-encryption-sdk-c/pull/531).

*Issue #, if available:*
N/A.

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_keyring_on_decrypt` function;
- Adds preconditions in `aws_cryptosdk_keyring_on_decrypt` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

