### PR TITLE
Update macos flag on github workflow

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-10.14, macos-latest]
+        os: [macOS-10.15, macos-latest]
         openssl_version: [openssl@1.1]
 
     steps:


### PR DESCRIPTION
This PR updates the github workflow file for macos to work with the latest version (solves #650)

I think we can also just set the flag to 'macos-latest' to avoid this behavior in the future. Let me know if you prefer that and I will update the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

