### PR TITLE
Adds CBMC proof for aws_cryptosdk_default_cmm_set_alg_id function

### DIFF
--- a/source/default_cmm.c
+++ b/source/default_cmm.c
@@ -169,6 +169,7 @@ struct aws_cryptosdk_cmm *aws_cryptosdk_default_cmm_new(struct aws_allocator *al
 }
 
 int aws_cryptosdk_default_cmm_set_alg_id(struct aws_cryptosdk_cmm *cmm, enum aws_cryptosdk_alg_id alg_id) {
+    AWS_PRECONDITION(cmm != NULL);
     struct default_cmm *self = (struct default_cmm *)cmm;
     assert(self->base.vtable == &default_cmm_vt);
 

--- a/verification/cbmc/proofs/aws_cryptosdk_default_cmm_set_alg_id/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_default_cmm_set_alg_id/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+
+#########
+# Local vars
+
+#########
+PROOF_UID = aws_cryptosdk_default_cmm_set_alg_id
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+CBMCFLAGS +=
+
+PROJECT_SOURCES += $(SRCDIR)/source/default_cmm.c
+PROJECT_SOURCES += $(SRCDIR)/source/materials.c
+
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/error.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+UNWINDSET +=
+###########
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_default_cmm_set_alg_id/aws_cryptosdk_default_cmm_set_alg_id_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_default_cmm_set_alg_id/aws_cryptosdk_default_cmm_set_alg_id_harness.c
@@ -24,19 +24,20 @@ void aws_cryptosdk_default_cmm_set_alg_id_harness() {
     /* Nondet input */
     enum aws_cryptosdk_alg_id alg_id;
 
+    struct aws_cryptosdk_keyring *keyring = malloc(sizeof(*keyring));
+
     const struct aws_cryptosdk_keyring_vt vtable = { .vt_size    = sizeof(struct aws_cryptosdk_keyring_vt),
                                                      .name       = ensure_c_str_is_allocated(SIZE_MAX),
                                                      .destroy    = nondet_voidp(),
                                                      .on_encrypt = nondet_voidp(),
                                                      .on_decrypt = nondet_voidp() };
-    struct aws_cryptosdk_keyring *keyring        = malloc(sizeof(*keyring));
     ensure_cryptosdk_keyring_has_allocated_members(keyring, &vtable);
     __CPROVER_assume(aws_cryptosdk_keyring_is_valid(keyring));
 
-    /* Instantiate the default (non-caching) implementation of the Crypto MaterialsManager (CMM).*/
+    /* Instantiate the default (non-caching) implementation of the Crypto MaterialsManager (CMM) */
     struct aws_cryptosdk_cmm *cmm = aws_cryptosdk_default_cmm_new(can_fail_allocator(), keyring);
 
-    /*Assumptions */
+    /* Assumptions */
     __CPROVER_assume(cmm != NULL);
 
     /* Operation under verification */

--- a/verification/cbmc/proofs/aws_cryptosdk_default_cmm_set_alg_id/aws_cryptosdk_default_cmm_set_alg_id_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_default_cmm_set_alg_id/aws_cryptosdk_default_cmm_set_alg_id_harness.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/default_cmm.h>
+#include <aws/cryptosdk/materials.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_default_cmm_set_alg_id_harness() {
+    /* Nondet input */
+    enum aws_cryptosdk_alg_id alg_id;
+
+    const struct aws_cryptosdk_keyring_vt vtable = { .vt_size    = sizeof(struct aws_cryptosdk_keyring_vt),
+                                                     .name       = ensure_c_str_is_allocated(SIZE_MAX),
+                                                     .destroy    = nondet_voidp(),
+                                                     .on_encrypt = nondet_voidp(),
+                                                     .on_decrypt = nondet_voidp() };
+    struct aws_cryptosdk_keyring *keyring        = malloc(sizeof(*keyring));
+    ensure_cryptosdk_keyring_has_allocated_members(keyring, &vtable);
+    __CPROVER_assume(aws_cryptosdk_keyring_is_valid(keyring));
+
+    /* Instantiate the default (non-caching) implementation of the Crypto MaterialsManager (CMM).*/
+    struct aws_cryptosdk_cmm *cmm = aws_cryptosdk_default_cmm_new(can_fail_allocator(), keyring);
+
+    /*Assumptions */
+    __CPROVER_assume(cmm != NULL);
+
+    /* Operation under verification */
+    aws_cryptosdk_default_cmm_set_alg_id(cmm, alg_id);
+
+    /* Post-conditions */
+    assert(aws_cryptosdk_cmm_base_is_valid(cmm));
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_default_cmm_set_alg_id/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_default_cmm_set_alg_id/cbmc-batch.yaml
@@ -1,0 +1,5 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.
+  

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -160,8 +160,10 @@ enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id
 
 void ensure_cryptosdk_keyring_has_allocated_members(
     struct aws_cryptosdk_keyring *keyring, const struct aws_cryptosdk_keyring_vt *vtable) {
-    keyring->refcount.value = can_fail_malloc(sizeof(size_t));
-    keyring->vtable         = nondet_bool() ? NULL : vtable;
+    if (keyring) {
+        keyring->refcount.value = malloc(sizeof(size_t));
+        keyring->vtable         = nondet_bool() ? NULL : vtable;
+    }
 }
 
 void ensure_nondet_allocate_keyring_vtable_members(struct aws_cryptosdk_keyring_vt *vtable, size_t max_len) {


### PR DESCRIPTION
*Description of changes:*

Adds harness, Makefile and yaml for aws_cryptosdk_default_cmm_set_alg_id. 
Adds preconditions to function. 
Updates ensure_cryptosdk_keyring_has_allocated_members. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

