### PR TITLE
Improves coverage for the aws_cryptosdk_enc_ctx_init proof 

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/Makefile
@@ -22,8 +22,10 @@ include ../Makefile.local_default
 ENTRY = aws_cryptosdk_enc_ctx_init_harness
 
 DEPENDENCIES += $(SRCDIR)/c-enc-sdk-src/enc_ctx.c
-DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/error.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/hash_table.c
+DEPENDENCIES += $(SRCDIR)/c-common-src/math.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.c
 
 ###########

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/README.md
@@ -7,7 +7,7 @@ Some functions contain unreachable blocks of code:
 
 * `aws_hash_table_init`
 
-    * s_update_template_size never returns an error due to choice of initial_size in aws_cryptosdk_enc_ctx_init
+    * s_update_template_size never returns an error due to choice of initial_size (10) in aws_cryptosdk_enc_ctx_init
 
 * `hash_table_state_is_valid`
 
@@ -19,16 +19,16 @@ Some functions contain unreachable blocks of code:
 
 * `aws_round_up_to_power_of_two`
 
-    *  n is always != 0 and <= SIZE_MAX_POWER_OF_TWO  due to choice of initial_size in aws_cryptosdk_enc_ctx_init
+    *  n is always != 0 and <= SIZE_MAX_POWER_OF_TWO  due to choice of initial_size (10) in aws_cryptosdk_enc_ctx_init
 
 * `aws_add_u64_checked`
 
-    *  Overflow never occurs 
+    *  Overflow never occurs adding initial size (10) to sizeof(struct hash_table_entry)
 
 * `aws_mul_u64_checked`
 
-    *  Overflow never occurs 
+    *  Overflow never occurs when multiplying initial size (10) by sizeof(struct hash_table_entry)
 
 * `hash_table_state_required_bytes`
 
-    *  Overflow never occurs when computing total number of bytes needed for a hash-table with "initial_size" slots. hash_table_state_required_bytes
+    *  Overflow never occurs when computing total number of bytes needed for a hash-table with "initial_size" slots. 

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/README.md
@@ -1,17 +1,17 @@
 # Memory safety proof for aws_cryptosdk_enc_ctx_init
 
 This proof harness attains 91% code coverage.  The following comments explain
-why the uncovered lines of code are unreachable code.
+why the uncovered lines of code are unreachable code, instrinsic to the function.
 
 Some functions contain unreachable blocks of code:
 
 * `aws_hash_table_init`
 
-    * s_update_template_size never returns an error
+    * s_update_template_size never returns an error due to choice of initial_size in aws_cryptosdk_enc_ctx_init
 
 * `hash_table_state_is_valid`
 
-    *  map is never NULL
+    *  map is never NULL, as ensured by precondition in source code. 
 
 * `aws_mem_calloc`
 
@@ -19,7 +19,7 @@ Some functions contain unreachable blocks of code:
 
 * `aws_round_up_to_power_of_two`
 
-    *  n is always != 0 and <= SIZE_MAX_POWER_OF_TWO 
+    *  n is always != 0 and <= SIZE_MAX_POWER_OF_TWO  due to choice of initial_size in aws_cryptosdk_enc_ctx_init
 
 * `aws_add_u64_checked`
 
@@ -31,4 +31,4 @@ Some functions contain unreachable blocks of code:
 
 * `hash_table_state_required_bytes`
 
-    *  Overflow never occurs
+    *  Overflow never occurs when computing total number of bytes needed for a hash-table with "initial_size" slots. hash_table_state_required_bytes

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/README.md
@@ -1,0 +1,34 @@
+# Memory safety proof for aws_cryptosdk_enc_ctx_init
+
+This proof harness attains 91% code coverage.  The following comments explain
+why the uncovered lines of code are unreachable code.
+
+Some functions contain unreachable blocks of code:
+
+* `aws_hash_table_init`
+
+    * s_update_template_size never returns an error
+
+* `hash_table_state_is_valid`
+
+    *  map is never NULL
+
+* `aws_mem_calloc`
+
+    *  Defensive overflow check always passes 
+
+* `aws_round_up_to_power_of_two`
+
+    *  n is always != 0 and <= SIZE_MAX_POWER_OF_TWO 
+
+* `aws_add_u64_checked`
+
+    *  Overflow never occurs 
+
+* `aws_mul_u64_checked`
+
+    *  Overflow never occurs 
+
+* `hash_table_state_required_bytes`
+
+    *  Overflow never occurs

--- a/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/aws_cryptosdk_enc_ctx_init_harness.c
+++ b/.cbmc-batch/jobs/aws_cryptosdk_enc_ctx_init/aws_cryptosdk_enc_ctx_init_harness.c
@@ -16,8 +16,7 @@
 #include <aws/cryptosdk/enc_ctx.h>
 #include <proof_helpers/proof_allocators.h>
 
-// This is a memory safety proof for aws_cryptosdk_multi_keyring() defined in
-// https://github.com/aws/aws-encryption-sdk-c/blob/master/source/multi_keyring.c
+// This is a memory safety proof for aws_cryptosdk_enc_ctx_init
 void aws_cryptosdk_enc_ctx_init_harness() {
     struct aws_allocator *alloc = can_fail_allocator();
     struct aws_hash_table enc_ctx;


### PR DESCRIPTION
Description of changes:
Addresses the unexpected missing function in the aws_cryptosdk_enc_ctx_init proof.
Includes a README for the aws_cryptosdk_enc_ctx_init proof specifying expected coverage behavior.
Adds missing dependencies tot he Makefile. 

Coverage for aws_cryptosdk_enc_ctx_init improves from .89 to .91. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@danielsn @feliperodri 

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

