### PR TITLE
Update Makefile.common to use --export-file-local-symbols 

### DIFF
--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -198,7 +198,7 @@ setup_dependencies: fill-linkfarm
 # the user must run make clean first.
 $(ENTRY)0.goto: setup_dependencies $(ENTRY).c $(DEPENDENT_GOTOS)
 	$(GOTO_CC) $(ENTRY).c $(DEPENDENT_GOTOS) \
-	  --export-function-local-symbols $(CBMC_VERBOSITY) \
+	  --export-file-local-symbols $(CBMC_VERBOSITY) \
 	  --function $(ENTRY) $(DEPENDENT_GOTOS) $(INC) $(DEFINES) -o $@ \
 	  2>&1 | tee $(ENTRY)1.log ; exit $${PIPESTATUS[0]}
 
@@ -275,7 +275,7 @@ $(ENTRY).goto: $(ENTRY)7.goto
 # Catch-all used for building goto-binaries of the individual
 # dependencies, which are then linked in the $(ENTRY)0.goto rule above
 %.goto: %.c
-	$(GOTO_CC) -c $< --export-function-local-symbols $(CBMC_VERBOSITY) \
+	$(GOTO_CC) -c $< --export-file-local-symbols $(CBMC_VERBOSITY) \
 	  $(INC) $(DEFINES) -o $@ \
 	  2>&1 | tee $(dir $<)/$(notdir $<).log ; exit $${PIPESTATUS[0]}
 


### PR DESCRIPTION
*Description of changes:*

Updates Makefile.common to use the --export-file-local-symbols flag instead of the older, misleadingly named --export-function-local-symbols flag. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

