### PR TITLE
Remove OpenSSL from interface includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/noninst_include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated/include>
+    $<BUILD_INTERFACE:${OPENSSL_INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>
-    ${OPENSSL_INCLUDE_DIR}
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PLATFORM_LIBS} ${OPENSSL_CRYPTO_LIBRARY})
@@ -152,7 +152,7 @@ target_include_directories(aws-encryption-sdk-test PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/noninst_include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated/include>
-    ${OPENSSL_INCLUDE_DIR}
+    $<BUILD_INTERFACE:${OPENSSL_INCLUDE_DIR}>
 )
 
 target_link_libraries(aws-encryption-sdk-test PRIVATE ${PLATFORM_LIBS} ${OPENSSL_CRYPTO_LIBRARY})


### PR DESCRIPTION
*Description of changes:*
Currently `${OPENSSL_INCLUDE_DIR}` is a part of install interface, which leaks a local OpenSSL dir used at the build time into `aws-encryption-sdk-targets.cmake`. This makes it impossible to link against SDK build artifacts on a different machine, since CMake doesn't allow non-existent paths in target `INTERFACE_INCLUDE_DIRECTORIES`.

Changed to use the `BUILD_INTERFACE` generator expression. Builds fine locally and unit tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

