### PR TITLE
Update harnesses for aes_gcm_encrypt and aes_gcm_decrypt

### DIFF
--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -87,7 +87,7 @@ HELPERDIR ?= $(SDKDIR)/.cbmc-batch
 LINKFARM = $(abspath ./link-farm)
 COMMON_REPO_NAME ?= aws-c-common
 COMMONDIR ?= $(HELPERDIR)/$(COMMON_REPO_NAME)
-COMMON_HELPERDIR ?= $(COMMONDIR)/.cbmc-batch
+COMMON_HELPERDIR ?= $(COMMONDIR)/verification/cbmc
 
 ################################################################
 # Setup include directory order
@@ -155,7 +155,7 @@ common-symlinks: linkfarm-dir
 
 common-helper-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/include, c-common-helper-inc)
-	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/source, c-common-helper-src)
+	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/sources, c-common-helper-src)
 	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/stubs, c-common-helper-stubs)
 	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/uninline, c-common-helper-uninline)
 

--- a/.cbmc-batch/jobs/Makefile.common
+++ b/.cbmc-batch/jobs/Makefile.common
@@ -85,8 +85,8 @@ SRCDIR ?= $(abspath ./link-farm)
 SDKDIR ?= $(abspath ../../..)
 HELPERDIR ?= $(SDKDIR)/.cbmc-batch
 LINKFARM = $(abspath ./link-farm)
-COMMON_REPO_NAME ?= aws-c-common-for-cryptosdk-proofs
-COMMONDIR ?= $(BASEDIR)/$(COMMON_REPO_NAME)
+COMMON_REPO_NAME ?= aws-c-common
+COMMONDIR ?= $(HELPERDIR)/$(COMMON_REPO_NAME)
 COMMON_HELPERDIR ?= $(COMMONDIR)/.cbmc-batch
 
 ################################################################
@@ -144,28 +144,16 @@ define make_symlink
 	fi
 endef
 
-################ Clone the necessary repos
-common-git:
-	@if [ ! -d $(COMMONDIR) ] ;\
-	then \
-		cd $(BASEDIR); \
-		git clone --quiet https://github.com/awslabs/aws-c-common.git $(COMMON_REPO_NAME); \
-    cd $(COMMON_REPO_NAME); \
-    git reset --hard dd600468fbd25c6f31828010c28056c4d5c3ab35; \
-    cd $(BASEDIR); \
-	else \
-		echo "c-common repo already exists. Nothing to do."; \
-	fi
-
+################ Make the linkfarm
 linkfarm-dir:
 	mkdir -p link-farm
 
 # If we have dangling links here, batch is not happy. So make them as needed.
-common-symlinks: common-git linkfarm-dir
+common-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(COMMONDIR)/include, c-common-inc)
 	$(call make_symlink, $(LINKFARM), $(COMMONDIR)/source, c-common-src)
 
-common-helper-symlinks: common-git linkfarm-dir
+common-helper-symlinks: linkfarm-dir
 	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/include, c-common-helper-inc)
 	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/source, c-common-helper-src)
 	$(call make_symlink, $(LINKFARM), $(COMMON_HELPERDIR)/stubs, c-common-helper-stubs)
@@ -329,7 +317,7 @@ veryclean: clean
 gitclean: veryclean
 	$(RM) -r $(COMMONDIR)
 
-.PHONY: cbmc property coverage report clean veryclean common-symlinks common-git harness-symlink fill-linkfarm helper-symlinks ci-yaml
+.PHONY: cbmc property coverage report clean veryclean common-symlinks harness-symlink fill-linkfarm helper-symlinks ci-yaml
 
 .PHONY: setup_dependencies cbmc property coverage report clean veryclean
 

--- a/.cbmc-batch/jobs/Makefile.local_default
+++ b/.cbmc-batch/jobs/Makefile.local_default
@@ -20,12 +20,4 @@ GOTO_ANALYZER ?= goto-analyzer
 BATCH ?= cbmc-batch
 VIEWER ?= cbmc-viewer
 
-SRCDIR ?= $(abspath ./link-farm)
-BASEDIR ?= $(abspath ../../../..)
-COMMON_REPO_NAME ?= aws-c-common-for-cryptosdk-proofs
-COMMONDIR ?= $(BASEDIR)/$(COMMON_REPO_NAME)
-COMMON_HELPERDIR ?= $(COMMONDIR)/.cbmc-batch
-SDKDIR ?= $(abspath ../../..)
-HELPERDIR ?= $(SDKDIR)/.cbmc-batch
-
 addone = $(shell echo $$(( $(1) + 1)))

--- a/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_aes_gcm_decrypt/Makefile
@@ -26,10 +26,10 @@ CBMCFLAGS +=
 
 ENTRY = aws_cryptosdk_aes_gcm_decrypt_harness
 
-DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/make_common_data_structures.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/proof_allocators.goto
 DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.goto
+DEPENDENCIES += $(SRCDIR)/c-common-helper-stubs/memcpy_override_havoc.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/byte_buf.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/common.goto
 DEPENDENCIES += $(SRCDIR)/c-common-src/error.goto

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_encrypt/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_on_encrypt/Makefile
@@ -47,6 +47,7 @@ DEPENDENCIES += $(SRCDIR)/c-common-helper-src/utils.c
 
 DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/array_list.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/atomics.c
+DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/error.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/math.c
 DEPENDENCIES += $(SRCDIR)/c-common-helper-uninline/string.c
 

--- a/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/Makefile
+++ b/.cbmc-batch/jobs/aws_cryptosdk_keyring_trace_add_record_buf/Makefile
@@ -25,6 +25,7 @@ ENTRY = aws_cryptosdk_keyring_trace_add_record_buf_harness
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/make_common_data_structures.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/proof_allocators.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-helper-src/utils.c
+DEPENDENCIES +=	$(SRCDIR)/c-common-helper-stubs/memcpy_override_havoc.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/array_list.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/byte_buf.c
 DEPENDENCIES +=	$(SRCDIR)/c-common-src/common.c
@@ -33,7 +34,6 @@ DEPENDENCIES +=	$(SRCDIR)/c-common-src/string.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/cipher.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/keyring_trace.c
 DEPENDENCIES +=	$(SRCDIR)/c-enc-sdk-src/utils.c
-DEPENDENCIES += $(COMMON_HELPERDIR)/stubs/memcpy_override_havoc.c
 DEPENDENCIES += $(SRCDIR)/helper-src/make_common_data_structures.c
 
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "aws-encryption-sdk-cpp/tests/test_vectors/aws-encryption-sdk-test-vectors"]
 	path = aws-encryption-sdk-cpp/tests/test_vectors/aws-encryption-sdk-test-vectors
 	url = https://github.com/awslabs/aws-encryption-sdk-test-vectors.git
+[submodule ".cbmc-batch/aws-c-common"]
+	path = .cbmc-batch/aws-c-common
+	url = https://github.com/awslabs/aws-c-common.git

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -814,6 +814,13 @@ int aws_cryptosdk_aes_gcm_encrypt(
     const struct aws_byte_cursor iv,
     const struct aws_byte_cursor aad,
     const struct aws_string *key) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(cipher));
+    AWS_PRECONDITION(cipher->buffer != NULL);
+    AWS_PRECONDITION(aws_byte_buf_is_valid(tag));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&plain));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&iv));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&aad));
+    AWS_PRECONDITION(aws_string_is_valid(key));
     const EVP_CIPHER *alg = get_alg_from_key_size(key->len);
     if (!alg || iv.len != aes_gcm_iv_len || tag->capacity < aes_gcm_tag_len || cipher->capacity < plain.len)
         return aws_raise_error(AWS_ERROR_INVALID_BUFFER_SIZE);
@@ -854,6 +861,13 @@ int aws_cryptosdk_aes_gcm_decrypt(
     const struct aws_byte_cursor iv,
     const struct aws_byte_cursor aad,
     const struct aws_string *key) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(plain));
+    AWS_PRECONDITION(plain->buffer != NULL);
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&cipher));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&tag));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&iv));
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&aad));
+    AWS_PRECONDITION(aws_string_is_valid(key));
     bool openssl_err      = true;
     const EVP_CIPHER *alg = get_alg_from_key_size(key->len);
     if (!alg || iv.len != aes_gcm_iv_len || tag.len != aes_gcm_tag_len || plain->capacity < cipher.len)


### PR DESCRIPTION
*Description of changes:*
Added assumptions that the output buffer cannot be NULL. 
This assumption is needed. If the output buffer is NULL, the EVP_EncryptUpdate or EVP_DecryptUpdate stubs assume the case where the aad is being specified and do not update outl. This results in an overflow error as there are no constraints on the size of outl. The behavior of the stubs does seem to match the specification for the functions so I updated the assumptions instead of the stubs. 
Added matching preconditions to source code.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

