### PR TITLE
Run CBMC proofs with appropriate AWS C Common version

### DIFF
--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -149,7 +149,10 @@ common-git:
 	@if [ ! -d $(COMMONDIR) ] ;\
 	then \
 		cd $(BASEDIR); \
-		git clone --quiet --depth 1 https://github.com/awslabs/aws-c-common.git $(COMMON_REPO_NAME); \
+		git clone --quiet --depth 30 https://github.com/awslabs/aws-c-common.git $(COMMON_REPO_NAME); \
+    cd $(COMMON_REPO_NAME); \
+    git reset --hard dd600468fbd25c6f31828010c28056c4d5c3ab35; \
+    cd $(BASEDIR); \
 	else \
 		echo "c-common repo already exists. Nothing to do."; \
 	fi


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Issue #, if available:*

N/A.

*Description of changes:*

Updates `Makefile.common` to use an appropriate version of AWS C Common when running CBMC proofs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

