### PR TITLE
Add CBMC proof for derive_data_key

### DIFF
--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -95,6 +95,23 @@ struct aws_cryptosdk_session {
     bool cmm_success;
 };
 
+AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_session_is_valid(
+    const struct aws_cryptosdk_session *session) {
+    if (!AWS_OBJECT_PTR_IS_WRITABLE(session)) {
+        return false;
+    }
+    bool allocator_valid            = aws_allocator_is_valid(session->alloc);
+    bool cmm_valid                  = aws_cryptosdk_cmm_base_is_valid(session->cmm);
+    bool hdr_valid                  = aws_cryptosdk_hdr_is_valid(&session->header);
+    bool keyring_trace_valid        = aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace);
+    bool alg_props_valid            = aws_cryptosdk_alg_properties_is_valid(session->alg_props);
+    bool content_key_valid          = aws_cryptosdk_content_key_is_valid(&session->content_key);
+    bool key_commitment_valid       = aws_byte_buf_is_valid(&session->key_commitment);
+    bool signctx_valid = (session->signctx == NULL) || aws_cryptosdk_sig_ctx_is_valid(session->signctx);
+    return allocator_valid && cmm_valid && hdr_valid && keyring_trace_valid &&
+           alg_props_valid && content_key_valid && key_commitment_valid && signctx_valid;
+}
+
 /* Common session routines */
 
 void aws_cryptosdk_priv_session_change_state(struct aws_cryptosdk_session *session, enum session_state new_state);

--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -95,21 +95,20 @@ struct aws_cryptosdk_session {
     bool cmm_success;
 };
 
-AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_session_is_valid(
-    const struct aws_cryptosdk_session *session) {
+AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_session_is_valid(const struct aws_cryptosdk_session *session) {
     if (!AWS_OBJECT_PTR_IS_WRITABLE(session)) {
         return false;
     }
-    bool allocator_valid            = aws_allocator_is_valid(session->alloc);
-    bool cmm_valid                  = aws_cryptosdk_cmm_base_is_valid(session->cmm);
-    bool hdr_valid                  = aws_cryptosdk_hdr_is_valid(&session->header);
-    bool keyring_trace_valid        = aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace);
-    bool alg_props_valid            = aws_cryptosdk_alg_properties_is_valid(session->alg_props);
-    bool content_key_valid          = aws_cryptosdk_content_key_is_valid(&session->content_key);
-    bool key_commitment_valid       = aws_byte_buf_is_valid(&session->key_commitment);
-    bool signctx_valid = (session->signctx == NULL) || aws_cryptosdk_sig_ctx_is_valid(session->signctx);
-    return allocator_valid && cmm_valid && hdr_valid && keyring_trace_valid &&
-           alg_props_valid && content_key_valid && key_commitment_valid && signctx_valid;
+    bool allocator_valid      = aws_allocator_is_valid(session->alloc);
+    bool cmm_valid            = aws_cryptosdk_cmm_base_is_valid(session->cmm);
+    bool hdr_valid            = aws_cryptosdk_hdr_is_valid(&session->header);
+    bool keyring_trace_valid  = aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace);
+    bool alg_props_valid      = aws_cryptosdk_alg_properties_is_valid(session->alg_props);
+    bool content_key_valid    = aws_cryptosdk_content_key_is_valid(&session->content_key);
+    bool key_commitment_valid = aws_byte_buf_is_valid(&session->key_commitment);
+    bool signctx_valid        = (session->signctx == NULL) || aws_cryptosdk_sig_ctx_is_valid(session->signctx);
+    return allocator_valid && cmm_valid && hdr_valid && keyring_trace_valid && alg_props_valid && content_key_valid &&
+           key_commitment_valid && signctx_valid;
 }
 
 /* Common session routines */

--- a/source/session_decrypt.c
+++ b/source/session_decrypt.c
@@ -67,6 +67,11 @@ UNEXPECTED_ERROR:
 }
 
 static int derive_data_key(struct aws_cryptosdk_session *session, struct aws_cryptosdk_dec_materials *materials) {
+    AWS_PRECONDITION(session != NULL);
+    AWS_PRECONDITION(materials != NULL);
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(&session->header.message_id));
+    AWS_PRECONDITION(aws_byte_buf_is_valid(&session->header.alg_suite_data));
     AWS_PRECONDITION(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
 
     if (materials->unencrypted_data_key.len != session->alg_props->data_key_len) {

--- a/source/session_decrypt.c
+++ b/source/session_decrypt.c
@@ -67,12 +67,8 @@ UNEXPECTED_ERROR:
 }
 
 static int derive_data_key(struct aws_cryptosdk_session *session, struct aws_cryptosdk_dec_materials *materials) {
-    AWS_PRECONDITION(session != NULL);
-    AWS_PRECONDITION(materials != NULL);
-    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(&session->header.message_id));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(&session->header.alg_suite_data));
-    AWS_PRECONDITION(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
+    AWS_PRECONDITION(aws_cryptosdk_session_is_valid(session));
+    AWS_PRECONDITION(aws_cryptosdk_dec_materials_is_valid(materials));
 
     if (materials->unencrypted_data_key.len != session->alg_props->data_key_len) {
         return aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);

--- a/source/session_decrypt.c
+++ b/source/session_decrypt.c
@@ -67,6 +67,8 @@ UNEXPECTED_ERROR:
 }
 
 static int derive_data_key(struct aws_cryptosdk_session *session, struct aws_cryptosdk_dec_materials *materials) {
+    AWS_PRECONDITION(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
+
     if (materials->unencrypted_data_key.len != session->alg_props->data_key_len) {
         return aws_raise_error(AWS_CRYPTOSDK_ERR_CRYPTO_UNKNOWN);
     }
@@ -86,7 +88,7 @@ static int derive_data_key(struct aws_cryptosdk_session *session, struct aws_cry
     int rv = aws_cryptosdk_private_derive_key(
         session->alg_props, &session->content_key, &data_key, &expected_commitment, &session->header.message_id);
 
-    if (rv != 0) {
+    if (rv != AWS_OP_SUCCESS) {
         return aws_raise_error(rv);
     }
 

--- a/verification/cbmc/include/make_common_data_structures.h
+++ b/verification/cbmc/include/make_common_data_structures.h
@@ -34,6 +34,12 @@ struct data_key *ensure_data_key_attempt_allocation();
 /* Ensures content_key structures are properly allocated. */
 struct content_key *ensure_content_key_attempt_allocation();
 
+/* Allocates session members and ensures that internal pointers are pointing to the correct objects. */
+struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len);
+
+/* Allocates dec_materials members and ensures that internal pointers are pointing to the correct objects. */
+struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation();
+
 /* Allocates the members of the context and ensures that internal pointers are pointing to the correct objects. */
 void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ctx);
 

--- a/verification/cbmc/include/make_common_data_structures.h
+++ b/verification/cbmc/include/make_common_data_structures.h
@@ -34,12 +34,6 @@ struct data_key *ensure_data_key_attempt_allocation();
 /* Ensures content_key structures are properly allocated. */
 struct content_key *ensure_content_key_attempt_allocation();
 
-/* Allocates session members and ensures that internal pointers are pointing to the correct objects. */
-struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len);
-
-/* Allocates dec_materials members and ensures that internal pointers are pointing to the correct objects. */
-struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation();
-
 /* Allocates the members of the context and ensures that internal pointers are pointing to the correct objects. */
 void ensure_md_context_has_allocated_members(struct aws_cryptosdk_md_context *ctx);
 
@@ -81,3 +75,9 @@ void ensure_cryptosdk_keyring_has_allocated_members(
 void ensure_nondet_allocate_keyring_vtable_members(struct aws_cryptosdk_keyring_vt *vtable, size_t max_len);
 /* Non-deterministically allocates a aws_cryptosdk_cmm_vt structure with a valid name*/
 void ensure_nondet_allocate_cmm_vtable_members(struct aws_cryptosdk_cmm_vt *vtable, size_t max_len);
+
+/* Allocates session members and ensures that internal pointers are pointing to the correct objects. */
+struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len);
+
+/* Allocates dec_materials members and ensures that internal pointers are pointing to the correct objects. */
+struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation();

--- a/verification/cbmc/include/make_common_data_structures.h
+++ b/verification/cbmc/include/make_common_data_structures.h
@@ -76,8 +76,25 @@ void ensure_nondet_allocate_keyring_vtable_members(struct aws_cryptosdk_keyring_
 /* Non-deterministically allocates a aws_cryptosdk_cmm_vt structure with a valid name*/
 void ensure_nondet_allocate_cmm_vtable_members(struct aws_cryptosdk_cmm_vt *vtable, size_t max_len);
 
+/* Allocates cmm_vt members and ensures that internal pointers are pointing to the correct objects. */
+struct aws_cryptosdk_cmm_vt *ensure_cmm_vt_attempt_allocation(const size_t max_len);
+
+/* Allocates cmm members and ensures that internal pointers are pointing to the correct objects. */
+struct aws_cryptosdk_cmm *ensure_cmm_attempt_allocation(const size_t max_len);
+
 /* Allocates session members and ensures that internal pointers are pointing to the correct objects. */
-struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len);
+struct aws_cryptosdk_session *ensure_nondet_session_has_allocated_members(size_t max_len);
+
+bool aws_cryptosdk_session_members_are_bounded(
+    const struct aws_cryptosdk_session *session, const size_t max_trace_items, const size_t max_edk_item_size, const size_t max_item_size);
+
+struct aws_cryptosdk_session *session_setup(const size_t max_table_size, const size_t max_trace_items,
+ const size_t max_edk_item_size, const size_t max_item_size, const size_t max_len);
+
 
 /* Allocates dec_materials members and ensures that internal pointers are pointing to the correct objects. */
 struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation();
+
+bool aws_cryptosdk_dec_materials_members_are_bounded(
+    const struct aws_cryptosdk_dec_materials *materials, const size_t max_trace_items, const size_t max_item_size);
+struct aws_cryptosdk_dec_materials *dec_materials_setup(const size_t max_trace_items, const size_t max_item_size, const size_t max_len);

--- a/verification/cbmc/include/make_common_data_structures.h
+++ b/verification/cbmc/include/make_common_data_structures.h
@@ -86,15 +86,23 @@ struct aws_cryptosdk_cmm *ensure_cmm_attempt_allocation(const size_t max_len);
 struct aws_cryptosdk_session *ensure_nondet_session_has_allocated_members(size_t max_len);
 
 bool aws_cryptosdk_session_members_are_bounded(
-    const struct aws_cryptosdk_session *session, const size_t max_trace_items, const size_t max_edk_item_size, const size_t max_item_size);
+    const struct aws_cryptosdk_session *session,
+    const size_t max_trace_items,
+    const size_t max_edk_item_size,
+    const size_t max_item_size);
 
-struct aws_cryptosdk_session *session_setup(const size_t max_table_size, const size_t max_trace_items,
- const size_t max_edk_item_size, const size_t max_item_size, const size_t max_len);
-
+struct aws_cryptosdk_session *session_setup(
+    const size_t max_table_size,
+    const size_t max_trace_items,
+    const size_t max_edk_item_size,
+    const size_t max_item_size,
+    const size_t max_len);
 
 /* Allocates dec_materials members and ensures that internal pointers are pointing to the correct objects. */
 struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation();
 
 bool aws_cryptosdk_dec_materials_members_are_bounded(
     const struct aws_cryptosdk_dec_materials *materials, const size_t max_trace_items, const size_t max_item_size);
-struct aws_cryptosdk_dec_materials *dec_materials_setup(const size_t max_trace_items, const size_t max_item_size, const size_t max_len);
+
+struct aws_cryptosdk_dec_materials *dec_materials_setup(
+    const size_t max_trace_items, const size_t max_item_size, const size_t max_len);

--- a/verification/cbmc/proofs/derive_data_key/Makefile
+++ b/verification/cbmc/proofs/derive_data_key/Makefile
@@ -49,6 +49,12 @@ DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
 DEFINES += -DMSG_ID_LEN=16
 DEFINES += -DMSG_ID_LEN_V2=32
 
+# The maximum number of objects is set to 2^8 = 256. This option changes that to 2^9.
+# Without this flag, running this proof causes the CBMC error of
+# "too many addressed objects: maximum number of objects is set to 2^n=256 (with n=8);
+# use the `--object-bits n` option to increase the maximum number"
+CBMC_OBJECT_BITS ?= 9
+
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/hash_table.c

--- a/verification/cbmc/proofs/derive_data_key/Makefile
+++ b/verification/cbmc/proofs/derive_data_key/Makefile
@@ -31,6 +31,10 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 CBMCFLAGS +=
 
+# these are defined in cipher.c
+DEFINES += -DMSG_ID_LEN=16
+DEFINES += -DMSG_ID_LEN_V2=32
+
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
 PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/bn_override.c

--- a/verification/cbmc/proofs/derive_data_key/Makefile
+++ b/verification/cbmc/proofs/derive_data_key/Makefile
@@ -31,17 +31,38 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 CBMCFLAGS +=
 
+# Values are chosen for performance. 
+# Increasing either does not increase the coverage.
+MAX_TRACE_LIST_ITEMS ?= 1
+MAX_EDK_LIST_ITEMS ?= 1
+MAX_TABLE_SIZE ?= 2
+
+DEFINES += -DARRAY_LIST_TYPE="struct aws_cryptosdk_edk"
+DEFINES += -DARRAY_LIST_TYPE_HEADER=\"aws/cryptosdk/edk.h\"
+DEFINES += -DAWS_CRYPTOSDK_HASH_ELEMS_ARRAY_INIT_GENERATOR=array_list_item_generator
+DEFINES += -DAWS_NO_STATIC_IMPL
+DEFINES += -DMAX_TRACE_LIST_ITEMS=$(MAX_TRACE_LIST_ITEMS)
+DEFINES += -DMAX_EDK_LIST_ITEMS=$(MAX_EDK_LIST_ITEMS)
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
+
 # these are defined in cipher.c
 DEFINES += -DMSG_ID_LEN=16
 DEFINES += -DMSG_ID_LEN_V2=32
 
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/hash_table.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/array_list.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/error.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/math.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/string.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/atomics.c
 PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/bn_override.c
 PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/ec_override.c
 PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/evp_override.c
 PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
 PROJECT_SOURCES += $(SRCDIR)/source/cipher_openssl.c
+PROJECT_SOURCES += $(SRCDIR)/source/edk.c
 PROJECT_SOURCES += $(SRCDIR)/source/header.c
 PROJECT_SOURCES += $(SRCDIR)/source/hkdf.c
 PROJECT_SOURCES += $(SRCDIR)/source/keyring_trace.c
@@ -51,10 +72,20 @@ PROJECT_SOURCES += $(SRCDIR)/source/session_decrypt.c
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
+# PROOF_SOURCES += $(COMMON_PROOF_STUB)/aws_array_list_defined_type.c
 PROOF_SOURCES += $(COMMON_PROOF_STUB)/error.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
 
 UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMITMENT_EQ_ITERATIONS))
+UNWINDSET += array_list_item_generator.0:$(call addone,$(MAX_TABLE_SIZE))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_bounded.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_valid.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
+UNWINDSET += aws_cryptosdk_enc_ctx_serialize.0:$(call addone,$(MAX_TABLE_SIZE))
+UNWINDSET += aws_cryptosdk_hdr_write.0:$(call addone,$(MAX_EDK_LIST_ITEMS)) 
+UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_list_elements.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
+UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
+UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
+
 ###########
 include ../Makefile.common

--- a/verification/cbmc/proofs/derive_data_key/Makefile
+++ b/verification/cbmc/proofs/derive_data_key/Makefile
@@ -17,10 +17,12 @@ sinclude ../Makefile.local
 #otherwise, use the default values
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
+include ../Makefile.string
 #########
-# Local vars
-COMMIT_BYTES_NUM = 4
-
+# In aws_cryptosdk_private_commitment_eq, two commitment values are
+# compared in a loop with (32 / sizeof(uintptr_t)) iterations.
+# (32 / sizeof(uintptr_t)) equals 4 since sizeof(uintptr_t) is 8UL
+COMMITMENT_EQ_ITERATIONS = 4
 #########
 PROOF_UID = derive_data_key
 
@@ -31,6 +33,7 @@ CBMCFLAGS +=
 
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/bn_override.c
 PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/ec_override.c
 PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/evp_override.c
 PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
@@ -48,6 +51,6 @@ PROOF_SOURCES += $(COMMON_PROOF_STUB)/error.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
 
-UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMIT_BYTES_NUM))
+UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMITMENT_EQ_ITERATIONS))
 ###########
 include ../Makefile.common

--- a/verification/cbmc/proofs/derive_data_key/Makefile
+++ b/verification/cbmc/proofs/derive_data_key/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 # this file except in compliance with the License. A copy of the License is

--- a/verification/cbmc/proofs/derive_data_key/Makefile
+++ b/verification/cbmc/proofs/derive_data_key/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.aws_byte_buf
+#########
+# Local vars
+COMMIT_BYTES_NUM = 4
+
+#########
+PROOF_UID = derive_data_key
+
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+CBMCFLAGS +=
+
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/ec_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/evp_override.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher_openssl.c
+PROJECT_SOURCES += $(SRCDIR)/source/header.c
+PROJECT_SOURCES += $(SRCDIR)/source/hkdf.c
+PROJECT_SOURCES += $(SRCDIR)/source/keyring_trace.c
+PROJECT_SOURCES += $(SRCDIR)/source/session.c
+PROJECT_SOURCES += $(SRCDIR)/source/session_decrypt.c
+
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/error.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+
+UNWINDSET += aws_cryptosdk_private_commitment_eq.0:$(call addone, $(COMMIT_BYTES_NUM))
+###########
+include ../Makefile.common

--- a/verification/cbmc/proofs/derive_data_key/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/derive_data_key/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
+++ b/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
@@ -25,16 +25,14 @@
 
 void derive_data_key_harness() {
     /* Nondet input */
-    struct aws_cryptosdk_session *session         = malloc(sizeof(*session));
-    struct aws_cryptosdk_dec_materials *materials = malloc(sizeof(*materials));
+    struct aws_cryptosdk_session *session         = ensure_session_attempt_allocation(MAX_STRING_LEN);
+    struct aws_cryptosdk_dec_materials *materials = ensure_dec_materials_attempt_allocation();
 
     /* Assumptions */
     __CPROVER_assume(session != NULL);
     __CPROVER_assume(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
 
-    session->alg_props = malloc(sizeof(*session->alg_props));
     __CPROVER_assume(session->alg_props != NULL);
-    ensure_alg_properties_attempt_allocation(session->alg_props);
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
     __CPROVER_assume(session->alg_props->commitment_len <= sizeof(session->key_commitment_arr));
 

--- a/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
+++ b/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
@@ -25,8 +25,10 @@
 
 void derive_data_key_harness() {
     /* Setup functions include nondet. allocation and common assumptions */
-    struct aws_cryptosdk_session *session         = session_setup(MAX_TABLE_SIZE, MAX_TRACE_LIST_ITEMS, MAX_EDK_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
-    struct aws_cryptosdk_dec_materials *materials = dec_materials_setup(MAX_TRACE_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
+    struct aws_cryptosdk_session *session =
+        session_setup(MAX_TABLE_SIZE, MAX_TRACE_LIST_ITEMS, MAX_EDK_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
+    struct aws_cryptosdk_dec_materials *materials =
+        dec_materials_setup(MAX_TRACE_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
 
     /* Assumptions */
     __CPROVER_assume(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));

--- a/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
+++ b/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
@@ -78,8 +78,9 @@ void derive_data_key_harness() {
             }
         } else if (session->alg_props->msg_format_version == AWS_CRYPTOSDK_HEADER_VERSION_2_0) {
             if (last_err == AWS_CRYPTOSDK_ERR_UNSUPPORTED_FORMAT) {
-                assert(session->header.message_id.len != MSG_ID_LEN_V2 ||
-                        aws_cryptosdk_which_sha(session->alg_props->alg_id) == AWS_CRYPTOSDK_NOSHA);
+                assert(
+                    session->header.message_id.len != MSG_ID_LEN_V2 ||
+                    aws_cryptosdk_which_sha(session->alg_props->alg_id) == AWS_CRYPTOSDK_NOSHA);
             }
         }
     }

--- a/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
+++ b/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/cipher.h>
+#include <aws/cryptosdk/private/header.h>
+#include <aws/cryptosdk/private/hkdf.h>
+#include <aws/cryptosdk/private/session.h>
+#include <aws/cryptosdk/session.h>
+#include <make_common_data_structures.h>
+
+void derive_data_key_harness() {
+    /* Nondet input */
+    struct aws_cryptosdk_session *session         = malloc(sizeof(*session));
+    struct aws_cryptosdk_dec_materials *materials = malloc(sizeof(*materials));
+
+    /* Assumptions */
+    __CPROVER_assume(session != NULL);
+    __CPROVER_assume(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
+
+    session->alg_props = malloc(sizeof(*session->alg_props));
+    __CPROVER_assume(session->alg_props != NULL);
+    ensure_alg_properties_attempt_allocation(session->alg_props);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
+    __CPROVER_assume(session->alg_props->commitment_len <= sizeof(session->key_commitment_arr));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&session->header.message_id, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&session->header.message_id);
+    __CPROVER_assume(aws_byte_buf_is_valid(&session->header.message_id));
+
+    __CPROVER_assume(aws_byte_buf_is_bounded(&session->header.alg_suite_data, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&session->header.alg_suite_data);
+    __CPROVER_assume(aws_byte_buf_is_valid(&session->header.alg_suite_data));
+
+    __CPROVER_assume(materials != NULL);
+    __CPROVER_assume(aws_byte_buf_is_bounded(&materials->unencrypted_data_key, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&materials->unencrypted_data_key);
+    __CPROVER_assume(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
+
+    /* Save current state of the data structures */
+    struct aws_byte_buf *old_message_id = &session->header.message_id;
+    struct store_byte_from_buffer old_byte_from_message_id;
+    save_byte_from_array(session->header.message_id.buffer, session->header.message_id.len, &old_byte_from_message_id);
+
+    struct aws_byte_buf *old_alg_suite_data = &session->header.alg_suite_data;
+    struct store_byte_from_buffer old_byte_from_alg_suite_data;
+    save_byte_from_array(
+        session->header.alg_suite_data.buffer, session->header.alg_suite_data.len, &old_byte_from_alg_suite_data);
+
+    struct aws_byte_buf *old_unencrypted_data_key = &materials->unencrypted_data_key;
+    struct store_byte_from_buffer old_byte_from_unencrypted_data_key;
+    save_byte_from_array(
+        materials->unencrypted_data_key.buffer,
+        materials->unencrypted_data_key.len,
+        &old_byte_from_unencrypted_data_key);
+
+    /* Operation under verification */
+    __CPROVER_file_local_session_decrypt_c_derive_data_key(session, materials);
+
+    /* Postconditions */
+    assert(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
+    assert(aws_byte_buf_is_valid(&session->header.alg_suite_data));
+    assert_byte_buf_equivalence(&session->header.alg_suite_data, old_alg_suite_data, &old_byte_from_alg_suite_data);
+    assert(aws_byte_buf_is_valid(&session->header.message_id));
+    assert_byte_buf_equivalence(&session->header.message_id, old_message_id, &old_byte_from_message_id);
+    assert(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
+    assert_byte_buf_equivalence(
+        &materials->unencrypted_data_key, old_unencrypted_data_key, &old_byte_from_unencrypted_data_key);
+}

--- a/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
+++ b/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
@@ -24,30 +24,13 @@
 #include <make_common_data_structures.h>
 
 void derive_data_key_harness() {
-    /* Nondet input */
-    struct aws_cryptosdk_session *session         = ensure_session_attempt_allocation(MAX_STRING_LEN);
-    struct aws_cryptosdk_dec_materials *materials = ensure_dec_materials_attempt_allocation();
+    /* Setup functions include nondet. allocation and common assumptions */
+    struct aws_cryptosdk_session *session         = session_setup(MAX_TABLE_SIZE, MAX_TRACE_LIST_ITEMS, MAX_EDK_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
+    struct aws_cryptosdk_dec_materials *materials = dec_materials_setup(MAX_TRACE_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
 
     /* Assumptions */
-    __CPROVER_assume(session != NULL);
     __CPROVER_assume(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
-
-    __CPROVER_assume(session->alg_props != NULL);
-    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
     __CPROVER_assume(session->alg_props->commitment_len <= sizeof(session->key_commitment_arr));
-
-    __CPROVER_assume(aws_byte_buf_is_bounded(&session->header.message_id, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(&session->header.message_id);
-    __CPROVER_assume(aws_byte_buf_is_valid(&session->header.message_id));
-
-    __CPROVER_assume(aws_byte_buf_is_bounded(&session->header.alg_suite_data, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(&session->header.alg_suite_data);
-    __CPROVER_assume(aws_byte_buf_is_valid(&session->header.alg_suite_data));
-
-    __CPROVER_assume(materials != NULL);
-    __CPROVER_assume(aws_byte_buf_is_bounded(&materials->unencrypted_data_key, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(&materials->unencrypted_data_key);
-    __CPROVER_assume(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
 
     /* Save current state of the data structures */
     struct aws_byte_buf *old_message_id = &session->header.message_id;
@@ -84,12 +67,10 @@ void derive_data_key_harness() {
             }
         }
     }
-    assert(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
-    assert(aws_byte_buf_is_valid(&session->header.alg_suite_data));
+    assert(aws_cryptosdk_session_is_valid(session));
+    assert(aws_cryptosdk_dec_materials_is_valid(materials));
     assert_byte_buf_equivalence(&session->header.alg_suite_data, old_alg_suite_data, &old_byte_from_alg_suite_data);
-    assert(aws_byte_buf_is_valid(&session->header.message_id));
     assert_byte_buf_equivalence(&session->header.message_id, old_message_id, &old_byte_from_message_id);
-    assert(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
     assert_byte_buf_equivalence(
         &materials->unencrypted_data_key, old_unencrypted_data_key, &old_byte_from_unencrypted_data_key);
 }

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -79,9 +79,10 @@ void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_reco
 }
 
 void ensure_trace_has_allocated_records(struct aws_array_list *trace, size_t max_len) {
+    struct aws_cryptosdk_keyring_trace_record *data;
     /* iterate over each record in the keyring trace */
     for (size_t i = 0; i < trace->length; ++i) {
-        struct aws_cryptosdk_keyring_trace_record *data = (struct aws_cryptosdk_keyring_trace_record *)trace->data;
+        data = (struct aws_cryptosdk_keyring_trace_record *)trace->data;
         ensure_record_has_allocated_members(&(data[i]), max_len);
     }
 }

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -51,7 +51,7 @@ struct aws_cryptosdk_alg_properties *ensure_alg_properties_attempt_allocation(co
         alg_props->cipher_name = ensure_c_str_is_allocated(max_len);
         alg_props->alg_name    = ensure_c_str_is_allocated(max_len);
         alg_props->sig_md_name = ensure_c_str_is_allocated(max_len);
-        alg_props->impl        = malloc(sizeof(struct aws_cryptosdk_alg_impl));
+        alg_props->impl        = ensure_impl_attempt_allocation(max_len);
     }
     return alg_props;
 }
@@ -80,13 +80,9 @@ void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_reco
 
 void ensure_trace_has_allocated_records(struct aws_array_list *trace, size_t max_len) {
     /* iterate over each record in the keyring trace */
-    size_t num_records = aws_array_list_length(trace);
-    for (size_t idx = 0; idx < num_records; ++idx) {
-        struct aws_cryptosdk_keyring_trace_record *record;
-        if (!aws_array_list_get_at_ptr(trace, (void **)&record, idx)) {
-            /* make sure each record is valid */
-            ensure_record_has_allocated_members(record, max_len);
-        }
+    for (size_t i = 0; i < trace->length; ++i) {
+        struct aws_cryptosdk_keyring_trace_record *data = (struct aws_cryptosdk_keyring_trace_record *)trace->data;
+        ensure_record_has_allocated_members(&(data[i]), max_len);
     }
 }
 
@@ -175,6 +171,18 @@ void ensure_cryptosdk_edk_list_has_allocated_list_elements(struct aws_array_list
     }
 }
 
+void ensure_nondet_hdr_has_allocated_members_ref(struct aws_cryptosdk_hdr *hdr, const size_t max_table_size) {
+    if (hdr) {
+        hdr->alloc = nondet_bool() ? NULL : can_fail_allocator();
+        ensure_byte_buf_has_allocated_buffer_member(&hdr->iv);
+        ensure_byte_buf_has_allocated_buffer_member(&hdr->auth_tag);
+        ensure_byte_buf_has_allocated_buffer_member(&hdr->message_id);
+        ensure_byte_buf_has_allocated_buffer_member(&hdr->alg_suite_data);
+        ensure_allocated_hash_table(&hdr->enc_ctx, max_table_size);
+        ensure_cryptosdk_edk_list_has_allocated_list(&hdr->edk_list);
+    }
+}
+
 struct aws_cryptosdk_hdr *ensure_nondet_hdr_has_allocated_members(const size_t max_table_size) {
     struct aws_cryptosdk_hdr *hdr = malloc(sizeof(*hdr));
     if (hdr != NULL) {
@@ -255,23 +263,98 @@ void ensure_nondet_allocate_cmm_vtable_members(struct aws_cryptosdk_cmm_vt *vtab
     }
 }
 
-struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len) {
+struct aws_cryptosdk_cmm_vt *ensure_cmm_vt_attempt_allocation(const size_t max_len) {
+    struct aws_cryptosdk_cmm_vt *vtable = malloc(sizeof(struct aws_cryptosdk_cmm_vt));
+    if (vtable) {
+        vtable->name                   = ensure_c_str_is_allocated(max_len);
+        vtable->destroy                = nondet_voidp();
+        vtable->generate_enc_materials = nondet_voidp();
+        vtable->decrypt_materials      = nondet_voidp();
+    }
+    return vtable;
+}
+
+struct aws_cryptosdk_cmm *ensure_cmm_attempt_allocation(const size_t max_len) {
+    struct aws_cryptosdk_cmm *cmm = malloc(sizeof(struct aws_cryptosdk_cmm));
+    if (cmm) {
+        cmm->vtable = ensure_cmm_vt_attempt_allocation(max_len);
+        cmm->refcount.value = malloc(sizeof(size_t));
+    }
+    return cmm;
+}
+
+struct aws_cryptosdk_session *ensure_nondet_session_has_allocated_members(const size_t max_table_size, size_t max_len) {
     struct aws_cryptosdk_session *session = malloc(sizeof(struct aws_cryptosdk_session));
     if (session) {
         session->alloc       = nondet_bool() ? NULL : can_fail_allocator();
-        session->cmm         = malloc(sizeof(struct aws_cryptosdk_cmm));
-        session->header_copy = malloc(sizeof(uint8_t));
+        session->cmm         = ensure_cmm_attempt_allocation(max_len);
+        session->header_copy = malloc(sizeof(*(session->header_copy)));
         session->alg_props   = ensure_alg_properties_attempt_allocation(max_len);
         session->signctx     = ensure_nondet_sig_ctx_has_allocated_members();
+        ensure_byte_buf_has_allocated_buffer_member(&session->key_commitment);
+        ensure_array_list_has_allocated_data_member(&session->keyring_trace);
+        ensure_nondet_hdr_has_allocated_members_ref(&session->header, max_table_size);
     }
     return session;
 }
 
+bool aws_cryptosdk_session_members_are_bounded(
+    const struct aws_cryptosdk_session *session, const size_t max_trace_items, const size_t max_edk_item_size, const size_t max_item_size) {
+    if (session != NULL) {
+        return aws_cryptosdk_hdr_members_are_bounded(&session->header, max_edk_item_size, max_item_size) &&
+               aws_byte_buf_is_bounded(&session->key_commitment, max_item_size) &&
+               aws_array_list_is_bounded(&session->keyring_trace, max_trace_items, sizeof(struct aws_cryptosdk_keyring_trace_record)) &&
+               session->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record);
+    }
+    return true; /* If hdr is NULL, true by default */
+}
+
+struct aws_cryptosdk_session *session_setup(const size_t max_table_size, const size_t max_trace_items,
+ const size_t max_edk_item_size, const size_t max_item_size, const size_t max_len) {
+    struct aws_cryptosdk_session *session = ensure_nondet_session_has_allocated_members(max_table_size, max_len);
+    __CPROVER_assume(aws_cryptosdk_session_members_are_bounded(session, max_trace_items, max_edk_item_size, max_item_size));
+    
+    /* Precondition: The keyring trace has allocated records */
+    if (session) {
+        __CPROVER_assume(aws_array_list_is_valid(&session->keyring_trace));
+        ensure_trace_has_allocated_records(&session->keyring_trace, max_len);
+    }
+    /* Precondition: The edk list has allocated list elements */
+    ensure_cryptosdk_edk_list_has_allocated_list_elements(&session->header.edk_list);
+
+    __CPROVER_assume(aws_cryptosdk_session_is_valid(session));
+    return session;
+}
+
+bool aws_cryptosdk_dec_materials_members_are_bounded(
+    const struct aws_cryptosdk_dec_materials *materials, const size_t max_trace_items, const size_t max_item_size) {
+    if (materials != NULL) {
+        return aws_byte_buf_is_bounded(&materials->unencrypted_data_key, max_item_size) &&
+               aws_array_list_is_bounded(&materials->keyring_trace, max_trace_items, sizeof(struct aws_cryptosdk_keyring_trace_record)) &&
+               materials->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record);
+    }
+    return true;
+}
 struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation() {
     struct aws_cryptosdk_dec_materials *materials = malloc(sizeof(struct aws_cryptosdk_dec_materials));
     if (materials) {
         materials->alloc   = nondet_bool() ? NULL : can_fail_allocator();
         materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
+        ensure_byte_buf_has_allocated_buffer_member(&materials->unencrypted_data_key);
+        ensure_array_list_has_allocated_data_member(&materials->keyring_trace);
     }
+    return materials;
+}
+
+ struct aws_cryptosdk_dec_materials *dec_materials_setup(const size_t max_trace_items, const size_t max_item_size, const size_t max_len) {
+    struct aws_cryptosdk_dec_materials *materials = ensure_dec_materials_attempt_allocation();
+    __CPROVER_assume(aws_cryptosdk_dec_materials_members_are_bounded(materials, max_trace_items, max_item_size));
+
+    /* Precondition: The keyring trace has allocated records */
+    if (materials) {
+        __CPROVER_assume(aws_array_list_is_valid(&materials->keyring_trace));
+        ensure_trace_has_allocated_records(&materials->keyring_trace, max_len);
+    }
+    __CPROVER_assume(aws_cryptosdk_dec_materials_is_valid(materials));
     return materials;
 }

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -270,7 +270,7 @@ struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len) 
 struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation() {
     struct aws_cryptosdk_dec_materials *materials = malloc(sizeof(struct aws_cryptosdk_dec_materials));
     if (materials) {
-        materials->alloc = nondet_bool() ? NULL : can_fail_allocator();
+        materials->alloc   = nondet_bool() ? NULL : can_fail_allocator();
         materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
     }
     return materials;

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -73,7 +73,7 @@ struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len) 
         session->cmm         = malloc(sizeof(struct aws_cryptosdk_cmm));
         session->header_copy = malloc(sizeof(uint8_t));
         session->alg_props   = ensure_alg_properties_attempt_allocation(max_len);
-        session->signctx     = ensure_nondet_sig_ctx_has_allocated_members();
+        // session->signctx     = ensure_nondet_sig_ctx_has_allocated_members();
     }
     return session;
 }
@@ -81,8 +81,8 @@ struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len) 
 struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation() {
     struct aws_cryptosdk_dec_materials *materials = malloc(sizeof(struct aws_cryptosdk_dec_materials));
     if (materials) {
-        materials->alloc   = nondet_bool() ? NULL : can_fail_allocator();
-        materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
+        materials->alloc = nondet_bool() ? NULL : can_fail_allocator();
+        // materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
     }
     return materials;
 }

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -277,7 +277,7 @@ struct aws_cryptosdk_cmm_vt *ensure_cmm_vt_attempt_allocation(const size_t max_l
 struct aws_cryptosdk_cmm *ensure_cmm_attempt_allocation(const size_t max_len) {
     struct aws_cryptosdk_cmm *cmm = malloc(sizeof(struct aws_cryptosdk_cmm));
     if (cmm) {
-        cmm->vtable = ensure_cmm_vt_attempt_allocation(max_len);
+        cmm->vtable         = ensure_cmm_vt_attempt_allocation(max_len);
         cmm->refcount.value = malloc(sizeof(size_t));
     }
     return cmm;
@@ -299,21 +299,30 @@ struct aws_cryptosdk_session *ensure_nondet_session_has_allocated_members(const 
 }
 
 bool aws_cryptosdk_session_members_are_bounded(
-    const struct aws_cryptosdk_session *session, const size_t max_trace_items, const size_t max_edk_item_size, const size_t max_item_size) {
+    const struct aws_cryptosdk_session *session,
+    const size_t max_trace_items,
+    const size_t max_edk_item_size,
+    const size_t max_item_size) {
     if (session != NULL) {
         return aws_cryptosdk_hdr_members_are_bounded(&session->header, max_edk_item_size, max_item_size) &&
                aws_byte_buf_is_bounded(&session->key_commitment, max_item_size) &&
-               aws_array_list_is_bounded(&session->keyring_trace, max_trace_items, sizeof(struct aws_cryptosdk_keyring_trace_record)) &&
+               aws_array_list_is_bounded(
+                   &session->keyring_trace, max_trace_items, sizeof(struct aws_cryptosdk_keyring_trace_record)) &&
                session->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record);
     }
     return true; /* If hdr is NULL, true by default */
 }
 
-struct aws_cryptosdk_session *session_setup(const size_t max_table_size, const size_t max_trace_items,
- const size_t max_edk_item_size, const size_t max_item_size, const size_t max_len) {
+struct aws_cryptosdk_session *session_setup(
+    const size_t max_table_size,
+    const size_t max_trace_items,
+    const size_t max_edk_item_size,
+    const size_t max_item_size,
+    const size_t max_len) {
     struct aws_cryptosdk_session *session = ensure_nondet_session_has_allocated_members(max_table_size, max_len);
-    __CPROVER_assume(aws_cryptosdk_session_members_are_bounded(session, max_trace_items, max_edk_item_size, max_item_size));
-    
+    __CPROVER_assume(
+        aws_cryptosdk_session_members_are_bounded(session, max_trace_items, max_edk_item_size, max_item_size));
+
     /* Precondition: The keyring trace has allocated records */
     if (session) {
         __CPROVER_assume(aws_array_list_is_valid(&session->keyring_trace));
@@ -330,7 +339,8 @@ bool aws_cryptosdk_dec_materials_members_are_bounded(
     const struct aws_cryptosdk_dec_materials *materials, const size_t max_trace_items, const size_t max_item_size) {
     if (materials != NULL) {
         return aws_byte_buf_is_bounded(&materials->unencrypted_data_key, max_item_size) &&
-               aws_array_list_is_bounded(&materials->keyring_trace, max_trace_items, sizeof(struct aws_cryptosdk_keyring_trace_record)) &&
+               aws_array_list_is_bounded(
+                   &materials->keyring_trace, max_trace_items, sizeof(struct aws_cryptosdk_keyring_trace_record)) &&
                materials->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record);
     }
     return true;
@@ -346,7 +356,8 @@ struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation() {
     return materials;
 }
 
- struct aws_cryptosdk_dec_materials *dec_materials_setup(const size_t max_trace_items, const size_t max_item_size, const size_t max_len) {
+struct aws_cryptosdk_dec_materials *dec_materials_setup(
+    const size_t max_trace_items, const size_t max_item_size, const size_t max_len) {
     struct aws_cryptosdk_dec_materials *materials = ensure_dec_materials_attempt_allocation();
     __CPROVER_assume(aws_cryptosdk_dec_materials_members_are_bounded(materials, max_trace_items, max_item_size));
 

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -66,27 +66,6 @@ struct data_key *ensure_data_key_attempt_allocation() {
     return key;
 }
 
-struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len) {
-    struct aws_cryptosdk_session *session = malloc(sizeof(struct aws_cryptosdk_session));
-    if (session) {
-        session->alloc       = nondet_bool() ? NULL : can_fail_allocator();
-        session->cmm         = malloc(sizeof(struct aws_cryptosdk_cmm));
-        session->header_copy = malloc(sizeof(uint8_t));
-        session->alg_props   = ensure_alg_properties_attempt_allocation(max_len);
-        // session->signctx     = ensure_nondet_sig_ctx_has_allocated_members();
-    }
-    return session;
-}
-
-struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation() {
-    struct aws_cryptosdk_dec_materials *materials = malloc(sizeof(struct aws_cryptosdk_dec_materials));
-    if (materials) {
-        materials->alloc = nondet_bool() ? NULL : can_fail_allocator();
-        // materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
-    }
-    return materials;
-}
-
 void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len) {
     record->wrapping_key_namespace = ensure_string_is_allocated_nondet_length();
     if (record->wrapping_key_namespace) {
@@ -274,4 +253,25 @@ void ensure_nondet_allocate_cmm_vtable_members(struct aws_cryptosdk_cmm_vt *vtab
     if (vtable) {
         vtable->name = ensure_c_str_is_allocated(max_len);
     }
+}
+
+struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len) {
+    struct aws_cryptosdk_session *session = malloc(sizeof(struct aws_cryptosdk_session));
+    if (session) {
+        session->alloc       = nondet_bool() ? NULL : can_fail_allocator();
+        session->cmm         = malloc(sizeof(struct aws_cryptosdk_cmm));
+        session->header_copy = malloc(sizeof(uint8_t));
+        session->alg_props   = ensure_alg_properties_attempt_allocation(max_len);
+        session->signctx     = ensure_nondet_sig_ctx_has_allocated_members();
+    }
+    return session;
+}
+
+struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation() {
+    struct aws_cryptosdk_dec_materials *materials = malloc(sizeof(struct aws_cryptosdk_dec_materials));
+    if (materials) {
+        materials->alloc = nondet_bool() ? NULL : can_fail_allocator();
+        materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
+    }
+    return materials;
 }

--- a/verification/cbmc/sources/make_common_data_structures.c
+++ b/verification/cbmc/sources/make_common_data_structures.c
@@ -20,6 +20,7 @@
 #include <aws/cryptosdk/private/hkdf.h>
 #include <aws/cryptosdk/private/keyring_trace.h>
 #include <aws/cryptosdk/private/multi_keyring.h>
+#include <aws/cryptosdk/private/session.h>
 #include <cipher_openssl.h>
 #include <ec_utils.h>
 #include <evp_utils.h>
@@ -63,6 +64,27 @@ struct content_key *ensure_content_key_attempt_allocation() {
 struct data_key *ensure_data_key_attempt_allocation() {
     struct data_key *key = malloc(sizeof(uint8_t) * MAX_DATA_KEY_SIZE);
     return key;
+}
+
+struct aws_cryptosdk_session *ensure_session_attempt_allocation(size_t max_len) {
+    struct aws_cryptosdk_session *session = malloc(sizeof(struct aws_cryptosdk_session));
+    if (session) {
+        session->alloc       = nondet_bool() ? NULL : can_fail_allocator();
+        session->cmm         = malloc(sizeof(struct aws_cryptosdk_cmm));
+        session->header_copy = malloc(sizeof(uint8_t));
+        session->alg_props   = ensure_alg_properties_attempt_allocation(max_len);
+        session->signctx     = ensure_nondet_sig_ctx_has_allocated_members();
+    }
+    return session;
+}
+
+struct aws_cryptosdk_dec_materials *ensure_dec_materials_attempt_allocation() {
+    struct aws_cryptosdk_dec_materials *materials = malloc(sizeof(struct aws_cryptosdk_dec_materials));
+    if (materials) {
+        materials->alloc   = nondet_bool() ? NULL : can_fail_allocator();
+        materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
+    }
+    return materials;
 }
 
 void ensure_record_has_allocated_members(struct aws_cryptosdk_keyring_trace_record *record, size_t max_len) {

--- a/verification/cbmc/sources/openssl/ec_override.c
+++ b/verification/cbmc/sources/openssl/ec_override.c
@@ -488,5 +488,11 @@ void write_unconstrained_data(unsigned char *out, size_t len) {
 
     // Currently we ignore the len parameter and just fill the entire buffer with unconstrained data.
     // This is fine because it is strictly more general behavior than writing only len bytes.
-    __CPROVER_havoc_object(out);
+    // __CPROVER_havoc_object(out);
+    if (len > 0) {
+        size_t index;
+        unsigned char nondet_char;
+        __CPROVER_assume(index < len);
+        out[index] = nondet_char;
+    }
 }


### PR DESCRIPTION
This PR adds a proof for derive_data_key, a function from session_decrypt.c, and also patches #653 for the proof to work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

