### PR TITLE
chore: fix old aws-sdk-cpp version references

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: "aws/aws-sdk-cpp"
-          ref: "1.7.231"
+          ref: "1.8.32"
           path: "aws-sdk-cpp"
 
       - name: Build and install aws-sdk-cpp

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Also, see the [API documentation](https://aws.github.io/aws-encryption-sdk-c/htm
 ## Dependencies
 
 The only direct dependencies of this code are OpenSSL 1.0.2 or higher or 1.1.0 or higher and
-[aws-c-common](https://github.com/awslabs/aws-c-common) v0.3.15. You will also need
+[aws-c-common](https://github.com/awslabs/aws-c-common) v0.4.42. You will also need
 a C compiler and CMake 3.9 or higher.
 
 To integrate with [KMS](https://aws.amazon.com/kms/) the AWS Encryption SDK for C also requires
@@ -22,7 +22,7 @@ For best results when doing a build with KMS integration, do not install aws-c-c
 Build and install the AWS SDK for C++, which will build and install aws-c-common for you (see the C++ SDK dependancies
  [here](https://github.com/aws/aws-sdk-cpp/blob/master/third-party/CMakeLists.txt#L18)). If
 you install aws-c-common before building the AWS SDK for C++, this will fool the AWS SDK for
-C++ install logic, and you will be forced to install several other dependencies manually. Version 1.7.231 of the 
+C++ install logic, and you will be forced to install several other dependencies manually. Version 1.8.32 of the
 AWS SDK for C++ is supported by version v1.0.1 of the AWS Encryption SDK for C.
 
 You need to compile both the AWS Encryption SDK for C and its dependencies as either all
@@ -174,7 +174,7 @@ aws-c-common for you.
 Do a KMS-only build of the AWS SDK for C++. If you want to use the AWS SDK for C++ for
 other AWS services, you can omit the `-DBUILD_ONLY="kms"` argument, but the build will take much longer.
 
-    git clone -b v1.7.231 https://github.com/aws/aws-sdk-cpp.git
+    git clone -b 1.8.32 https://github.com/aws/aws-sdk-cpp.git
     mkdir build-aws-sdk-cpp && cd build-aws-sdk-cpp
     cmake -G Xcode -DBUILD_SHARED_LIBS=ON -DBUILD_ONLY="kms" -DENABLE_UNITY_BUILD=ON ../aws-sdk-cpp 
     xcodebuild -target install ; cd ..

--- a/codebuild/common-windows.bat
+++ b/codebuild/common-windows.bat
@@ -15,7 +15,7 @@ set ROOT_SRC_DIR=%cd%
 rmdir/s/q \build
 mkdir \build
 cd \build
-git clone -b 1.7.231 https://github.com/aws/aws-sdk-cpp.git || goto error
+git clone -b 1.8.32 https://github.com/aws/aws-sdk-cpp.git || goto error
 mkdir build-aws-sdk-cpp
 cd build-aws-sdk-cpp
 cmake %* -DCMAKE_INSTALL_PREFIX=c:/deps -DCMAKE_BUILD_TYPE="Release" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_ONLY="kms" -DENABLE_UNITY_BUILD=ON ../aws-sdk-cpp || goto error

--- a/examples/build_osx.sh
+++ b/examples/build_osx.sh
@@ -17,7 +17,7 @@
 set +ex
 
 OS=$(uname -s)
-AWS_SDK_CPP_VER="1.7.231"  #github versioned branch
+AWS_SDK_CPP_VER="1.8.32"  #github versioned branch
 BUILDROOT="/var/tmp/build-$(date +%s)"
 OPENSSL_VER="openssl@1.1" #note this is a brew label, not an exact version reference
 BUILDROOT="/var/tmp/build-$(date +%Y%m%d)"


### PR DESCRIPTION
*Description of changes:* I missed some aws-sdk-cpp version references in #589, leaving the in-repo documentation and CI scripts in an inconsistent state. This PR brings those references up to date, so that no old version numbers remain (except in the changelog):

```
$ rg -g '!.git' --hidden '1\.7\.231'
CHANGELOG.md
8:* aws-cpp-sdk dependency bump to version 1.7.231

$ rg -g '!.git' --hidden '0\.3\.15'

$
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

