### PR TITLE
Add aws-encryption-sdk-test-vectors as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "aws-encryption-sdk-cpp/tests/test_vectors/aws-encryption-sdk-test-vectors"]
+	path = aws-encryption-sdk-cpp/tests/test_vectors/aws-encryption-sdk-test-vectors
+	url = https://github.com/awslabs/aws-encryption-sdk-test-vectors.git


### PR DESCRIPTION
Fixes #225 

TODO: script to unzip the vectors and run test_vectors, which should then be added to CI (#414)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

