### PR TITLE
Adds a proof harness for aws_cryptosdk_hash_elems_array_init

### DIFF
--- a/.cbmc-batch/jobs/Makefile.aws_hash_table
+++ b/.cbmc-batch/jobs/Makefile.aws_hash_table
@@ -1,0 +1,22 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file was copied over from AWS C Common.
+# https://github.com/aws/aws-encryption-sdk-c/issues/535
+
+MAX_TABLE_SIZE ?= 4
+
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
+
+#A table has 10 words for the struct, plus 3 words for each entry
+TABLE_SIZE_IN_WORDS=$(shell echo $$(($$((3 * $(MAX_TABLE_SIZE))) + 10)))

--- a/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/Makefile
@@ -1,0 +1,43 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_hash_table
+
+# Expected runtime for this harness is 2min
+
+ABSTRACTIONS += $(SRCDIR)/helper-stubs/aws_hash_iter_overrides.c
+
+ABSTRACTIONS += $(LINKFARM)/helper-stubs/aws_add_size_checked.c
+REMOVE_FUNCTION_BODY += --remove-function-body aws_add_size_checked
+
+CBMCFLAGS +=
+
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/math.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/array_list.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/utils.c
+DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
+
+ENTRY = aws_cryptosdk_hash_elems_array_init_harness
+
+UNWINDSET += aws_cryptosdk_hash_elems_array_init.0:$(call addone,$(MAX_TABLE_SIZE))
+
+include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/Makefile
@@ -26,13 +26,16 @@ REMOVE_FUNCTION_BODY += --remove-function-body aws_add_size_checked
 
 CBMCFLAGS +=
 
+DEFINES += -DAWS_NO_STATIC_IMPL
+
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/array_list.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/math.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/array_list.c
-DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/utils.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/aws_cryptosdk_hash_elems_array_init_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/aws_cryptosdk_hash_elems_array_init_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/common/hash_table.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <aws/common/string.h>
+
+#include <aws/cryptosdk/private/utils.h>
+
+#include <make_common_data_structures.h>
+
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+
+void aws_cryptosdk_hash_elems_array_init_harness() {
+    /* Non-deterministic inputs. */
+    struct aws_allocator *alloc = nondet_bool() ? NULL : can_fail_allocator();
+    __CPROVER_assume(aws_allocator_is_valid(alloc));
+
+    struct aws_array_list *list = can_fail_malloc(sizeof(*list));
+    __CPROVER_assume(list != NULL);
+
+    struct aws_hash_table *map = can_fail_malloc(sizeof(*map));
+    __CPROVER_assume(map != NULL);
+    ensure_allocated_hash_table(map, MAX_TABLE_SIZE);
+    __CPROVER_assume(aws_hash_table_is_valid(map));
+
+    /* Operation under verification. */
+    if (aws_cryptosdk_hash_elems_array_init(alloc, list, map) == AWS_OP_SUCCESS) {
+        /* Post-conditions. */
+        assert(aws_hash_table_is_valid(map));
+        assert(aws_array_list_is_valid(list));
+    }
+}

--- a/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_hash_elems_array_init.0:5,aws_cryptosdk_hash_elems_array_init_harness.0:5;--object-bits;8"
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_hash_elems_array_init.0:5;--object-bits;8"
 expected: "SUCCESSFUL"
 goto: aws_cryptosdk_hash_elems_array_init_harness.goto
 jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_hash_elems_array_init/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;aws_cryptosdk_hash_elems_array_init.0:5,aws_cryptosdk_hash_elems_array_init_harness.0:5;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_hash_elems_array_init_harness.goto
+jobos: ubuntu16

--- a/.cbmc-batch/stubs/aws_add_size_checked.c
+++ b/.cbmc-batch/stubs/aws_add_size_checked.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/common/math.h>
+#include <proof_helpers/nondet.h>
+
+/**
+ * If a + b overflows, returns AWS_OP_ERR; otherwise adds
+ * a + b, returns the result in *r, and non-deterministically returns either
+ * AWS_OP_SUCCESS or AWS_OP_ERR. This increases coverage even for smaller bounds.
+ */
+int aws_add_size_checked(size_t a, size_t b, size_t *r) {
+    if (__CPROVER_overflow_plus(a, b)) return aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+    *r = a + b;
+    return nondet_bool() ? AWS_OP_SUCCESS : aws_raise_error(AWS_ERROR_OVERFLOW_DETECTED);
+}

--- a/.cbmc-batch/stubs/aws_hash_iter_overrides.c
+++ b/.cbmc-batch/stubs/aws_hash_iter_overrides.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * This file was copied over from AWS C Common.
+ * https://github.com/aws/aws-encryption-sdk-c/issues/535
+ */
+
+#include <aws/common/hash_table.h>
+#include <aws/common/math.h>
+#include <aws/common/private/hash_table_impl.h>
+#include <aws/common/string.h>
+
+#include <limits.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/utils.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* If the consumer of the iterator doesn't use the .element in the iterator, we can just leave it undef
+ * This is sound, as it gives you a totally nondet value every time you call the iterator, and is the default behaviour
+ * of CBMC. But if it is used, we need a way for the harness to specify valid values for the element, for example if
+ * they are copying values out of the table. They can do this by defining
+ * -DHASH_ITER_ELEMENT_GENERATOR=the_generator_fn, where the_generator_fn has signature:
+ *   the_generator_fn(struct aws_hash_iter *new_iter, const struct aws_hash_iter* old_iter).
+ *
+ * [new_iter] is a pointer to the iterator that will be returned from this function, and the generator function can
+ * modify it in any way it sees fit.  In particular, it can update the [new_iter->element] field to be valid for the
+ * type of hash-table being proved.  Two obvious generators are:
+ *   (a) one that simply creates a new non-determinsitic value each time its called using malloc
+ *   (b) one that uses a value stored in the underlying map, and copies it into the iterator.
+ *
+ * [old_iter] is a pointer to the old iterator, in the case of a "aws_hash_iter_next" call, and null in the case of
+ * "aws_hash_iter_begin".
+ */
+#ifdef HASH_ITER_ELEMENT_GENERATOR
+void HASH_ITER_ELEMENT_GENERATOR(struct aws_hash_iter *new_iter, const struct aws_hash_iter *old_iter);
+#endif
+
+/* Simple map for what the iterator does: it just chugs along, returns a nondet value, until its gone at most map->size
+ * times */
+struct aws_hash_iter aws_hash_iter_begin(const struct aws_hash_table *map) {
+    /* Leave it as non-det as possible */
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+
+    /* Build a nondet iterator, set the required fields, and return it */
+    struct aws_hash_iter rval;
+    rval.map    = map;
+    rval.limit  = map->p_impl->entry_count;
+    rval.slot   = 0;
+    rval.status = (rval.slot == rval.limit) ? AWS_HASH_ITER_STATUS_DONE : AWS_HASH_ITER_STATUS_READY_FOR_USE;
+#ifdef HASH_ITER_ELEMENT_GENERATOR
+    HASH_ITER_ELEMENT_GENERATOR(&rval, NULL);
+#endif
+    return rval;
+}
+
+bool aws_hash_iter_done(const struct aws_hash_iter *iter) {
+    AWS_PRECONDITION(
+        iter->status == AWS_HASH_ITER_STATUS_DONE || iter->status == AWS_HASH_ITER_STATUS_READY_FOR_USE,
+        "Input aws_hash_iter [iter] status should either be done or ready to use.");
+    bool rval = iter->slot == iter->limit;
+    assert(rval == (iter->status == AWS_HASH_ITER_STATUS_DONE));
+    return rval;
+}
+
+void aws_hash_iter_next(struct aws_hash_iter *iter) {
+    if (iter->slot == iter->limit) {
+        iter->status = AWS_HASH_ITER_STATUS_DONE;
+        return;
+    }
+
+    /* Build a nondet iterator, set the required fields, and copy it over */
+    struct aws_hash_iter rval;
+    rval.map         = iter->map;
+    rval.limit       = iter->limit;
+    size_t next_step = 1;
+    __CPROVER_assume(next_step > 0 && next_step <= iter->limit - iter->slot);
+    rval.limit  = iter->limit;
+    rval.slot   = iter->slot + next_step;
+    rval.status = (rval.slot == rval.limit) ? AWS_HASH_ITER_STATUS_DONE : AWS_HASH_ITER_STATUS_READY_FOR_USE;
+#ifdef HASH_ITER_ELEMENT_GENERATOR
+    HASH_ITER_ELEMENT_GENERATOR(&rval, iter);
+#endif
+
+    *iter = rval;
+}
+
+/* delete always leaves the element unusable, so we'll just leave the element totally nondet */
+void aws_hash_iter_delete(struct aws_hash_iter *iter, bool destroy_contents) {
+    /* Build a nondet iterator, set the required fields, and copy it over */
+    struct aws_hash_iter rval;
+    rval.map    = iter->map;
+    rval.slot   = iter->slot;
+    rval.limit  = iter->limit - 1;
+    rval.status = AWS_HASH_ITER_STATUS_DELETE_CALLED;
+    *iter       = rval;
+}

--- a/source/utils.c
+++ b/source/utils.c
@@ -27,6 +27,10 @@ int aws_cryptosdk_compare_hash_elems_by_key_string(const void *elem_a, const voi
 
 int aws_cryptosdk_hash_elems_array_init(
     struct aws_allocator *alloc, struct aws_array_list *elems, const struct aws_hash_table *map) {
+    AWS_PRECONDITION(aws_allocator_is_valid(alloc));
+    AWS_PRECONDITION(elems != NULL);
+    AWS_PRECONDITION(aws_hash_table_is_valid(map));
+
     size_t entry_count = aws_hash_table_get_entry_count(map);
     if (aws_array_list_init_dynamic(elems, alloc, entry_count, sizeof(struct aws_hash_element))) {
         return AWS_OP_ERR;
@@ -38,6 +42,7 @@ int aws_cryptosdk_hash_elems_array_init(
             return AWS_OP_ERR;
         }
     }
+
     assert(aws_array_list_length(elems) == entry_count);
     return AWS_OP_SUCCESS;
 }

--- a/source/utils.c
+++ b/source/utils.c
@@ -28,7 +28,7 @@ int aws_cryptosdk_compare_hash_elems_by_key_string(const void *elem_a, const voi
 int aws_cryptosdk_hash_elems_array_init(
     struct aws_allocator *alloc, struct aws_array_list *elems, const struct aws_hash_table *map) {
     AWS_PRECONDITION(aws_allocator_is_valid(alloc));
-    AWS_PRECONDITION(elems != NULL);
+    AWS_PRECONDITION(AWS_OBJECT_PTR_IS_WRITABLE(elems));
     AWS_PRECONDITION(aws_hash_table_is_valid(map));
 
     size_t entry_count = aws_hash_table_get_entry_count(map);


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
It is related to issue https://github.com/aws/aws-encryption-sdk-c/issues/535 (but it does not solve it).

*Description of changes:*
- Adds a proof harness for `aws_cryptosdk_hash_elems_array_init` function;
- Adds preconditions in `aws_cryptosdk_hash_elems_array_init` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

