### PR TITLE
Quick fix to Makefile.common to run cbmc proofs with new c-common structure

### DIFF
--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -149,7 +149,10 @@ common-git:
 	@if [ ! -d $(COMMONDIR) ] ;\
 	then \
 		cd $(BASEDIR); \
-		git clone --quiet --depth 1 https://github.com/awslabs/aws-c-common.git $(COMMON_REPO_NAME); \
+		git clone --quiet --depth 30 https://github.com/awslabs/aws-c-common.git $(COMMON_REPO_NAME); \
+		cd $(COMMON_REPO_NAME); \
+		git reset --hard dd600468fbd25c6f31828010c28056c4d5c3ab35; \
+		cd $(BASEDIR); \
 	else \
 		echo "c-common repo already exists. Nothing to do."; \
 	fi


### PR DESCRIPTION
Quick fix to Makefile.common needed to run the EDSK-C cbmc proofs given that the structure of aws-c-common has changed. 
Instead of using the most recent commit of aws-c-common, reset to the most recent commit before the changes to the directory structure. 
This is not meant to be a permanent fix! Ideally, we would update ESDK-C to use the same submodule as aws-c-common. 
Currently clones all commits to a depth of 30 but this might need to be updated if more commits come in before there is a more permanent fix. 

@danielsn @feliperodri @karkhaz 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



