### PR TITLE
Improves coverage in proof harnesses

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_sign_header/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sign_header/Makefile
@@ -11,7 +11,6 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
 # if Makefile.local exists, use it. This provides a way to override the defaults 
 sinclude ../Makefile.local
 #otherwise, use the default values
@@ -29,7 +28,6 @@ DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
@@ -38,6 +36,10 @@ DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
 
-###########
+# We abstract these functions because manual inspection demonstrates that they are unreachable,
+# which leads to improvements in coverage metrics
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_DecryptUpdate
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha256
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha384
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_sign_header/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_sign_header/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--flush;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--object-bits;8"
 expected: "SUCCESSFUL"
 goto: aws_cryptosdk_sign_header_harness.goto
 jobos: ubuntu16

--- a/.cbmc-batch/jobs/aws_cryptosdk_verify_header/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_verify_header/Makefile
@@ -11,7 +11,6 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
 # if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
@@ -29,7 +28,6 @@ DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
@@ -39,6 +37,7 @@ DEPENDENCIES += $(SRCDIR)/helper-src/openssl/ec_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/err_override.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/evp_override.goto
 
-###########
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha256
+REMOVE_FUNCTION_BODY += --remove-function-body EVP_sha384
 
 include ../Makefile.common

--- a/.cbmc-batch/jobs/aws_cryptosdk_verify_header/aws_cryptosdk_verify_header_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_verify_header/aws_cryptosdk_verify_header_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/.cbmc-batch/jobs/aws_cryptosdk_verify_header/cbmc-batch.yaml
+++ b/.cbmc-batch/jobs/aws_cryptosdk_verify_header/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--flush;--bounds-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_cipher_c_flush_openssl_errors.0:2;--object-bits;8"
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwind;1;--unwinding-assertions;--unwindset;__CPROVER_file_local_cipher_c_flush_openssl_errors.0:2;--object-bits;8"
 expected: "SUCCESSFUL"
 goto: aws_cryptosdk_verify_header_harness.goto
 jobos: ubuntu16


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
There are two proofs with low-coverage results because their Makefile was incomplete. This PR updates the Makefiles (improving coverage).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

