### PR TITLE
Adds documentation for aws_cryptosdk_cmm_base_init proof coverage

### DIFF
--- a/.cbmc-batch/jobs/aws_cryptosdk_cmm_base_init/README.md
+++ b/.cbmc-batch/jobs/aws_cryptosdk_cmm_base_init/README.md
@@ -1,0 +1,16 @@
+# Memory safety proof for aws_cryptosdk_cmm_base_init
+
+This proof harness attains 86% code coverage.  The following comments explain
+why the uncovered lines of code are unreachable code.
+
+Some functions contain unreachable blocks of code:
+
+* `aws_atomic_priv_xlate_order`
+
+    * aws_memory_order order is always aws_memory_order_seq_cst
+
+Some functions are simply unreachable:
+
+* `abort`
+
+    * Memory order is never unknown, therefore only call to abort is not reached


### PR DESCRIPTION
Description of changes:
Addresses the low coverage of the aws_cryptosdk_cmm_base_init proof.
Includes a README for the aws_cryptosdk_cmm_base_init proof specifying expected coverage behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

@danielsn @feliperodri 

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

