### PR TITLE
Improves coverage for the aws_cryptosdk_enc_ctx_clone proof

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/Makefile
@@ -29,6 +29,7 @@ ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_string_destroy_override.c
 ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/aws_string_new_from_array_override.c
 ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/error.c
 ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/hash_table_generators.c
+ABSTRACTIONS += $(SRCDIR)/c-common-helper-stubs/memcmp_override_no_op.c
 
 CBMCFLAGS +=
 
@@ -42,6 +43,7 @@ DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/math.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/string.c
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
 
 ENTRY = aws_cryptosdk_enc_ctx_clone_harness

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/README.md
@@ -1,0 +1,18 @@
+# Memory safety proof for aws_cryptosdk_enc_ctx_clone
+
+This proof harness attains 95% code coverage.  The following comments explain
+why the uncovered lines of code are unreachable code.
+
+Some functions contain unreachable blocks of code:
+
+* `aws_hash_table_put`
+
+    * Edge cases never reached. was_created is always false and we never try and put an item in a full table
+
+* `aws_string_eq`
+
+    *  a !=b and neither a nor b are even NULL
+
+* `aws_hash_iter_is_valid`
+
+    *  Data structure invariants always hold

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/README.md
@@ -1,13 +1,18 @@
 # Memory safety proof for aws_cryptosdk_enc_ctx_clone
 
 This proof harness attains 95% code coverage.  The following comments explain
-why the uncovered lines of code are unreachable code.
+why the uncovered lines of code are unreachable code, instrinsic to the function. 
+This proof assumes the representation of a hash_table given in aws_hash_table_no_slots_override.c 
+(a hash-table that is not backed by any actual memory. It just takes non-det actions when given inputs). 
+Otherwise the only assumption in the harness is for valid hash tables.
 
 Some functions contain unreachable blocks of code:
 
 * `aws_hash_table_put`
 
-    * Edge cases never reached. was_created is always false and we never try and put an item in a full table
+    * Edge cases never reached. 
+    * was_created is always false, as hardcoded in the function aws_cryptosdk_enc_ctx_clone 
+    * The MAX_NUM_ELEMS in a table is 4 as defined in the Makefile, meaning no overflow is possible. 
 
 * `aws_string_eq`
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_clone/README.md
@@ -16,8 +16,14 @@ Some functions contain unreachable blocks of code:
 
 * `aws_string_eq`
 
-    *  a !=b and neither a nor b are even NULL
+    * a !=b and neither a nor b are even NULL
+    * dest_elem->value!=iter.element.value by construction in aws_cryptosdk_enc_ctx_clone
+    * A NULL check on dest_elem precedes the call to this function 
+    * iter.element.value is not NULL by construction of loop
+
 
 * `aws_hash_iter_is_valid`
 
-    *  Data structure invariants always hold
+    * Data structure invariants always hold
+    * iter is never NULL by construction 
+    * A precondition on iter->map ensures it is always a valid hash table


### PR DESCRIPTION
Description of changes:
Addresses the unexpected missing function in the aws_cryptosdk_enc_ctx_clone proof. 
Includes a README for the aws_cryptosdk_enc_ctx_clone proof specifying expected coverage behavior.
Adds the dependency for aws_string_eq to the Makefile. 
Adds a stub for the resulting call to memcmp. 

Coverage for aws_cryptosdk_enc_ctx_clone remains at .95. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@danielsn @feliperodri 

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

