### PR TITLE
chore: fix CHANGELOG commit hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0 -- 2020-09-24
 
-* Updates to the AWS Encryption SDK. 13e0f81
+* Updates to the AWS Encryption SDK. c43d706
 
   This change includes fixes for issues that were reported by Thai Duong from
   Google's Security team, and for issues that were identified by AWS
@@ -19,7 +19,7 @@
 
 ## 1.7.0 -- 2020-09-24
 
-* Updates to the AWS Encryption SDK. cbed43b
+* Updates to the AWS Encryption SDK. 4ba5825
 
   This change includes fixes for issues that were reported by Thai Duong from
   Google's Security team, and for issues that were identified by AWS


### PR DESCRIPTION
*Description of changes:* This PR fixes incorrect commit hashes in the CHANGELOG entries for the 1.7.0 and 2.0.0 releases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

