### PR TITLE
downgrade CMake in macOS Actions build

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-10.14, macos-latest]
+        os: [macOS-10.15, macos-latest]
         openssl_version: [openssl@1.1]
 
     steps:
@@ -28,6 +28,19 @@ jobs:
           repository: "aws/aws-sdk-cpp"
           ref: "1.8.32"
           path: "aws-sdk-cpp"
+
+      # The hosted Actions runners include CMake v3.19.1 by default, which has
+      # a regression that causes aws-sdk-cpp and aws-encryption-sdk-c to fail
+      # to build on the runners. We install the previous working version as a
+      # workaround. See https://github.com/aws/aws-encryption-sdk-c/issues/650.
+      - name: Install CMake v3.18.5
+        run: |
+          brew uninstall cmake
+          curl -L https://github.com/Kitware/CMake/releases/download/v3.18.5/cmake-3.18.5-Darwin-x86_64.tar.gz | tar xz
+          cd cmake-3.18.5-Darwin-x86_64/CMake.app/Contents
+          sudo cp bin/* /usr/local/bin/
+          sudo cp share/aclocal/* /usr/local/share/aclocal/
+          sudo cp -R share/cmake-3.18 /usr/local/share/
 
       - name: Build and install aws-sdk-cpp
         run: |


### PR DESCRIPTION
The hosted macOS Actions runners include CMake v3.19.1 by default, which
has a regression that causes aws-sdk-cpp and aws-encryption-sdk-c to
fail to build on the runners. We install the previous working version as
a workaround. See #650 for more details.

Resolves #650.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

