### PR TITLE
Adds documentation for aws_cryptosdk_md_* proof coverage

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_md_finish/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_md_finish/Makefile
@@ -28,8 +28,8 @@ ENTRY = aws_cryptosdk_md_finish_harness
 
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/error.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_md_finish/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_md_finish/README.md
@@ -1,0 +1,18 @@
+# Expected Coverage 
+
+0.91 (73 lines out of 80 statically-reachable lines in 19 functions reached)
+0.70 (73 lines out of 105 statically-reachable lines in 27 statically-reachable functions)
+
+## Expected Functions with Incomplete Coverage 
+
+(4/5) aws_cryptosdk_md_abort: md_context is never NULL
+(4/6) aws_raise_error_private: 
+(2/6) EVP_PKEY_free: pkey field of EVP_MD_CTX is always NULL, therefore there is nothing to free. 
+(0/2) BN_clear_free: function never reached, part of chain originating with EVP_PKEY_free
+(0/2) BN_free: function never reached, part of chain originating with EVP_PKEY_free
+(0/2) bignum_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
+(0/4) EC_GROUP_free: function never reached, part of chain originating with EVP_PKEY_free
+(0/7) EC_KEY_free: function never reached, part of chain originating with EVP_PKEY_free
+(0/3) ec_group_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
+(0/3) ec_key_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
+(0/2) evp_pkey_is_valid: Since pkey is always NULL, this is never called from evp_md_ctx_is_valid. 

--- a/.cbmc-batch/jobs/aws_cryptosdk_md_finish/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_md_finish/README.md
@@ -1,18 +1,44 @@
-# Expected Coverage 
+# Memory safety proof for aws_cryptosdk_md_finish
 
-0.91 (73 lines out of 80 statically-reachable lines in 19 functions reached)
-0.70 (73 lines out of 105 statically-reachable lines in 27 statically-reachable functions)
+This proof harness attains 70% code coverage.  The following comments explain
+why the uncovered lines of code are unreachable code.
 
-## Expected Functions with Incomplete Coverage 
+Some functions contain unreachable blocks of code:
 
-(4/5) aws_cryptosdk_md_abort: md_context is never NULL
-(4/6) aws_raise_error_private: 
-(2/6) EVP_PKEY_free: pkey field of EVP_MD_CTX is always NULL, therefore there is nothing to free. 
-(0/2) BN_clear_free: function never reached, part of chain originating with EVP_PKEY_free
-(0/2) BN_free: function never reached, part of chain originating with EVP_PKEY_free
-(0/2) bignum_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
-(0/4) EC_GROUP_free: function never reached, part of chain originating with EVP_PKEY_free
-(0/7) EC_KEY_free: function never reached, part of chain originating with EVP_PKEY_free
-(0/3) ec_group_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
-(0/3) ec_key_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
-(0/2) evp_pkey_is_valid: Since pkey is always NULL, this is never called from evp_md_ctx_is_valid. 
+* `aws_cryptosdk_md_abort`:
+
+    * md_context is never NULL
+
+* `EVP_PKEY_free`:
+
+    * pkey field of EVP_MD_CTX is always NULL, therefore there is nothing to free
+
+Some functions are simply unreachable:
+
+* `BN_clear_free`
+
+    * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
+
+* `bignum_is_valid`
+
+    * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid
+
+* `EC_GROUP_free`
+
+    * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
+
+* `EC_KEY_free`
+
+    * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
+
+* `ec_group_is_valid`
+
+    * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid
+
+* `ec_key_is_valid`
+
+    * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid
+
+* `evp_pkey_is_valid`
+
+    * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid

--- a/.cbmc-batch/jobs/aws_cryptosdk_md_finish/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_md_finish/README.md
@@ -19,6 +19,10 @@ Some functions are simply unreachable:
 
     * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
 
+* `BN_free`
+
+    * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
+
 * `bignum_is_valid`
 
     * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid

--- a/.cbmc-batch/jobs/aws_cryptosdk_md_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_md_init/Makefile
@@ -27,8 +27,8 @@ CBMCFLAGS += --memory-leak-check
 ENTRY = aws_cryptosdk_md_init_harness
 
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/error.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
-DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/cipher_openssl.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/cbmc_invariants.goto
 DEPENDENCIES += $(SRCDIR)/helper-src/openssl/bn_override.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_md_init/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_md_init/README.md
@@ -1,17 +1,40 @@
-# Expected Coverage 
+# Memory safety proof for aws_cryptosdk_md_init
 
-0.93 (83 lines out of 89 statically-reachable lines in 18 functions reached)
-0.73 (83 lines out of 114 statically-reachable lines in 26 statically-reachable functions)
+This proof harness attains 74% code coverage.  The following comments explain
+why the uncovered lines of code are unreachable code.
 
-## Expected Functions with Incomplete Coverage 
+Some functions contain unreachable blocks of code:
 
-(4/6) aws_raise_error_private:
-(2/6) EVP_PKEY_free: pkey field of EVP_MD_CTX is always NULL, therefore there is nothing to free. 
-(0/2) BN_clear_free: function never reached, part of chain originating with EVP_PKEY_free
-(0/2) BN_free: function never reached, part of chain originating with EVP_PKEY_free
-(0/2) bignum_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
-(0/4) EC_GROUP_free: function never reached, part of chain originating with EVP_PKEY_free
-(0/7) EC_KEY_free: function never reached, part of chain originating with EVP_PKEY_free
-(0/3) ec_group_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
-(0/3) ec_key_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
-(0/2) evp_pkey_is_valid: Since pkey is always NULL, this is never called from evp_md_ctx_is_valid. 
+* `EVP_PKEY_free`:
+
+    * pkey field of EVP_MD_CTX is always NULL, therefore there is nothing to free. 
+
+Some functions are simply unreachable:
+
+* `BN_clear_free`
+
+    * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
+
+* `bignum_is_valid`
+
+    * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid
+
+* `EC_GROUP_free`
+
+    * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
+
+* `EC_KEY_free`
+
+    * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
+
+* `ec_group_is_valid`
+
+    * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid
+
+* `ec_key_is_valid`
+
+    * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid
+
+* `evp_pkey_is_valid`
+
+    * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid

--- a/.cbmc-batch/jobs/aws_cryptosdk_md_init/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_md_init/README.md
@@ -15,6 +15,10 @@ Some functions are simply unreachable:
 
     * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
 
+* `BN_free`
+
+    * Only function call is from a chain starting at the unreachable block of EVP_PKEY_free
+
 * `bignum_is_valid`
 
     * Only function call is from a chain starting at an unreachable condition in evp_md_ctx_is_valid

--- a/.cbmc-batch/jobs/aws_cryptosdk_md_init/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_md_init/README.md
@@ -1,0 +1,17 @@
+# Expected Coverage 
+
+0.93 (83 lines out of 89 statically-reachable lines in 18 functions reached)
+0.73 (83 lines out of 114 statically-reachable lines in 26 statically-reachable functions)
+
+## Expected Functions with Incomplete Coverage 
+
+(4/6) aws_raise_error_private:
+(2/6) EVP_PKEY_free: pkey field of EVP_MD_CTX is always NULL, therefore there is nothing to free. 
+(0/2) BN_clear_free: function never reached, part of chain originating with EVP_PKEY_free
+(0/2) BN_free: function never reached, part of chain originating with EVP_PKEY_free
+(0/2) bignum_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
+(0/4) EC_GROUP_free: function never reached, part of chain originating with EVP_PKEY_free
+(0/7) EC_KEY_free: function never reached, part of chain originating with EVP_PKEY_free
+(0/3) ec_group_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
+(0/3) ec_key_is_valid: function never called, part of chain originating with evp_md_ctx_is_valid. 
+(0/2) evp_pkey_is_valid: Since pkey is always NULL, this is never called from evp_md_ctx_is_valid. 

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -161,10 +161,7 @@ int aws_cryptosdk_md_finish(struct aws_cryptosdk_md_context *md_context, void *o
     int rv            = AWS_OP_SUCCESS;
     unsigned int size = 0;
 
-    // Replace with AWS_FATAL_PRECONDITION once that version is integrated
-    if (!output_buf) {
-        abort();
-    }
+    AWS_FATAL_PRECONDITION(output_buf != NULL);
 
     if (1 != EVP_DigestFinal_ex(md_context->evp_md_ctx, output_buf, &size)) {
         rv   = aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);


### PR DESCRIPTION
Description of changes:
Addresses the low coverage of the aws_cryptosdk_md_init and aws_cryptosdk_md_finish proofs.
Includes a README for both the aws_cryptosdk_md_init and aws_cryptosdk_md_finish proofs specifying expected coverage behavior.
Uses AWS_FATAL_PRECONDITION instead of abort(). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

