### PR TITLE
Adds precondition to aws_cryptosdk_keyring_on_decrypt

### DIFF
--- a/source/materials.c
+++ b/source/materials.c
@@ -146,6 +146,7 @@ int aws_cryptosdk_keyring_on_decrypt(
     AWS_PRECONDITION(aws_byte_buf_is_valid(unencrypted_data_key));
     AWS_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(keyring_trace));
     AWS_PRECONDITION(aws_cryptosdk_edk_list_is_valid(edks));
+    AWS_PRECONDITION(enc_ctx == NULL || aws_hash_table_is_valid(enc_ctx));
 
     /* Precondition: data key buffer must be unset. */
     if (unencrypted_data_key->buffer) return aws_raise_error(AWS_CRYPTOSDK_ERR_BAD_STATE);


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*
N/A.

*Description of changes:*
`aws_cryptosdk_keyring_on_decrypt` proof was missing one pre-condition to ensure `enc_ctx` is valid.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

