### PR TITLE
fix: base64_encode error in examples/caching_cmm.cpp

### DIFF
--- a/examples/caching_cmm.cpp
+++ b/examples/caching_cmm.cpp
@@ -92,24 +92,25 @@ std::string decrypt(
     return std::string(buffer.begin(), buffer.end());
 }
 
-std::string base64_encode(const std::vector<uint8_t> &vec) {
+std::string base64_encode(struct aws_allocator *alloc, const std::vector<uint8_t> &vec) {
     size_t b64_len;
 
     if (aws_base64_compute_encoded_len(vec.size(), &b64_len)) {
         error("aws_base64_compute_encoded_len");
     }
 
-    std::vector<uint8_t> tmp;
-    tmp.resize(b64_len);
-
     struct aws_byte_cursor cursor = aws_byte_cursor_from_array(vec.data(), vec.size());
-    struct aws_byte_buf b64_buf   = aws_byte_buf_from_array(tmp.data(), tmp.size());
+
+    struct aws_byte_buf b64_buf;
+    if (aws_byte_buf_init(&b64_buf, alloc, b64_len)) {
+        error("aws_byte_buf_init");
+    }
 
     if (aws_base64_encode(&cursor, &b64_buf)) {
         error("aws_base64_encode");
     }
 
-    return std::string(tmp.begin(), tmp.end());
+    return std::string(reinterpret_cast<const char *>(b64_buf.buffer), b64_buf.len);
 }
 
 struct aws_cryptosdk_cmm *setup_cmm(struct aws_allocator *alloc, const char *key_arn) {
@@ -167,7 +168,7 @@ int main(int argc, char **argv) {
         std::string str(argv[i]);
 
         std::vector<uint8_t> ciphertext = encrypt(alloc, cmm, str);
-        std::cout << "Ciphertext for string \"" << str << "\":\n" << base64_encode(ciphertext) << "\n\n" << std::flush;
+        std::cout << "Ciphertext for string \"" << str << "\":\n" << base64_encode(alloc, ciphertext) << "\n\n" << std::flush;
         ciphertexts.push_back(std::move(ciphertext));
     }
 


### PR DESCRIPTION
Fixes #550

The example code was invoking `aws_byte_buf_from_array` on the vector's backing array, but this initializer creates a `byte_buf` that is already full (i.e. `len == capacity`), so the encoding logic would think there was `0` capacity left to encode into. The correct initializer is `aws_byte_buf_from_empty_array` which sets `len` to `0` instead and overwrites the array contents when written to.

Cut a separate issue for the fact that the CI is not executing the examples: #552 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

