### PR TITLE
Adds CBMC proofs for session functions

### DIFF
--- a/source/session.c
+++ b/source/session.c
@@ -202,6 +202,7 @@ int aws_cryptosdk_session_set_message_bound(struct aws_cryptosdk_session *sessio
 
 int aws_cryptosdk_session_set_commitment_policy(
     struct aws_cryptosdk_session *session, enum aws_cryptosdk_commitment_policy commitment_policy) {
+    AWS_PRECONDITION(session != NULL);
     /*
      * We set the commitment policy _first_ in order to ensure that, if someone ignores the INVALID_ARGUMENT error,
      * we'll fail subsequent operations.

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+PROOF_UID = aws_cryptosdk_priv_algorithm_allowed_for_decrypt
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+CBMCFLAGS +=
+
+PROJECT_SOURCES += $(SRCDIR)/source/session.c
+
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/error.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+
+UNWINDSET += 
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/Makefile
@@ -15,7 +15,6 @@
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
-include ../Makefile.aws_byte_buf
 
 PROOF_UID = aws_cryptosdk_priv_algorithm_allowed_for_decrypt
 

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/aws_cryptosdk_priv_algorithm_allowed_for_decrypt_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/aws_cryptosdk_priv_algorithm_allowed_for_decrypt_harness.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/session.h>
+#include <aws/cryptosdk/session.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_priv_algorithm_allowed_for_decrypt_harness() {
+    /* Nondet Input */
+    enum aws_cryptosdk_alg_id alg_id;
+    enum aws_cryptosdk_commitment_policy policy;
+
+    /* Assumptions */
+    __CPROVER_assume(aws_cryptosdk_commitment_policy_is_valid(policy));
+
+    /* Function under test */
+    int ret = aws_cryptosdk_priv_algorithm_allowed_for_decrypt(alg_id, policy);
+    if (policy == COMMITMENT_POLICY_FORBID_ENCRYPT_ALLOW_DECRYPT ||
+        policy == COMMITMENT_POLICY_REQUIRE_ENCRYPT_ALLOW_DECRYPT) {
+        assert(ret == true);
+    }
+
+    /* Assertions */
+    assert(aws_cryptosdk_commitment_policy_is_valid(policy));
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--flush;--object-bits;8;--external-sat-solver;kissat;--malloc-may-fail;--malloc-fail-null;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/tegab/clean/aws-encryption-sdk-c/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/gotos/aws_cryptosdk_priv_algorithm_allowed_for_decrypt_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--flush;--object-bits;8;--external-sat-solver;kissat;--malloc-may-fail;--malloc-fail-null;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/tegab/clean/aws-encryption-sdk-c/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_decrypt/gotos/aws_cryptosdk_priv_algorithm_allowed_for_decrypt_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+PROOF_UID = aws_cryptosdk_priv_algorithm_allowed_for_encrypt
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+CBMCFLAGS +=
+
+PROJECT_SOURCES += $(SRCDIR)/source/session.c
+
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/error.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+
+UNWINDSET += 
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/aws_cryptosdk_priv_algorithm_allowed_for_encrypt_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/aws_cryptosdk_priv_algorithm_allowed_for_encrypt_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/session.h>
+#include <aws/cryptosdk/session.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_priv_algorithm_allowed_for_encrypt_harness() {
+    /* Nondet Input */
+    enum aws_cryptosdk_alg_id alg_id;
+    enum aws_cryptosdk_commitment_policy policy;
+
+    /* Assumptions */
+    __CPROVER_assume(aws_cryptosdk_commitment_policy_is_valid(policy));
+
+    /* Function under test */
+    aws_cryptosdk_priv_algorithm_allowed_for_encrypt(alg_id, policy);
+
+    /* Assertions */
+    assert(aws_cryptosdk_commitment_policy_is_valid(policy));
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--flush;--object-bits;8;--external-sat-solver;kissat;--malloc-may-fail;--malloc-fail-null;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/tegab/clean/aws-encryption-sdk-c/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/gotos/aws_cryptosdk_priv_algorithm_allowed_for_encrypt_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--flush;--object-bits;8;--external-sat-solver;kissat;--malloc-may-fail;--malloc-fail-null;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/tegab/clean/aws-encryption-sdk-c/verification/cbmc/proofs/aws_cryptosdk_priv_algorithm_allowed_for_encrypt/gotos/aws_cryptosdk_priv_algorithm_allowed_for_encrypt_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/Makefile
@@ -16,7 +16,7 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 
-PROOF_UID = aws_cryptosdk_priv_algorithm_allowed_for_encrypt
+PROOF_UID = aws_cryptosdk_session_set_commitment_policy
 
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c

--- a/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/README.md
+++ b/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/README.md
@@ -1,0 +1,18 @@
+# Memory safety proof for aws_cryptosdk_session_set_commitment_policy
+
+This proof harness attains 40% code coverage.  The following comments explain
+why the uncovered lines of code are unreachable code.
+
+Some functions contain unreachable blocks of code:
+
+* `aws_cryptosdk_priv_session_change_state`
+
+    * Called from aws_cryptosdk_priv_fail_session with the argument "new_state" hard-coded to ST_ERROR. 
+    * Only one case of the switch statement on "new_state" is therefore covered. 
+    * Additionally, the current state is not ST_CONFIG from a conditional check in aws_cryptosdk_session_set_commitment_policy. 
+
+Some functions are never reached:
+
+* `abort`
+
+    * abort is called from unexplored cases of aws_cryptosdk_priv_session_change_state.

--- a/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/README.md
+++ b/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/README.md
@@ -1,4 +1,4 @@
-# Memory safety proof for aws_cryptosdk_session_set_commitment_policy
+# Memory safety proof for `aws_cryptosdk_session_set_commitment_policy`
 
 This proof harness attains 40% code coverage.  The following comments explain
 why the uncovered lines of code are unreachable code.
@@ -7,12 +7,12 @@ Some functions contain unreachable blocks of code:
 
 * `aws_cryptosdk_priv_session_change_state`
 
-    * Called from aws_cryptosdk_priv_fail_session with the argument "new_state" hard-coded to ST_ERROR. 
-    * Only one case of the switch statement on "new_state" is therefore covered. 
-    * Additionally, the current state is not ST_CONFIG from a conditional check in aws_cryptosdk_session_set_commitment_policy. 
+    * Called from `aws_cryptosdk_priv_fail_session` with the argument `new_state` hard-coded to `ST_ERROR`. 
+    * Only one case of the switch statement on `new_state` is therefore covered. 
+    * Additionally, the current state is not `ST_CONFIG` from a conditional check in `aws_cryptosdk_session_set_commitment_policy`. 
 
 Some functions are never reached:
 
-* `abort`
+* `abort()`
 
-    * abort is called from unexplored cases of aws_cryptosdk_priv_session_change_state.
+    * `abort()` is called from unexplored cases of `aws_cryptosdk_priv_session_change_state`.

--- a/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/aws_cryptosdk_session_set_commitment_policy_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/aws_cryptosdk_session_set_commitment_policy_harness.c
@@ -26,8 +26,7 @@ void aws_cryptosdk_session_set_commitment_policy_harness() {
     __CPROVER_assume(session != NULL);
 
     /* Function under test */
-    int ret = aws_cryptosdk_session_set_commitment_policy(session, policy);
-    if (ret == AWS_OP_SUCCESS) {
+    if (aws_cryptosdk_session_set_commitment_policy(session, policy) == AWS_OP_SUCCESS) {
         /* Assertions */
         assert(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
         assert(session->state == ST_CONFIG);

--- a/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/aws_cryptosdk_session_set_commitment_policy_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/aws_cryptosdk_session_set_commitment_policy_harness.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/session.h>
+#include <aws/cryptosdk/session.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_session_set_commitment_policy_harness() {
+    /* Nondet Input */
+    struct aws_cryptosdk_session *session = malloc(sizeof(*session));
+    enum aws_cryptosdk_commitment_policy policy;
+
+    /* Assumptions */
+    __CPROVER_assume(session != NULL);
+
+    /* Function under test */
+    int ret = aws_cryptosdk_session_set_commitment_policy(session, policy);
+    if (ret == AWS_OP_SUCCESS) {
+        /* Assertions */
+        assert(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
+        assert(session->state == ST_CONFIG);
+    } else {
+        /* Assertions */
+        assert(session->state == ST_ERROR || !aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
+    }
+
+    /* Assertions */
+    assert(session->commitment_policy == policy);
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/cbmc-batch.yaml
@@ -1,0 +1,8 @@
+build_memory: 32000
+cbmcflags: "--unwind;1;--flush;--object-bits;8;--external-sat-solver;kissat;--malloc-may-fail;--malloc-fail-null;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null"
+coverage_memory: 32000
+expected: SUCCESSFUL
+goto: /Users/tegab/clean/aws-encryption-sdk-c/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/gotos/aws_cryptosdk_session_set_commitment_policy_harness.c.goto
+jobos: ubuntu16
+property_memory: 32000
+report_memory: 32000

--- a/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/cbmc-batch.yaml
@@ -1,8 +1,4 @@
-build_memory: 32000
-cbmcflags: "--unwind;1;--flush;--object-bits;8;--external-sat-solver;kissat;--malloc-may-fail;--malloc-fail-null;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null"
-coverage_memory: 32000
-expected: SUCCESSFUL
-goto: /Users/tegab/clean/aws-encryption-sdk-c/verification/cbmc/proofs/aws_cryptosdk_session_set_commitment_policy/gotos/aws_cryptosdk_session_set_commitment_policy_harness.c.goto
-jobos: ubuntu16
-property_memory: 32000
-report_memory: 32000
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.


### PR DESCRIPTION
*Description of changes:*
CBMC harnesses and Makefiles for aws_cryptosdk_session_set_commitment_policy, aws_cryptosdk_priv_algorithm_allowed_for_encrypt, aws_cryptosdk_priv_algorithm_allowed_for_decrypt. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

