### PR TITLE
Upgrade aws-sdk-cpp (+aws-c-common, transitively)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Now skip to the "Mac: Build and install the AWS Encryption SDK for C" section be
 
 Build and install aws-c-common:
 
-    git clone -b v0.3.15 https://github.com/awslabs/aws-c-common.git
+    git clone -b v0.4.42 https://github.com/awslabs/aws-c-common.git
     mkdir build-aws-c-common && cd build-aws-c-common
     cmake -G Xcode -DBUILD_SHARED_LIBS=ON ../aws-c-common
     xcodebuild -target install ; cd ..

--- a/codebuild/bin/install-aws-deps.sh
+++ b/codebuild/bin/install-aws-deps.sh
@@ -62,5 +62,5 @@ for libtype in shared static; do
     root=/deps/$libtype
 
     # not installing aws-c-common anymore because aws-sdk-cpp installs it for us
-    build_pkg $root/install https://github.com/aws/aws-sdk-cpp.git 1.7.163 $CMAKE_ARGS -DBUILD_ONLY=kms -DENABLE_UNITY_BUILD=ON
+    build_pkg $root/install https://github.com/aws/aws-sdk-cpp.git 1.8.32 $CMAKE_ARGS -DBUILD_ONLY=kms -DBUILD_DEPS=OFF
 done

--- a/codebuild/bin/install-aws-deps.sh
+++ b/codebuild/bin/install-aws-deps.sh
@@ -62,5 +62,5 @@ for libtype in shared static; do
     root=/deps/$libtype
 
     # not installing aws-c-common anymore because aws-sdk-cpp installs it for us
-    build_pkg $root/install https://github.com/aws/aws-sdk-cpp.git 1.8.32 $CMAKE_ARGS -DBUILD_ONLY=kms -DBUILD_DEPS=OFF
+    build_pkg $root/install https://github.com/aws/aws-sdk-cpp.git 1.8.32 $CMAKE_ARGS -DBUILD_ONLY=kms
 done

--- a/codebuild/ubuntu-latest-x64.Dockerfile
+++ b/codebuild/ubuntu-latest-x64.Dockerfile
@@ -14,7 +14,7 @@
 FROM ubuntu:latest
 
 # Needed for setup-apt-cache.sh
-ADD https://mirrors.kernel.org/ubuntu/pool/main/n/net-tools/net-tools_1.60+git20161116.90da8a0-2ubuntu1_amd64.deb /tmp
+ADD https://mirrors.kernel.org/ubuntu/pool/main/n/net-tools/net-tools_1.60+git20180626.aebd88e-1ubuntu1_amd64.deb /tmp
 ADD https://mirrors.kernel.org/ubuntu/pool/universe/n/netcat/netcat-traditional_1.10-40_amd64.deb /tmp
 RUN dpkg -i /tmp/net-tools_*.deb /tmp/netcat-*.deb
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Upgrade aws-sdk-cpp dependency to 1.8.32 (released 2020 August), which transitively [upgrades aws-c-common to v0.4.42](https://github.com/aws/aws-sdk-cpp/blob/1.8.32/third-party/CMakeLists.txt).

The `-DENABLE_UNITY_BUILD=ON` is no longer specified since it is on by default [as of aws-sdk-cpp 1.8.0](https://github.com/aws/aws-sdk-cpp/wiki/What%E2%80%99s-New-in-AWS-SDK-for-CPP-Version-1.8#turn-on-enable_unity_build--by-default).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

