### PR TITLE
Improves coverage for the aws_cryptosdk_enc_ctx_serialize proof

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/Makefile
@@ -34,22 +34,22 @@ ABSTRACTIONS += $(SRCDIR)/helper-stubs/aws_array_list_sort_noop_stub.c
 ABSTRACTIONS += $(SRCDIR)/helper-stubs/aws_cryptosdk_enc_ctx_size_stub.c
 ABSTRACTIONS += $(SRCDIR)/helper-stubs/aws_cryptosdk_hash_elems_array_init_stub.c
 
-#Remove function bodies to deal with CBMC function pointer removal
-ADDITIONAL_REMOVE_FUNCTION_BODY += --remove-function-body aws_array_list_sort
-ADDITIONAL_REMOVE_FUNCTION_BODY += --remove-function-body aws_byte_buf_write
-ADDITIONAL_REMOVE_FUNCTION_BODY += --remove-function-body aws_cryptosdk_enc_ctx_size
-ADDITIONAL_REMOVE_FUNCTION_BODY += --remove-function-body aws_cryptosdk_hash_elems_array_init
-
 CBMCFLAGS +=
 
 DEFINES += -DAWS_CRYPTOSDK_HASH_ELEMS_ARRAY_INIT_GENERATOR=array_list_item_generator
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
 DEFINES += -DMEMCPY_STUB_MAX=128
+DEFINES += -DAWS_NO_STATIC_IMPL
 
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/array_list.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/byte_order.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/math.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/string.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
@@ -59,6 +59,11 @@ DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
 
 ENTRY = aws_cryptosdk_enc_ctx_serialize_harness
 
+#Remove function bodies to deal with CBMC function pointer removal
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_array_list_sort
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_byte_buf_write
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_cryptosdk_enc_ctx_size
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_cryptosdk_hash_elems_array_init
 
 UNWINDSET += array_list_item_generator.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
 UNWINDSET += aws_cryptosdk_enc_ctx_serialize.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/README.md
@@ -1,0 +1,38 @@
+# Memory safety proof for aws_cryptosdk_enc_ctx_serialize
+
+This proof harness attains 95% code coverage.  The following comments explain
+why the uncovered lines of code are unreachable code.
+
+Some functions contain unreachable blocks of code:
+
+* `aws_cryptosdk_enc_ctx_serialize`
+
+    * aws_array_list_get_at_ptr is never given an invalid index
+
+* `hash_table_state_is_valid`
+
+    *  map is never NULL
+
+* `aws_array_list_is_valid`
+
+    *  list is never NULL
+
+* `aws_byte_buf_write_from_whole_string`
+
+    *  Neither buf nor src are even NULL
+
+* `aws_add_u64_checked`
+
+    *  Overflow never occurs 
+
+* `aws_mul_u64_checked`
+
+    *  Overflow never occurs 
+
+* `aws_array_list_get_at_ptr`
+
+    *  Index is always valid
+
+* `hash_table_state_required_bytes`
+
+    *  Overflow never occurs

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/README.md
@@ -7,32 +7,34 @@ Some functions contain unreachable blocks of code:
 
 * `aws_cryptosdk_enc_ctx_serialize`
 
-    * aws_array_list_get_at_ptr is never given an invalid index
+    * idx is always less than num_elems, so aws_array_list_get_at_ptr is never given an invalid index
 
 * `hash_table_state_is_valid`
 
-    *  map is never NULL
+    *  map is never NULL as ensured by precondition that enc_ctx is valid hash table  
 
 * `aws_array_list_is_valid`
 
-    *  list is never NULL
+    *  list is never NULL, as ensured by precondition when array list is initialized 
 
 * `aws_byte_buf_write_from_whole_string`
 
     *  Neither buf nor src are ever NULL
+    *  Precondition on the output parameter of aws_cryptosdk_enc_ctx_serialize ensures that buf is never NULL
+    *  The generator array_list_item_generator ensures that src is never NULL (see comment of aws_cryptosdk_hash_elems_array_init_stub.c)
 
 * `aws_add_u64_checked`
 
-    *  Overflow never occurs 
+    *  Overflow never occurs as ensured by precondition in ensure_allocated_hash_table
 
 * `aws_mul_u64_checked`
 
-    *  Overflow never occurs 
+    *  Overflow never occurs as ensured by precondition in ensure_allocated_hash_table
 
 * `aws_array_list_get_at_ptr`
 
-    *  Index is always valid
+    *  idx is always less than num_elems, so no AWS_ERROR_INVALID_INDEX is raised
 
 * `hash_table_state_required_bytes`
 
-    *  Overflow never occurs
+    *  Overflow never occurs as ensured by precondition in ensure_allocated_hash_table

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_serialize/README.md
@@ -1,7 +1,7 @@
 # Memory safety proof for aws_cryptosdk_enc_ctx_serialize
 
 This proof harness attains 95% code coverage.  The following comments explain
-why the uncovered lines of code are unreachable code.
+why the uncovered lines of code are unreachable code, instrinsic to the function.
 
 Some functions contain unreachable blocks of code:
 
@@ -19,7 +19,7 @@ Some functions contain unreachable blocks of code:
 
 * `aws_byte_buf_write_from_whole_string`
 
-    *  Neither buf nor src are even NULL
+    *  Neither buf nor src are ever NULL
 
 * `aws_add_u64_checked`
 


### PR DESCRIPTION
Description of changes:
Addresses the unexpected missing function in the aws_cryptosdk_enc_ctx_serialize proof.
Includes a README for the aws_cryptosdk_enc_ctx_serialize proof specifying expected coverage behavior.
Adds the '-DAWS_NO_STATIC_IMPL'  flag and .inl dependencies to the Makefile so that the stub for aws_array_list_sort can be used. 

Coverage for aws_cryptosdk_enc_ctx_serialize remains at .95.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@danielsn @feliperodri 
# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

