### PR TITLE
Add CBMC proofs for various functions in cipher.c

### DIFF
--- a/include/aws/cryptosdk/private/cipher.h
+++ b/include/aws/cryptosdk/private/cipher.h
@@ -251,4 +251,8 @@ int aws_cryptosdk_rsa_encrypt(
     const struct aws_string *rsa_public_key_pem,
     enum aws_cryptosdk_rsa_padding_mode rsa_padding_mode);
 
+bool aws_cryptosdk_data_key_is_valid(const struct data_key *key);
+
+bool aws_cryptosdk_content_key_is_valid(const struct content_key *key);
+
 #endif  // AWS_CRYPTOSDK_PRIVATE_CIPHER_H

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -321,8 +321,9 @@ static int aws_cryptosdk_private_derive_key_v1(
     struct content_key *content_key,
     const struct data_key *data_key,
     const struct aws_byte_buf *message_id) {
-    AWS_PRECONDITION(content_key != NULL);
-    AWS_PRECONDITION(data_key != NULL);
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(props));
+    AWS_PRECONDITION(aws_cryptosdk_content_key_is_valid(content_key));
+    AWS_PRECONDITION(aws_cryptosdk_data_key_is_valid(data_key));
     AWS_PRECONDITION(aws_byte_buf_is_valid(message_id));
 
     if (message_id->len != MSG_ID_LEN) {
@@ -354,8 +355,9 @@ static int aws_cryptosdk_private_derive_key_v2(
     const struct data_key *data_key,
     struct aws_byte_buf *commitment,
     const struct aws_byte_buf *message_id) {
-    AWS_PRECONDITION(content_key != NULL);
-    AWS_PRECONDITION(data_key != NULL);
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(props));
+    AWS_PRECONDITION(aws_cryptosdk_content_key_is_valid(content_key));
+    AWS_PRECONDITION(aws_cryptosdk_data_key_is_valid(data_key));
     AWS_PRECONDITION(aws_byte_buf_is_valid(commitment));
     AWS_PRECONDITION(aws_byte_buf_is_valid(message_id));
 
@@ -410,8 +412,8 @@ int aws_cryptosdk_private_derive_key(
     struct aws_byte_buf *commitment,
     const struct aws_byte_buf *message_id) {
     AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(props));
-    AWS_PRECONDITION(content_key != NULL);
-    AWS_PRECONDITION(data_key != NULL);
+    AWS_PRECONDITION(aws_cryptosdk_content_key_is_valid(content_key));
+    AWS_PRECONDITION(aws_cryptosdk_data_key_is_valid(data_key));
     if (props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_2_0) {
         AWS_PRECONDITION(aws_byte_buf_is_valid(commitment));
     }
@@ -1049,4 +1051,12 @@ cleanup:
     } else {
         return AWS_OP_SUCCESS;
     }
+}
+
+bool aws_cryptosdk_data_key_is_valid(const struct data_key *key) {
+    return key != NULL && AWS_MEM_IS_WRITABLE(key->keybuf, MAX_DATA_KEY_SIZE);
+}
+
+bool aws_cryptosdk_content_key_is_valid(const struct content_key *key) {
+    return key != NULL && AWS_MEM_IS_WRITABLE(key->keybuf, MAX_DATA_KEY_SIZE);
 }

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -280,8 +280,6 @@ bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_proper
 }
 
 bool aws_cryptosdk_private_commitment_eq(struct aws_byte_buf *a, struct aws_byte_buf *b) {
-    AWS_PRECONDITION(a != NULL);
-    AWS_PRECONDITION(b != NULL);
     AWS_PRECONDITION(aws_byte_buf_is_valid(a));
     AWS_PRECONDITION(aws_byte_buf_is_valid(b));
 
@@ -325,7 +323,6 @@ static int aws_cryptosdk_private_derive_key_v1(
     const struct aws_byte_buf *message_id) {
     AWS_PRECONDITION(content_key != NULL);
     AWS_PRECONDITION(data_key != NULL);
-    AWS_PRECONDITION(message_id != NULL);
     AWS_PRECONDITION(aws_byte_buf_is_valid(message_id));
 
     if (message_id->len != MSG_ID_LEN) {
@@ -359,8 +356,6 @@ static int aws_cryptosdk_private_derive_key_v2(
     const struct aws_byte_buf *message_id) {
     AWS_PRECONDITION(content_key != NULL);
     AWS_PRECONDITION(data_key != NULL);
-    AWS_PRECONDITION(commitment != NULL);
-    AWS_PRECONDITION(message_id != NULL);
     AWS_PRECONDITION(aws_byte_buf_is_valid(commitment));
     AWS_PRECONDITION(aws_byte_buf_is_valid(message_id));
 
@@ -418,10 +413,8 @@ int aws_cryptosdk_private_derive_key(
     AWS_PRECONDITION(content_key != NULL);
     AWS_PRECONDITION(data_key != NULL);
     if (props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_2_0) {
-        AWS_PRECONDITION(commitment != NULL);
         AWS_PRECONDITION(aws_byte_buf_is_valid(commitment));
     }
-    AWS_PRECONDITION(message_id != NULL);
     AWS_PRECONDITION(aws_byte_buf_is_valid(message_id));
 
     if (props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_1_0) {

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -224,6 +224,8 @@ const struct aws_cryptosdk_alg_properties *aws_cryptosdk_alg_props(enum aws_cryp
 }
 
 size_t aws_cryptosdk_private_algorithm_message_id_len(const struct aws_cryptosdk_alg_properties *alg_props) {
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(alg_props));
+
     switch (alg_props->msg_format_version) {
         case AWS_CRYPTOSDK_HEADER_VERSION_1_0: return MSG_ID_LEN;
         case AWS_CRYPTOSDK_HEADER_VERSION_2_0: return MSG_ID_LEN_V2;
@@ -278,6 +280,11 @@ bool aws_cryptosdk_alg_properties_is_valid(const struct aws_cryptosdk_alg_proper
 }
 
 bool aws_cryptosdk_private_commitment_eq(struct aws_byte_buf *a, struct aws_byte_buf *b) {
+    AWS_PRECONDITION(a != NULL);
+    AWS_PRECONDITION(b != NULL);
+    AWS_PRECONDITION(aws_byte_buf_is_valid(a));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(b));
+
     if (a->len != b->len) return false;
 
     // If the (expected and true) commitment is zero-length, we're in a non-committing
@@ -316,6 +323,11 @@ static int aws_cryptosdk_private_derive_key_v1(
     struct content_key *content_key,
     const struct data_key *data_key,
     const struct aws_byte_buf *message_id) {
+    AWS_PRECONDITION(content_key != NULL);
+    AWS_PRECONDITION(data_key != NULL);
+    AWS_PRECONDITION(message_id != NULL);
+    AWS_PRECONDITION(aws_byte_buf_is_valid(message_id));
+
     if (message_id->len != MSG_ID_LEN) {
         return AWS_CRYPTOSDK_ERR_UNSUPPORTED_FORMAT;
     }
@@ -345,6 +357,13 @@ static int aws_cryptosdk_private_derive_key_v2(
     const struct data_key *data_key,
     struct aws_byte_buf *commitment,
     const struct aws_byte_buf *message_id) {
+    AWS_PRECONDITION(content_key != NULL);
+    AWS_PRECONDITION(data_key != NULL);
+    AWS_PRECONDITION(commitment != NULL);
+    AWS_PRECONDITION(message_id != NULL);
+    AWS_PRECONDITION(aws_byte_buf_is_valid(commitment));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(message_id));
+
     if (commitment->capacity < props->commitment_len) {
         return AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN;
     }
@@ -395,6 +414,16 @@ int aws_cryptosdk_private_derive_key(
     const struct data_key *data_key,
     struct aws_byte_buf *commitment,
     const struct aws_byte_buf *message_id) {
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(props));
+    AWS_PRECONDITION(content_key != NULL);
+    AWS_PRECONDITION(data_key != NULL);
+    if (props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_2_0) {
+        AWS_PRECONDITION(commitment != NULL);
+        AWS_PRECONDITION(aws_byte_buf_is_valid(commitment));
+    }
+    AWS_PRECONDITION(message_id != NULL);
+    AWS_PRECONDITION(aws_byte_buf_is_valid(message_id));
+
     if (props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_1_0) {
         if (commitment->len != 0) {
             return AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN;

--- a/source/cipher.c
+++ b/source/cipher.c
@@ -1054,9 +1054,9 @@ cleanup:
 }
 
 bool aws_cryptosdk_data_key_is_valid(const struct data_key *key) {
-    return key != NULL && AWS_MEM_IS_WRITABLE(key->keybuf, MAX_DATA_KEY_SIZE);
+    return AWS_MEM_IS_WRITABLE(key->keybuf, MAX_DATA_KEY_SIZE);
 }
 
 bool aws_cryptosdk_content_key_is_valid(const struct content_key *key) {
-    return key != NULL && AWS_MEM_IS_WRITABLE(key->keybuf, MAX_DATA_KEY_SIZE);
+    return AWS_MEM_IS_WRITABLE(key->keybuf, MAX_DATA_KEY_SIZE);
 }

--- a/verification/cbmc/include/make_common_data_structures.h
+++ b/verification/cbmc/include/make_common_data_structures.h
@@ -25,7 +25,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-void ensure_alg_properties_attempt_allocation(struct aws_cryptosdk_alg_properties *const alg_props);
+/* Allocates the members of alg_properties and ensures that internal pointers are pointing to the correct objects. */
+struct aws_cryptosdk_alg_properties *ensure_alg_properties_attempt_allocation(const size_t max_len);
+
+struct data_key *ensure_data_key_attempt_allocation();
+
+struct content_key *ensure_content_key_attempt_allocation();
 
 /* Allocates the members of the context and ensures that internal pointers are pointing to the correct objects. */
 void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ctx);

--- a/verification/cbmc/include/make_common_data_structures.h
+++ b/verification/cbmc/include/make_common_data_structures.h
@@ -25,11 +25,13 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-/* Allocates the members of alg_properties and ensures that internal pointers are pointing to the correct objects. */
+/* Allocates alg_properties members and ensures that internal pointers are pointing to the correct objects. */
 struct aws_cryptosdk_alg_properties *ensure_alg_properties_attempt_allocation(const size_t max_len);
 
+/* Ensures data_key structures are properly allocated. */
 struct data_key *ensure_data_key_attempt_allocation();
 
+/* Ensures content_key structures are properly allocated. */
 struct content_key *ensure_content_key_attempt_allocation();
 
 /* Allocates the members of the context and ensures that internal pointers are pointing to the correct objects. */

--- a/verification/cbmc/include/utils.h
+++ b/verification/cbmc/include/utils.h
@@ -9,12 +9,7 @@
 #include <aws/cryptosdk/private/cipher.h>
 
 /* Compares the contents of two aws_byte_buf objects */
-void assert_byte_buf_contents_are_equal(
-    const struct aws_byte_buf *const lhs,
-    const struct aws_byte_buf *const rhs);
+void assert_byte_buf_contents_are_equal(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs);
 
 /* Compares the contents of a content key with a data key up to max_len */
-void assert_keys_are_equal(
-    const struct content_key *ckey,
-    const struct data_key *dkey,
-    const size_t max_len);
+void assert_keys_are_equal(const struct content_key *ckey, const struct data_key *dkey, const size_t max_len);

--- a/verification/cbmc/include/utils.h
+++ b/verification/cbmc/include/utils.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/common/byte_buf.h>
+#include <aws/cryptosdk/private/cipher.h>
+
+/* Compares the contents of two aws_byte_buf objects */
+void assert_byte_buf_contents_are_equal(
+    const struct aws_byte_buf *const lhs,
+    const struct aws_byte_buf *const rhs);
+
+/* Compares the contents of a content key with a data key up to max_len */
+void assert_keys_are_equal(
+    const struct content_key *ckey,
+    const struct data_key *dkey,
+    const size_t max_len);

--- a/verification/cbmc/include/utils.h
+++ b/verification/cbmc/include/utils.h
@@ -6,6 +6,9 @@
 #include <aws/common/byte_buf.h>
 #include <aws/cryptosdk/private/cipher.h>
 
+/* Asserts that the contents of two aws_byte_buf objects match */
+void assert_byte_buf_contents_match(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs);
+
 /* Compares the contents of two aws_byte_buf objects */
 bool aws_byte_buf_contents_match(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs);
 

--- a/verification/cbmc/include/utils.h
+++ b/verification/cbmc/include/utils.h
@@ -3,13 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#pragma once
-
 #include <aws/common/byte_buf.h>
 #include <aws/cryptosdk/private/cipher.h>
 
 /* Compares the contents of two aws_byte_buf objects */
-void assert_byte_buf_contents_are_equal(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs);
+bool aws_byte_buf_contents_match(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs);
 
 /* Compares the contents of a content key with a data key up to max_len */
-void assert_keys_are_equal(const struct content_key *ckey, const struct data_key *dkey, const size_t max_len);
+bool key_contents_match(const struct content_key *ckey, const struct data_key *dkey, const size_t max_len);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/Makefile
@@ -24,6 +24,10 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 CBMCFLAGS += 
 
+# these are defined in cipher.c
+DEFINES += -DMSG_ID_LEN=16
+DEFINES += -DMSG_ID_LEN_V2=32
+
 PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
 
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/Makefile
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+#include ../Makefile.aws_byte_buf
+
+PROOF_UID = aws_cryptosdk_private_algorithm_message_id_len
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+CBMCFLAGS += 
+
+PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
+
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+###########
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/Makefile
@@ -16,6 +16,7 @@
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
+include ../Makefile.string
 
 PROOF_UID = aws_cryptosdk_private_algorithm_message_id_len
 
@@ -31,6 +32,7 @@ DEFINES += -DMSG_ID_LEN_V2=32
 PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
 
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
 ###########

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/Makefile
@@ -16,7 +16,6 @@
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
-#include ../Makefile.aws_byte_buf
 
 PROOF_UID = aws_cryptosdk_private_algorithm_message_id_len
 

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
@@ -18,7 +18,7 @@
 
 void aws_cryptosdk_private_algorithm_message_id_len_harness() {
     /* Nondet Input */
-    struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);;
+    struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);
 
     /* Assumptions */
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_private_algorithm_message_id_len_harness() {
+    /* Nondet Input */
+    const struct aws_cryptosdk_alg_properties *props = malloc(sizeof(*props));
+
+    /* Assumptions */
+    ensure_alg_properties_attempt_allocation(props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
+
+    /* Operation under verification */
+    aws_cryptosdk_private_algorithm_message_id_len(props);
+
+    /* Postconditions */
+    assert(aws_cryptosdk_alg_properties_is_valid(props));
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
@@ -18,10 +18,9 @@
 
 void aws_cryptosdk_private_algorithm_message_id_len_harness() {
     /* Nondet Input */
-    const struct aws_cryptosdk_alg_properties *props = malloc(sizeof(*props));
+    struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);;
 
     /* Assumptions */
-    ensure_alg_properties_attempt_allocation(props);
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
     /* Operation under verification */

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/aws_cryptosdk_private_algorithm_message_id_len_harness.c
@@ -25,8 +25,10 @@ void aws_cryptosdk_private_algorithm_message_id_len_harness() {
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
     /* Operation under verification */
-    aws_cryptosdk_private_algorithm_message_id_len(props);
+    size_t message_id_len = aws_cryptosdk_private_algorithm_message_id_len(props);
 
     /* Postconditions */
     assert(aws_cryptosdk_alg_properties_is_valid(props));
+    assert(IMPLIES(props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_1_0, message_id_len == MSG_ID_LEN));
+    assert(IMPLIES(props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_2_0, message_id_len == MSG_ID_LEN_V2));
 }

--- a/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_algorithm_message_id_len/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
@@ -18,12 +18,11 @@ sinclude ../Makefile.local
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 #########
-# Local vars
 # Commitment values are 32 bytes long. In aws_cryptosdk_private_commitment_eq,
 # two of these are compared in a loop with (32 / sizeof(uintptr_t)) iterations.
 # (32 / sizeof(uintptr_t)) equals 4 since sizeof(uintptr_t) is 8UL
 COMMITMENT_EQ_ITERATIONS = 4
-
+MAX_COMMITMENT_BUF_SIZE = 32
 #########
 PROOF_UID = aws_cryptosdk_private_commitment_eq
 HARNESS_ENTRY = $(PROOF_UID)_harness
@@ -41,6 +40,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
 
 UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMITMENT_EQ_ITERATIONS))
+UNWINDSET += aws_byte_buf_contents_match.0:$(call addone, $(MAX_COMMITMENT_BUF_SIZE))
 ###########
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
@@ -35,9 +35,10 @@ PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
 
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
-PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
 
 UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMITMENT_EQ_ITERATIONS))
 ###########

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
@@ -18,17 +18,20 @@ sinclude ../Makefile.local
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 #########
-# Commitment values are 32 bytes long. In aws_cryptosdk_private_commitment_eq,
-# two of these are compared in a loop with (32 / sizeof(uintptr_t)) iterations.
+# Commitment values are 32 bytes long.
+COMMITMENT_BUF_SIZE = 32
+# In aws_cryptosdk_private_commitment_eq, two commitment values are
+# compared in a loop with (32 / sizeof(uintptr_t)) iterations.
 # (32 / sizeof(uintptr_t)) equals 4 since sizeof(uintptr_t) is 8UL
 COMMITMENT_EQ_ITERATIONS = 4
-MAX_COMMITMENT_BUF_SIZE = 32
 #########
 PROOF_UID = aws_cryptosdk_private_commitment_eq
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 CBMCFLAGS += 
+
+DEFINES += -DCOMMITMENT_BUF_SIZE=$(COMMITMENT_BUF_SIZE)
 
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
@@ -40,7 +43,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
 
 UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMITMENT_EQ_ITERATIONS))
-UNWINDSET += aws_byte_buf_contents_match.0:$(call addone, $(MAX_COMMITMENT_BUF_SIZE))
+UNWINDSET += aws_byte_buf_contents_match.0:$(call addone, $(COMMITMENT_BUF_SIZE))
 ###########
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults 
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+#########
+# Local vars
+COMMIT_BYTES_NUM = 4
+
+#########
+PROOF_UID = aws_cryptosdk_private_commitment_eq
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+CBMCFLAGS += 
+
+DEFINES += $(COMMIT_BYTES_NUM)
+
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
+
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMIT_BYTES_NUM))
+###########
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/Makefile
@@ -19,17 +19,17 @@ include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 #########
 # Local vars
-COMMIT_BYTES_NUM = 4
+# Commitment values are 32 bytes long. In aws_cryptosdk_private_commitment_eq,
+# two of these are compared in a loop with (32 / sizeof(uintptr_t)) iterations.
+# (32 / sizeof(uintptr_t)) equals 4 since sizeof(uintptr_t) is 8UL
+COMMITMENT_EQ_ITERATIONS = 4
 
 #########
 PROOF_UID = aws_cryptosdk_private_commitment_eq
-
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 CBMCFLAGS += 
-
-DEFINES += $(COMMIT_BYTES_NUM)
 
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
@@ -39,7 +39,7 @@ PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
-UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMIT_BYTES_NUM))
+UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMITMENT_EQ_ITERATIONS))
 ###########
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
@@ -14,8 +14,8 @@
  */
 
 #include <aws/cryptosdk/private/cipher.h>
-#include <utils.h>
 #include <make_common_data_structures.h>
+#include <utils.h>
 
 void aws_cryptosdk_private_commitment_eq_harness() {
     /* Nondet Input */
@@ -41,8 +41,7 @@ void aws_cryptosdk_private_commitment_eq_harness() {
     save_byte_from_array(buf2->buffer, buf2->len, &old_byte_from_buf2);
 
     /* Operation under verification */
-    if (aws_cryptosdk_private_commitment_eq(buf1, buf2))
-        assert_byte_buf_contents_are_equal(buf1, buf2);
+    if (aws_cryptosdk_private_commitment_eq(buf1, buf2)) assert_byte_buf_contents_are_equal(buf1, buf2);
 
     /* Postconditions */
     assert(aws_byte_buf_is_valid(buf1));

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
@@ -23,13 +23,11 @@ void aws_cryptosdk_private_commitment_eq_harness() {
     struct aws_byte_buf *buf2 = malloc(sizeof(*buf2));
 
     /* Assumptions */
-    __CPROVER_assume(buf1 != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(buf1, MAX_BUFFER_SIZE));
+    __CPROVER_assume(IMPLIES(buf1 != NULL, aws_byte_buf_is_bounded(buf1, MAX_BUFFER_SIZE)));
     ensure_byte_buf_has_allocated_buffer_member(buf1);
     __CPROVER_assume(aws_byte_buf_is_valid(buf1));
 
-    __CPROVER_assume(buf2 != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(buf2, MAX_BUFFER_SIZE));
+    __CPROVER_assume(IMPLIES(buf2 != NULL, aws_byte_buf_is_bounded(buf2, MAX_BUFFER_SIZE)));
     ensure_byte_buf_has_allocated_buffer_member(buf2);
     __CPROVER_assume(aws_byte_buf_is_valid(buf2));
 

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
@@ -44,7 +44,7 @@ void aws_cryptosdk_private_commitment_eq_harness() {
     if (aws_cryptosdk_private_commitment_eq(buf1, buf2)) {
         assert(aws_byte_buf_contents_match(buf1, buf2));
     } else {
-        assert(buf1->len != 32 || !aws_byte_buf_contents_match(buf1, buf2));
+        assert(buf1->len != COMMITMENT_BUF_SIZE || !aws_byte_buf_contents_match(buf1, buf2));
     }
 
     /* Postconditions */

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// #include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_private_commitment_eq_harness() {
+    /* Nondet Input */
+    struct aws_byte_buf *buf1 = malloc(sizeof(*buf1));
+    struct aws_byte_buf *buf2 = malloc(sizeof(*buf2));
+
+    /* Assumptions */
+    __CPROVER_assume(buf1 != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(buf1, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(buf1);
+    __CPROVER_assume(aws_byte_buf_is_valid(buf1));
+
+    __CPROVER_assume(buf2 != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(buf2, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(buf2);
+    __CPROVER_assume(aws_byte_buf_is_valid(buf2));
+
+    /* Save current state of the data structures */
+    struct aws_byte_buf *old_buf1 = buf1;
+    struct store_byte_from_buffer old_byte_from_buf1;
+    save_byte_from_array(buf1->buffer, buf1->len, &old_byte_from_buf1);
+
+    struct aws_byte_buf *old_buf2 = buf2;
+    struct store_byte_from_buffer old_byte_from_buf2;
+    save_byte_from_array(buf2->buffer, buf2->len, &old_byte_from_buf2);
+
+    /* Operation under verification */
+    aws_cryptosdk_private_commitment_eq(buf1, buf2);
+
+    /* Postconditions */
+    assert(aws_byte_buf_is_valid(buf1));
+    assert_byte_buf_equivalence(buf1, old_buf1, &old_byte_from_buf1);
+    assert(aws_byte_buf_is_valid(buf2));
+    assert_byte_buf_equivalence(buf2, old_buf2, &old_byte_from_buf2);
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
@@ -13,8 +13,8 @@
  * permissions and limitations under the License.
  */
 
-// #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/cipher.h>
+#include <utils.h>
 #include <make_common_data_structures.h>
 
 void aws_cryptosdk_private_commitment_eq_harness() {
@@ -43,7 +43,8 @@ void aws_cryptosdk_private_commitment_eq_harness() {
     save_byte_from_array(buf2->buffer, buf2->len, &old_byte_from_buf2);
 
     /* Operation under verification */
-    aws_cryptosdk_private_commitment_eq(buf1, buf2);
+    if (aws_cryptosdk_private_commitment_eq(buf1, buf2))
+        assert_byte_buf_contents_are_equal(buf1, buf2);
 
     /* Postconditions */
     assert(aws_byte_buf_is_valid(buf1));

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/aws_cryptosdk_private_commitment_eq_harness.c
@@ -41,7 +41,11 @@ void aws_cryptosdk_private_commitment_eq_harness() {
     save_byte_from_array(buf2->buffer, buf2->len, &old_byte_from_buf2);
 
     /* Operation under verification */
-    if (aws_cryptosdk_private_commitment_eq(buf1, buf2)) assert_byte_buf_contents_are_equal(buf1, buf2);
+    if (aws_cryptosdk_private_commitment_eq(buf1, buf2)) {
+        assert(aws_byte_buf_contents_match(buf1, buf2));
+    } else {
+        assert(buf1->len != 32 || !aws_byte_buf_contents_match(buf1, buf2));
+    }
 
     /* Postconditions */
     assert(aws_byte_buf_is_valid(buf1));

--- a/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_commitment_eq/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
@@ -17,6 +17,7 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
+include ../Makefile.string
 
 PROOF_UID = aws_cryptosdk_private_derive_key
 

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
@@ -40,6 +40,7 @@ PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
 ###########
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
@@ -24,6 +24,12 @@ PROOF_UID = aws_cryptosdk_private_derive_key
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
+CBMCFLAGS +=
+
+# these are defined in cipher.c
+DEFINES += -DMSG_ID_LEN=16
+DEFINES += -DMSG_ID_LEN_V2=32
+
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/error.c

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+PROOF_UID = aws_cryptosdk_private_derive_key
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/error.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/bn_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/ec_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/evp_override.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher_openssl.c
+PROJECT_SOURCES += $(SRCDIR)/source/hkdf.c
+
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+###########
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/Makefile
@@ -18,7 +18,10 @@ sinclude ../Makefile.local
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 include ../Makefile.string
-
+###########
+# Maximum data key size, defined in cipher.c
+MAX_DATA_KEY_SIZE=32
+###########
 PROOF_UID = aws_cryptosdk_private_derive_key
 
 HARNESS_ENTRY = $(PROOF_UID)_harness
@@ -47,6 +50,8 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
+
+UNWINDSET += key_contents_match.0:$(call addone, $(MAX_DATA_KEY_SIZE))
 ###########
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
@@ -68,7 +68,7 @@ void aws_cryptosdk_private_derive_key_harness() {
             if (rv == AWS_CRYPTOSDK_ERR_UNSUPPORTED_FORMAT) {
                 assert(message_id->len != MSG_ID_LEN);
             } else if (rv == AWS_OP_SUCCESS && aws_cryptosdk_which_sha(props->alg_id) == AWS_CRYPTOSDK_NOSHA) {
-                assert_keys_are_equal(content_key, data_key, props->data_key_len);
+                assert(key_contents_match(content_key, data_key, props->data_key_len));
             }
         }
     } else if (props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_2_0) {

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
@@ -18,14 +18,13 @@
 #include <make_common_data_structures.h>
 
 void aws_cryptosdk_private_derive_key_harness() {
-    struct aws_cryptosdk_alg_properties *props = malloc(sizeof(*props));
-    struct content_key *content_key            = malloc(sizeof(*content_key));
-    struct data_key *data_key                  = malloc(sizeof(*data_key));
+    struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);
+    struct content_key *content_key            = ensure_content_key_attempt_allocation();
+    struct data_key *data_key                  = ensure_data_key_attempt_allocation();
     struct aws_byte_buf *message_id            = malloc(sizeof(*message_id));
     struct aws_byte_buf *commitment            = malloc(sizeof(*commitment));
 
     /* Assumptions */
-    ensure_alg_properties_attempt_allocation(props);
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
     __CPROVER_assume(content_key != NULL);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
@@ -15,7 +15,9 @@
 
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/cipher.h>
+#include <aws/cryptosdk/private/hkdf.h>
 #include <make_common_data_structures.h>
+#include <utils.h>
 
 void aws_cryptosdk_private_derive_key_harness() {
     struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -32,15 +32,15 @@ void aws_cryptosdk_private_derive_key_harness() {
 
     __CPROVER_assume(data_key != NULL);
 
-    __CPROVER_assume(message_id != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(message_id);
-    __CPROVER_assume(aws_byte_buf_is_valid(message_id));
-
     __CPROVER_assume(commitment != NULL);
     __CPROVER_assume(aws_byte_buf_is_bounded(commitment, MAX_BUFFER_SIZE));
     ensure_byte_buf_has_allocated_buffer_member(commitment);
     __CPROVER_assume(aws_byte_buf_is_valid(commitment));
+
+    __CPROVER_assume(message_id != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(message_id);
+    __CPROVER_assume(aws_byte_buf_is_valid(message_id));
 
     /* Save current state of the data structure */
     struct aws_byte_buf *old_commitment = commitment;

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_private_derive_key_harness() {
+    struct aws_cryptosdk_alg_properties *props = malloc(sizeof(*props));
+    struct content_key *content_key            = malloc(sizeof(*content_key));
+    struct data_key *data_key                  = malloc(sizeof(*data_key));
+    struct aws_byte_buf *message_id            = malloc(sizeof(*message_id));
+    struct aws_byte_buf *commitment            = malloc(sizeof(*commitment));
+
+    /* Assumptions */
+    ensure_alg_properties_attempt_allocation(props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
+
+    __CPROVER_assume(content_key != NULL);
+
+    __CPROVER_assume(data_key != NULL);
+
+    __CPROVER_assume(message_id != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(message_id);
+    __CPROVER_assume(aws_byte_buf_is_valid(message_id));
+
+    __CPROVER_assume(commitment != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(commitment, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(commitment);
+    __CPROVER_assume(aws_byte_buf_is_valid(commitment));
+
+    /* Save current state of the data structure */
+    struct aws_byte_buf *old_commitment = commitment;
+    struct store_byte_from_buffer old_byte_from_commitment;
+    save_byte_from_array(commitment->buffer, commitment->len, &old_byte_from_commitment);
+
+    struct aws_byte_buf *old_message_id = message_id;
+    struct store_byte_from_buffer old_byte_from_message_id;
+    save_byte_from_array(message_id->buffer, message_id->len, &old_byte_from_message_id);
+
+    /* Operation under verification */
+    aws_cryptosdk_private_derive_key(props, content_key, data_key, commitment, message_id);
+
+    /* Postconditions */
+    assert(aws_cryptosdk_alg_properties_is_valid(props));
+    assert(aws_byte_buf_is_valid(message_id));
+    assert_byte_buf_equivalence(message_id, old_message_id, &old_byte_from_message_id);
+    assert(aws_byte_buf_is_valid(commitment));
+    assert_byte_buf_equivalence(commitment, old_commitment, &old_byte_from_commitment);
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/aws_cryptosdk_private_derive_key_harness.c
@@ -29,28 +29,26 @@ void aws_cryptosdk_private_derive_key_harness() {
     /* Assumptions */
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
-    __CPROVER_assume(content_key != NULL);
+    __CPROVER_assume(aws_cryptosdk_content_key_is_valid(content_key));
 
-    __CPROVER_assume(data_key != NULL);
+    __CPROVER_assume(aws_cryptosdk_data_key_is_valid(data_key));
 
-    __CPROVER_assume(commitment != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(commitment, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(commitment);
-    __CPROVER_assume(aws_byte_buf_is_valid(commitment));
-
-    __CPROVER_assume(message_id != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));
+    __CPROVER_assume(IMPLIES(message_id != NULL, aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE)));
     ensure_byte_buf_has_allocated_buffer_member(message_id);
     __CPROVER_assume(aws_byte_buf_is_valid(message_id));
 
-    /* Save current state of the data structure */
-    struct aws_byte_buf *old_commitment = commitment;
-    struct store_byte_from_buffer old_byte_from_commitment;
-    save_byte_from_array(commitment->buffer, commitment->len, &old_byte_from_commitment);
+    __CPROVER_assume(IMPLIES(commitment != NULL, aws_byte_buf_is_bounded(commitment, MAX_BUFFER_SIZE)));
+    ensure_byte_buf_has_allocated_buffer_member(commitment);
+    __CPROVER_assume(aws_byte_buf_is_valid(commitment));
 
+    /* Save current state of the data structure */
     struct aws_byte_buf *old_message_id = message_id;
     struct store_byte_from_buffer old_byte_from_message_id;
     save_byte_from_array(message_id->buffer, message_id->len, &old_byte_from_message_id);
+
+    struct aws_byte_buf *old_commitment = commitment;
+    struct store_byte_from_buffer old_byte_from_commitment;
+    save_byte_from_array(commitment->buffer, commitment->len, &old_byte_from_commitment);
 
     /* Operation under verification */
     aws_cryptosdk_private_derive_key(props, content_key, data_key, commitment, message_id);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
@@ -18,7 +18,10 @@ sinclude ../Makefile.local
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 include ../Makefile.string
-
+###########
+# Maximum data key size, defined in cipher.c
+MAX_DATA_KEY_SIZE=32
+###########
 PROOF_UID = aws_cryptosdk_private_derive_key_v1
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
@@ -45,6 +48,8 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
+
+UNWINDSET += key_contents_match.0:$(call addone, $(MAX_DATA_KEY_SIZE))
 ###########
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
@@ -17,6 +17,7 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
+include ../Makefile.string
 
 PROOF_UID = aws_cryptosdk_private_derive_key_v1
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
@@ -41,6 +41,7 @@ PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/utils.c
 ###########
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+PROOF_UID = aws_cryptosdk_private_derive_key_v1
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+CBMCFLAGS +=
+
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/error.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/bn_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/ec_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/evp_override.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher_openssl.c
+PROJECT_SOURCES += $(SRCDIR)/source/hkdf.c
+
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+###########
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
@@ -25,6 +25,9 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 CBMCFLAGS +=
 
+# this is defined on cipher.c
+DEFINES += -DMSG_ID_LEN=16
+
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/error.c

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/Makefile
@@ -19,7 +19,6 @@ include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 
 PROOF_UID = aws_cryptosdk_private_derive_key_v1
-
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_private_derive_key_v1_harness() {
+    struct aws_cryptosdk_alg_properties *props = malloc(sizeof(*props));
+    struct content_key *content_key            = malloc(sizeof(*content_key));
+    struct data_key *data_key                  = malloc(sizeof(*data_key));
+    struct aws_byte_buf *message_id            = malloc(sizeof(*message_id));
+
+    /* Assumptions */
+    ensure_alg_properties_attempt_allocation(props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
+
+    __CPROVER_assume(content_key != NULL);
+
+    __CPROVER_assume(data_key != NULL);
+
+    __CPROVER_assume(message_id != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(message_id);
+    __CPROVER_assume(aws_byte_buf_is_valid(message_id));
+
+    // /* Save current state of the data structure */
+    struct aws_byte_buf *old_message_id = message_id;
+    struct store_byte_from_buffer old_byte_from_message_id;
+    save_byte_from_array(message_id->buffer, message_id->len, &old_byte_from_message_id);
+
+    /* Operation under verification */
+    __CPROVER_file_local_cipher_c_aws_cryptosdk_private_derive_key_v1(props, content_key, data_key, message_id);
+
+    /* Postconditions */
+    assert(aws_cryptosdk_alg_properties_is_valid(props));
+    assert(aws_byte_buf_is_valid(message_id));
+    assert_byte_buf_equivalence(message_id, old_message_id, &old_byte_from_message_id);
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
@@ -18,13 +18,12 @@
 #include <make_common_data_structures.h>
 
 void aws_cryptosdk_private_derive_key_v1_harness() {
-    struct aws_cryptosdk_alg_properties *props = malloc(sizeof(*props));
-    struct content_key *content_key            = malloc(sizeof(*content_key));
-    struct data_key *data_key                  = malloc(sizeof(*data_key));
+    struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);
+    struct content_key *content_key            = ensure_content_key_attempt_allocation();
+    struct data_key *data_key                  = ensure_data_key_attempt_allocation();
     struct aws_byte_buf *message_id            = malloc(sizeof(*message_id));
 
     /* Assumptions */
-    ensure_alg_properties_attempt_allocation(props);
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
     __CPROVER_assume(content_key != NULL);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
@@ -42,7 +42,8 @@ void aws_cryptosdk_private_derive_key_v1_harness() {
     save_byte_from_array(message_id->buffer, message_id->len, &old_byte_from_message_id);
 
     /* Operation under verification */
-    int rv = __CPROVER_file_local_cipher_c_aws_cryptosdk_private_derive_key_v1(props, content_key, data_key, message_id);
+    int rv =
+        __CPROVER_file_local_cipher_c_aws_cryptosdk_private_derive_key_v1(props, content_key, data_key, message_id);
 
     /* Postconditions */
     assert(aws_cryptosdk_alg_properties_is_valid(props));

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ void aws_cryptosdk_private_derive_key_v1_harness() {
     ensure_byte_buf_has_allocated_buffer_member(message_id);
     __CPROVER_assume(aws_byte_buf_is_valid(message_id));
 
-    // /* Save current state of the data structure */
+    /* Save current state of the data structure */
     struct aws_byte_buf *old_message_id = message_id;
     struct store_byte_from_buffer old_byte_from_message_id;
     save_byte_from_array(message_id->buffer, message_id->len, &old_byte_from_message_id);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
@@ -54,6 +54,6 @@ void aws_cryptosdk_private_derive_key_v1_harness() {
     if (rv == AWS_CRYPTOSDK_ERR_UNSUPPORTED_FORMAT) {
         assert(message_id->len != MSG_ID_LEN);
     } else if (rv == AWS_OP_SUCCESS && aws_cryptosdk_which_sha(props->alg_id) == AWS_CRYPTOSDK_NOSHA) {
-        assert_keys_are_equal(content_key, data_key, props->data_key_len);
+        assert(key_contents_match(content_key, data_key, props->data_key_len));
     }
 }

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
@@ -26,9 +26,9 @@ void aws_cryptosdk_private_derive_key_v1_harness() {
     /* Assumptions */
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
-    __CPROVER_assume(content_key != NULL);
+    __CPROVER_assume(aws_cryptosdk_content_key_is_valid(content_key));
 
-    __CPROVER_assume(data_key != NULL);
+    __CPROVER_assume(aws_cryptosdk_data_key_is_valid(data_key));
 
     __CPROVER_assume(message_id != NULL);
     __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
@@ -16,6 +16,7 @@
 #include <aws/cryptosdk/cipher.h>
 #include <aws/cryptosdk/private/cipher.h>
 #include <make_common_data_structures.h>
+#include <utils.h>
 
 void aws_cryptosdk_private_derive_key_v1_harness() {
     struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/aws_cryptosdk_private_derive_key_v1_harness.c
@@ -31,8 +31,7 @@ void aws_cryptosdk_private_derive_key_v1_harness() {
 
     __CPROVER_assume(aws_cryptosdk_data_key_is_valid(data_key));
 
-    __CPROVER_assume(message_id != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));
+    __CPROVER_assume(IMPLIES(message_id != NULL, aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE)));
     ensure_byte_buf_has_allocated_buffer_member(message_id);
     __CPROVER_assume(aws_byte_buf_is_valid(message_id));
 

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v1/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/Makefile
@@ -25,6 +25,9 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 CBMCFLAGS +=
 
+# this is defined on cipher.c
+DEFINES += -DMSG_ID_LEN_V2=32
+
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/error.c

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/Makefile
@@ -19,11 +19,10 @@ include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 
 PROOF_UID = aws_cryptosdk_private_derive_key_v2
-
-CBMCFLAGS +=
-
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
+
+CBMCFLAGS +=
 
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/Makefile
@@ -1,0 +1,46 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+
+PROOF_UID = aws_cryptosdk_private_derive_key_v2
+
+CBMCFLAGS +=
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/error.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/bn_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/ec_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/evp_override.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher_openssl.c
+PROJECT_SOURCES += $(SRCDIR)/source/hkdf.c
+
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+###########
+
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/Makefile
@@ -17,6 +17,7 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
+include ../Makefile.string
 
 PROOF_UID = aws_cryptosdk_private_derive_key_v2
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
@@ -18,14 +18,13 @@
 #include <make_common_data_structures.h>
 
 void aws_cryptosdk_private_derive_key_v2_harness() {
-    struct aws_cryptosdk_alg_properties *props = malloc(sizeof(*props));
-    struct content_key *content_key            = malloc(sizeof(*content_key));
-    struct data_key *data_key                  = malloc(sizeof(*data_key));
+    struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);
+    struct content_key *content_key            = ensure_content_key_attempt_allocation();
+    struct data_key *data_key                  = ensure_data_key_attempt_allocation();
     struct aws_byte_buf *message_id            = malloc(sizeof(*message_id));
     struct aws_byte_buf *commitment            = malloc(sizeof(*commitment));
 
     /* Assumptions */
-    ensure_alg_properties_attempt_allocation(props);
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
     __CPROVER_assume(content_key != NULL);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
@@ -50,7 +50,8 @@ void aws_cryptosdk_private_derive_key_v2_harness() {
     save_byte_from_array(message_id->buffer, message_id->len, &old_byte_from_message_id);
 
     /* Operation under verification */
-    int rv  = __CPROVER_file_local_cipher_c_aws_cryptosdk_private_derive_key_v2(props, content_key, data_key, commitment, message_id);
+    int rv = __CPROVER_file_local_cipher_c_aws_cryptosdk_private_derive_key_v2(
+        props, content_key, data_key, commitment, message_id);
 
     /* Postconditions */
     assert(aws_cryptosdk_alg_properties_is_valid(props));

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/cipher.h>
+#include <aws/cryptosdk/private/cipher.h>
+#include <make_common_data_structures.h>
+
+void aws_cryptosdk_private_derive_key_v2_harness() {
+    struct aws_cryptosdk_alg_properties *props = malloc(sizeof(*props));
+    struct content_key *content_key            = malloc(sizeof(*content_key));
+    struct data_key *data_key                  = malloc(sizeof(*data_key));
+    struct aws_byte_buf *message_id            = malloc(sizeof(*message_id));
+    struct aws_byte_buf *commitment            = malloc(sizeof(*commitment));
+
+    /* Assumptions */
+    ensure_alg_properties_attempt_allocation(props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
+
+    __CPROVER_assume(content_key != NULL);
+
+    __CPROVER_assume(data_key != NULL);
+
+    __CPROVER_assume(message_id != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(message_id);
+    __CPROVER_assume(aws_byte_buf_is_valid(message_id));
+
+    __CPROVER_assume(commitment != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(commitment, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(commitment);
+    __CPROVER_assume(aws_byte_buf_is_valid(commitment));
+
+    // /* Save current state of the data structure */
+    struct aws_byte_buf *old_commitment = commitment;
+    struct store_byte_from_buffer old_byte_from_commitment;
+    save_byte_from_array(commitment->buffer, commitment->len, &old_byte_from_commitment);
+
+    struct aws_byte_buf *old_message_id = message_id;
+    struct store_byte_from_buffer old_byte_from_message_id;
+    save_byte_from_array(message_id->buffer, message_id->len, &old_byte_from_message_id);
+
+    __CPROVER_file_local_cipher_c_aws_cryptosdk_private_derive_key_v2(
+        props, content_key, data_key, commitment, message_id);
+
+    /* Postconditions */
+    assert(aws_cryptosdk_alg_properties_is_valid(props));
+    assert(aws_byte_buf_is_valid(message_id));
+    assert_byte_buf_equivalence(message_id, old_message_id, &old_byte_from_message_id);
+    assert(aws_byte_buf_is_valid(commitment));
+    assert_byte_buf_equivalence(commitment, old_commitment, &old_byte_from_commitment);
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
@@ -31,13 +31,11 @@ void aws_cryptosdk_private_derive_key_v2_harness() {
 
     __CPROVER_assume(aws_cryptosdk_data_key_is_valid(data_key));
 
-    __CPROVER_assume(message_id != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));
+    __CPROVER_assume(IMPLIES(message_id != NULL, aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE)));
     ensure_byte_buf_has_allocated_buffer_member(message_id);
     __CPROVER_assume(aws_byte_buf_is_valid(message_id));
 
-    __CPROVER_assume(commitment != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(commitment, MAX_BUFFER_SIZE));
+    __CPROVER_assume(IMPLIES(commitment != NULL, aws_byte_buf_is_bounded(commitment, MAX_BUFFER_SIZE)));
     ensure_byte_buf_has_allocated_buffer_member(commitment);
     __CPROVER_assume(aws_byte_buf_is_valid(commitment));
 

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ void aws_cryptosdk_private_derive_key_v2_harness() {
     ensure_byte_buf_has_allocated_buffer_member(commitment);
     __CPROVER_assume(aws_byte_buf_is_valid(commitment));
 
-    // /* Save current state of the data structure */
+    /* Save current state of the data structure */
     struct aws_byte_buf *old_commitment = commitment;
     struct store_byte_from_buffer old_byte_from_commitment;
     save_byte_from_array(commitment->buffer, commitment->len, &old_byte_from_commitment);

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/aws_cryptosdk_private_derive_key_v2_harness.c
@@ -27,9 +27,9 @@ void aws_cryptosdk_private_derive_key_v2_harness() {
     /* Assumptions */
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
-    __CPROVER_assume(content_key != NULL);
+    __CPROVER_assume(aws_cryptosdk_content_key_is_valid(content_key));
 
-    __CPROVER_assume(data_key != NULL);
+    __CPROVER_assume(aws_cryptosdk_data_key_is_valid(data_key));
 
     __CPROVER_assume(message_id != NULL);
     __CPROVER_assume(aws_byte_buf_is_bounded(message_id, MAX_BUFFER_SIZE));

--- a/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_private_derive_key_v2/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/Makefile
@@ -16,6 +16,7 @@
 sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
+include ../Makefile.string
 
 PROOF_UID = aws_cryptosdk_serialize_frame
 

--- a/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -24,25 +24,25 @@ void aws_cryptosdk_serialize_frame_harness() {
     size_t ciphertext_size;
     size_t plaintext_size;
     struct aws_byte_buf ciphertext_buf;
-    struct aws_cryptosdk_alg_properties alg_props;
+    struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);
 
     /* Assumptions about the function input */
     ensure_byte_buf_has_allocated_buffer_member(&ciphertext_buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&ciphertext_buf));
 
     __CPROVER_assume(aws_cryptosdk_frame_has_valid_type(&frame));
-    ensure_alg_properties_attempt_allocation(&alg_props);
-    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(&alg_props));
+
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
     /* Save the old state of the ciphertext buffer */
     uint8_t *old_ciphertext_buffer   = ciphertext_buf.buffer;
     size_t old_ciphertext_buffer_len = ciphertext_buf.len;
 
-    int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, &alg_props);
+    int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, props);
     if (rval == AWS_OP_SUCCESS) {
         assert(aws_cryptosdk_frame_is_valid(&frame));
-        assert(aws_cryptosdk_alg_properties_is_valid(&alg_props));
-        assert(aws_cryptosdk_frame_serialized(&frame, &alg_props, plaintext_size));
+        assert(aws_cryptosdk_alg_properties_is_valid(props));
+        assert(aws_cryptosdk_frame_serialized(&frame, props, plaintext_size));
         assert(ciphertext_buf.buffer == old_ciphertext_buffer);
         assert(ciphertext_buf.len == old_ciphertext_buffer_len + ciphertext_size);
     } else {

--- a/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -38,8 +38,8 @@ void aws_cryptosdk_serialize_frame_harness() {
     uint8_t *old_ciphertext_buffer   = ciphertext_buf.buffer;
     size_t old_ciphertext_buffer_len = ciphertext_buf.len;
 
-    int rval = aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, props);
-    if (rval == AWS_OP_SUCCESS) {
+    if (aws_cryptosdk_serialize_frame(&frame, &ciphertext_size, plaintext_size, &ciphertext_buf, props) ==
+        AWS_OP_SUCCESS) {
         assert(aws_cryptosdk_frame_is_valid(&frame));
         assert(aws_cryptosdk_alg_properties_is_valid(props));
         assert(aws_cryptosdk_frame_serialized(&frame, props, plaintext_size));

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -31,13 +31,14 @@
 #include <proof_helpers/proof_allocators.h>
 
 void ensure_alg_properties_attempt_allocation(struct aws_cryptosdk_alg_properties *const alg_props) {
-    if (alg_props == NULL) return;
-    size_t md_name_size;
-    alg_props->md_name = malloc(md_name_size);
-    size_t cipher_name_size;
-    alg_props->cipher_name = malloc(cipher_name_size);
-    size_t alg_name_size;
-    alg_props->alg_name = malloc(alg_name_size);
+    if (alg_props) {
+        size_t md_name_size;
+        alg_props->md_name = malloc(md_name_size);
+        size_t cipher_name_size;
+        alg_props->cipher_name = malloc(cipher_name_size);
+        size_t alg_name_size;
+        alg_props->alg_name = malloc(alg_name_size);
+    }
 }
 
 void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len) {

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -32,12 +32,9 @@
 
 void ensure_alg_properties_attempt_allocation(struct aws_cryptosdk_alg_properties *const alg_props) {
     if (alg_props) {
-        size_t md_name_size;
-        alg_props->md_name = malloc(md_name_size);
-        size_t cipher_name_size;
-        alg_props->cipher_name = malloc(cipher_name_size);
-        size_t alg_name_size;
-        alg_props->alg_name = malloc(alg_name_size);
+        alg_props->md_name     = malloc(nondet_size_t());
+        alg_props->cipher_name = malloc(nondet_size_t());
+        alg_props->alg_name    = malloc(nondet_size_t());
     }
 }
 

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -31,12 +31,13 @@
 #include <proof_helpers/proof_allocators.h>
 
 void ensure_alg_properties_attempt_allocation(struct aws_cryptosdk_alg_properties *const alg_props) {
+    if (alg_props == NULL) return;
     size_t md_name_size;
-    alg_props->md_name = can_fail_malloc(md_name_size);
+    alg_props->md_name = malloc(md_name_size);
     size_t cipher_name_size;
-    alg_props->cipher_name = can_fail_malloc(cipher_name_size);
+    alg_props->cipher_name = malloc(cipher_name_size);
     size_t alg_name_size;
-    alg_props->alg_name = can_fail_malloc(alg_name_size);
+    alg_props->alg_name = malloc(alg_name_size);
 }
 
 void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len) {

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -30,12 +30,39 @@
 #include <proof_helpers/make_common_data_structures.h>
 #include <proof_helpers/proof_allocators.h>
 
-void ensure_alg_properties_attempt_allocation(struct aws_cryptosdk_alg_properties *const alg_props) {
-    if (alg_props) {
-        alg_props->md_name     = malloc(nondet_size_t());
-        alg_props->cipher_name = malloc(nondet_size_t());
-        alg_props->alg_name    = malloc(nondet_size_t());
+const EVP_MD *nondet_EVP_MD_ptr(void);
+const EVP_CIPHER *nondet_EVP_CIPHER_ptr(void);
+
+struct aws_cryptosdk_alg_impl *ensure_impl_attempt_allocation(const size_t max_len) {
+    struct aws_cryptosdk_alg_impl *impl = malloc(sizeof(struct aws_cryptosdk_alg_impl));
+    if (impl) {
+        *(const EVP_MD **)(&impl->md_ctor)         = (nondet_bool()) ? NULL : &nondet_EVP_MD_ptr;
+        *(const EVP_MD **)(&impl->sig_md_ctor)     = (nondet_bool()) ? NULL : &nondet_EVP_MD_ptr;
+        *(const EVP_CIPHER **)(&impl->cipher_ctor) = (nondet_bool()) ? NULL : &nondet_EVP_CIPHER_ptr;
+        *(const char **)(&impl->curve_name)        = ensure_c_str_is_allocated(max_len);
     }
+    return impl;
+}
+struct aws_cryptosdk_alg_properties *ensure_alg_properties_attempt_allocation(const size_t max_len) {
+    struct aws_cryptosdk_alg_properties *alg_props = malloc(sizeof(struct aws_cryptosdk_alg_properties));
+    if (alg_props) {
+        alg_props->md_name     = ensure_c_str_is_allocated(max_len);
+        alg_props->cipher_name = ensure_c_str_is_allocated(max_len);
+        alg_props->alg_name    = ensure_c_str_is_allocated(max_len);
+        alg_props->sig_md_name = ensure_c_str_is_allocated(max_len);
+        alg_props->impl        = malloc(sizeof(struct aws_cryptosdk_alg_impl));
+    }
+    return alg_props;
+}
+
+struct content_key *ensure_content_key_attempt_allocation() {
+    struct content_key *key = malloc(sizeof(uint8_t) * MAX_DATA_KEY_SIZE);
+    return key;
+}
+
+struct data_key *ensure_data_key_attempt_allocation() {
+    struct data_key *key = malloc(sizeof(uint8_t) * MAX_DATA_KEY_SIZE);
+    return key;
 }
 
 void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len) {

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -205,6 +205,8 @@ bool aws_cryptosdk_hdr_members_are_bounded(
 
 enum aws_cryptosdk_sha_version aws_cryptosdk_which_sha(enum aws_cryptosdk_alg_id alg_id) {
     switch (alg_id) {
+        case ALG_AES256_GCM_HKDF_SHA512_COMMIT_KEY_ECDSA_P384:
+        case ALG_AES256_GCM_HKDF_SHA512_COMMIT_KEY: return AWS_CRYPTOSDK_SHA512;
         case ALG_AES256_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384:
         case ALG_AES192_GCM_IV12_TAG16_HKDF_SHA384_ECDSA_P384: return AWS_CRYPTOSDK_SHA384;
         case ALG_AES128_GCM_IV12_TAG16_HKDF_SHA256_ECDSA_P256:

--- a/verification/cbmc/sources/utils.c
+++ b/verification/cbmc/sources/utils.c
@@ -1,0 +1,24 @@
+#include <utils.h>
+
+void assert_byte_buf_contents_are_equal(
+    const struct aws_byte_buf *const lhs,
+    const struct aws_byte_buf *const rhs) {
+    assert(lhs && rhs);
+    assert(lhs->len == rhs->len);
+    if (lhs->len > 0) {
+        size_t index;
+        __CPROVER_assume(index < lhs->len);
+        assert(lhs->buffer[index] == rhs->buffer[index]);
+    }
+}
+
+void assert_keys_are_equal(
+    const struct content_key *ckey,
+    const struct data_key *dkey,
+    const size_t max_len) {
+    assert(ckey && dkey);
+    assert(ckey->keybuf && dkey->keybuf);
+    size_t index;
+    __CPROVER_assume(index < max_len);
+    assert(ckey->keybuf[index] == dkey->keybuf[index]);
+}

--- a/verification/cbmc/sources/utils.c
+++ b/verification/cbmc/sources/utils.c
@@ -1,19 +1,28 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 #include <utils.h>
 
-void assert_byte_buf_contents_are_equal(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs) {
-    assert(lhs && rhs);
-    assert(lhs->len == rhs->len);
+bool aws_byte_buf_contents_match(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs) {
+    /* Filter null pointers */
+    if (!lhs || !rhs) return (lhs == rhs); /* Return true if both null */
+    if (lhs->len != rhs->len) return false;
     if (lhs->len > 0) {
-        size_t index;
-        __CPROVER_assume(index < lhs->len);
-        assert(lhs->buffer[index] == rhs->buffer[index]);
+        for (size_t i = 0; i < lhs->len; ++i) {
+            if (lhs->buffer[i] != rhs->buffer[i]) return false;
+        }
     }
+    return true;
 }
 
-void assert_keys_are_equal(const struct content_key *ckey, const struct data_key *dkey, const size_t max_len) {
-    assert(ckey && dkey);
-    assert(ckey->keybuf && dkey->keybuf);
-    size_t index;
-    __CPROVER_assume(index < max_len);
-    assert(ckey->keybuf[index] == dkey->keybuf[index]);
+bool key_contents_match(const struct content_key *ckey, const struct data_key *dkey, const size_t max_len) {
+    /* Filter null pointers */
+    if (!ckey || !dkey) return (ckey == dkey); /* Return true if both null */
+    if (!ckey->keybuf || !dkey->keybuf) return (ckey->keybuf == dkey->keybuf);
+    for (size_t i = 0; i < max_len; ++i) {
+        if (ckey->keybuf[i] != dkey->keybuf[i]) return false;
+    }
+    return true;
 }

--- a/verification/cbmc/sources/utils.c
+++ b/verification/cbmc/sources/utils.c
@@ -1,8 +1,6 @@
 #include <utils.h>
 
-void assert_byte_buf_contents_are_equal(
-    const struct aws_byte_buf *const lhs,
-    const struct aws_byte_buf *const rhs) {
+void assert_byte_buf_contents_are_equal(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs) {
     assert(lhs && rhs);
     assert(lhs->len == rhs->len);
     if (lhs->len > 0) {
@@ -12,10 +10,7 @@ void assert_byte_buf_contents_are_equal(
     }
 }
 
-void assert_keys_are_equal(
-    const struct content_key *ckey,
-    const struct data_key *dkey,
-    const size_t max_len) {
+void assert_keys_are_equal(const struct content_key *ckey, const struct data_key *dkey, const size_t max_len) {
     assert(ckey && dkey);
     assert(ckey->keybuf && dkey->keybuf);
     size_t index;

--- a/verification/cbmc/sources/utils.c
+++ b/verification/cbmc/sources/utils.c
@@ -5,6 +5,23 @@
 
 #include <utils.h>
 
+/*
+ * assert_byte_buf_contents_match is more efficient than assert(aws_byte_buf_contents_match) because
+ * we are using a nondeterministic index for comparison (instead of a loop). But if we want to assert
+ * the inverse (i.e., !assert_byte_buf_contents_match) then we have to use assert(!aws_byte_buf_contents_match)
+ * In fact, !assert_byte_buf_contents_match asserts that none of the bytes are equal
+ */
+void assert_byte_buf_contents_match(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs) {
+    /* Filter null pointers */
+    if (!lhs || !rhs) assert(lhs == rhs);
+    assert(lhs->len == rhs->len);
+    if (lhs->len > 0) {
+        size_t index;
+        __CPROVER_assume(index < lhs->len);
+        assert(lhs->buffer[index] == rhs->buffer[index]);
+    }
+}
+
 bool aws_byte_buf_contents_match(const struct aws_byte_buf *const lhs, const struct aws_byte_buf *const rhs) {
     /* Filter null pointers */
     if (!lhs || !rhs) return (lhs == rhs); /* Return true if both null */


### PR DESCRIPTION
This PR adds proofs for the following functions in cipher.c:
* aws_cryptosdk_private_algorithm_message_id_len
* aws_cryptosdk_private_commitment_eq
* aws_cryptosdk_private_derive_key
* aws_cryptosdk_private_derive_key_v1
* aws_cryptosdk_private_derive_key_v2

It also updates `ensure_alg_properties_attempt_allocation` to initialize pointers within alg_properties structures, adds two new utils function to compare byte_bufs and content/data keys.

Finally, it updates existing proofs that were failing due to changes introduced in nondet. allocation:
* aws_cryptosdk_serialize_frame

Proofs not breaking because of these changes should be updated regardless to follow the new allocation style for alg_properties. Issue created here: #660 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

