### PR TITLE
Update Makefile.common as part of attempt to fix S3 sync issues 

### DIFF
--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -149,7 +149,7 @@ common-git:
 	@if [ ! -d $(COMMONDIR) ] ;\
 	then \
 		cd $(BASEDIR); \
-		git clone --quiet --depth 30 https://github.com/awslabs/aws-c-common.git $(COMMON_REPO_NAME); \
+		git clone --quiet --depth 100 https://github.com/awslabs/aws-c-common.git $(COMMON_REPO_NAME); \
     cd $(COMMON_REPO_NAME); \
     git reset --hard dd600468fbd25c6f31828010c28056c4d5c3ab35; \
     cd $(BASEDIR); \


### PR DESCRIPTION
*Description of changes:*

Increases clone depth for aws-c-common in Makefile.common to 100 to see if insufficient clone depth was the problem. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

