### PR TITLE
Adds CBMC proof for aws_cryptosdk_priv_try_gen_key

### DIFF
--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -103,7 +103,7 @@ AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_session_is_valid(const struct aws
     bool cmm_valid            = aws_cryptosdk_cmm_base_is_valid(session->cmm);
     bool hdr_valid            = aws_cryptosdk_hdr_is_valid(&session->header);
     bool keyring_trace_valid  = aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace);
-    bool alg_props_valid      = aws_cryptosdk_alg_properties_is_valid(session->alg_props);
+    bool alg_props_valid      = session->alg_props == NULL || aws_cryptosdk_alg_properties_is_valid(session->alg_props);
     bool content_key_valid    = aws_cryptosdk_content_key_is_valid(&session->content_key);
     bool key_commitment_valid = aws_byte_buf_is_valid(&session->key_commitment);
     bool signctx_valid        = (session->signctx == NULL) || aws_cryptosdk_sig_ctx_is_valid(session->signctx);

--- a/include/aws/cryptosdk/private/session.h
+++ b/include/aws/cryptosdk/private/session.h
@@ -99,12 +99,12 @@ AWS_CRYPTOSDK_STATIC_INLINE bool aws_cryptosdk_session_is_valid(const struct aws
     if (!AWS_OBJECT_PTR_IS_WRITABLE(session)) {
         return false;
     }
-    bool allocator_valid      = aws_allocator_is_valid(session->alloc);
-    bool cmm_valid            = aws_cryptosdk_cmm_base_is_valid(session->cmm);
-    bool hdr_valid            = aws_cryptosdk_hdr_is_valid(&session->header);
-    bool keyring_trace_valid  = aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace);
-    bool alg_props_valid      = session->alg_props == NULL || aws_cryptosdk_alg_properties_is_valid(session->alg_props);
-    bool content_key_valid    = aws_cryptosdk_content_key_is_valid(&session->content_key);
+    bool allocator_valid     = aws_allocator_is_valid(session->alloc);
+    bool cmm_valid           = aws_cryptosdk_cmm_base_is_valid(session->cmm);
+    bool hdr_valid           = aws_cryptosdk_hdr_is_valid(&session->header);
+    bool keyring_trace_valid = aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace);
+    bool alg_props_valid   = (session->alg_props == NULL || aws_cryptosdk_alg_properties_is_valid(session->alg_props));
+    bool content_key_valid = aws_cryptosdk_content_key_is_valid(&session->content_key);
     bool key_commitment_valid = aws_byte_buf_is_valid(&session->key_commitment);
     bool signctx_valid        = (session->signctx == NULL) || aws_cryptosdk_sig_ctx_is_valid(session->signctx);
     return allocator_valid && cmm_valid && hdr_valid && keyring_trace_valid && alg_props_valid && content_key_valid &&

--- a/source/session_decrypt.c
+++ b/source/session_decrypt.c
@@ -68,6 +68,7 @@ UNEXPECTED_ERROR:
 
 static int derive_data_key(struct aws_cryptosdk_session *session, struct aws_cryptosdk_dec_materials *materials) {
     AWS_PRECONDITION(aws_cryptosdk_session_is_valid(session));
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
     AWS_PRECONDITION(aws_cryptosdk_dec_materials_is_valid(materials));
 
     if (materials->unencrypted_data_key.len != session->alg_props->data_key_len) {

--- a/source/session_encrypt.c
+++ b/source/session_encrypt.c
@@ -49,8 +49,6 @@ void aws_cryptosdk_priv_encrypt_compute_body_estimate(struct aws_cryptosdk_sessi
 
 int aws_cryptosdk_priv_try_gen_key(struct aws_cryptosdk_session *session) {
     AWS_PRECONDITION(aws_cryptosdk_session_is_valid(session));
-    AWS_PRECONDITION(session->header.iv.len <= session->alg_props->iv_len);
-    AWS_PRECONDITION(session->header.auth_tag.len <= session->alg_props->tag_len);
     AWS_PRECONDITION(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
     AWS_PRECONDITION(session->state == ST_GEN_KEY);
     AWS_PRECONDITION(session->mode == AWS_CRYPTOSDK_ENCRYPT);

--- a/source/session_encrypt.c
+++ b/source/session_encrypt.c
@@ -52,6 +52,8 @@ int aws_cryptosdk_priv_try_gen_key(struct aws_cryptosdk_session *session) {
     AWS_PRECONDITION(aws_cryptosdk_cmm_base_is_valid(session->cmm));
     AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
     AWS_PRECONDITION(aws_cryptosdk_hdr_is_valid(&session->header));
+    AWS_PRECONDITION(session->header.iv.len <= session->alg_props->iv_len);
+    AWS_PRECONDITION(session->header.auth_tag.len <= session->alg_props->tag_len);
     AWS_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace));
     AWS_PRECONDITION(aws_allocator_is_valid(session->alloc));
     AWS_PRECONDITION(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));

--- a/source/session_encrypt.c
+++ b/source/session_encrypt.c
@@ -175,6 +175,7 @@ static int build_header(struct aws_cryptosdk_session *session, struct aws_crypto
 
 static int sign_header(struct aws_cryptosdk_session *session) {
     AWS_PRECONDITION(aws_cryptosdk_session_is_valid(session));
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
     AWS_PRECONDITION(session->alg_props->impl->cipher_ctor != NULL);
     AWS_PRECONDITION(session->header.iv.len <= session->alg_props->iv_len);
     AWS_PRECONDITION(session->header.auth_tag.len <= session->alg_props->tag_len);

--- a/source/session_encrypt.c
+++ b/source/session_encrypt.c
@@ -48,6 +48,15 @@ void aws_cryptosdk_priv_encrypt_compute_body_estimate(struct aws_cryptosdk_sessi
 }
 
 int aws_cryptosdk_priv_try_gen_key(struct aws_cryptosdk_session *session) {
+    AWS_PRECONDITION(session != NULL);
+    AWS_PRECONDITION(aws_cryptosdk_cmm_base_is_valid(session->cmm));
+    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
+    AWS_PRECONDITION(aws_cryptosdk_hdr_is_valid(&session->header));
+    AWS_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace));
+    AWS_PRECONDITION(aws_allocator_is_valid(session->alloc));
+    AWS_PRECONDITION(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
+    AWS_PRECONDITION(session->state == ST_GEN_KEY);
+    AWS_PRECONDITION(session->mode == AWS_CRYPTOSDK_ENCRYPT);
     struct aws_cryptosdk_enc_request request;
     struct aws_cryptosdk_enc_materials *materials = NULL;
     struct data_key data_key;

--- a/source/session_encrypt.c
+++ b/source/session_encrypt.c
@@ -89,7 +89,9 @@ int aws_cryptosdk_priv_try_gen_key(struct aws_cryptosdk_session *session) {
 
     // Generate message ID and derive the content key from the data key.
     size_t message_id_len = aws_cryptosdk_private_algorithm_message_id_len(session->alg_props);
-    aws_byte_buf_init(&session->header.message_id, session->alloc, message_id_len);
+    if (aws_byte_buf_init(&session->header.message_id, session->alloc, message_id_len) != AWS_OP_SUCCESS) {
+        goto out;
+    }
     if (aws_cryptosdk_genrandom(session->header.message_id.buffer, message_id_len)) {
         goto out;
     }

--- a/source/session_encrypt.c
+++ b/source/session_encrypt.c
@@ -48,14 +48,9 @@ void aws_cryptosdk_priv_encrypt_compute_body_estimate(struct aws_cryptosdk_sessi
 }
 
 int aws_cryptosdk_priv_try_gen_key(struct aws_cryptosdk_session *session) {
-    AWS_PRECONDITION(session != NULL);
-    AWS_PRECONDITION(aws_cryptosdk_cmm_base_is_valid(session->cmm));
-    AWS_PRECONDITION(aws_cryptosdk_alg_properties_is_valid(session->alg_props));
-    AWS_PRECONDITION(aws_cryptosdk_hdr_is_valid(&session->header));
+    AWS_PRECONDITION(aws_cryptosdk_session_is_valid(session));
     AWS_PRECONDITION(session->header.iv.len <= session->alg_props->iv_len);
     AWS_PRECONDITION(session->header.auth_tag.len <= session->alg_props->tag_len);
-    AWS_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(&session->keyring_trace));
-    AWS_PRECONDITION(aws_allocator_is_valid(session->alloc));
     AWS_PRECONDITION(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
     AWS_PRECONDITION(session->state == ST_GEN_KEY);
     AWS_PRECONDITION(session->mode == AWS_CRYPTOSDK_ENCRYPT);

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
@@ -43,7 +43,9 @@ DEFINES += -DMAX_TRACE_NUM_ITEMS=$(MAX_TRACE_NUM_ITEMS)
 # Without this flag, running this proof causes the CBMC error of 
 # "too many addressed objects: maximum number of objects is set to 2^n=256 (with n=8);
 # use the `--object-bits n` option to increase the maximum number"
-CBMCFLAGS += --object-bits 9
+# The proof hits the error when the line "rv = aws_cryptosdk_hdr_write(&session->header,
+# &actual_size, session->header_copy, session->header_size);" is reached.
+CBMC_OBJECT_BITS = 9
 
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
@@ -28,7 +28,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 # Therefore, we choose these values for performance. 
 MAX_EDK_LIST_ITEMS ?= 1
 MAX_TABLE_SIZE ?= 2
-MAX_TRACE_NUM_ITEMS ?= 2
+MAX_TRACE_LIST_ITEMS ?= 2
 
 DEFINES += -DARRAY_LIST_TYPE="struct aws_cryptosdk_edk"
 DEFINES += -DARRAY_LIST_TYPE_HEADER=\"aws/cryptosdk/edk.h\"
@@ -37,7 +37,7 @@ DEFINES += -DAWS_NO_STATIC_IMPL
 DEFINES += -DMAX_EDK_LIST_ITEMS=$(MAX_EDK_LIST_ITEMS)
 DEFINES += -DMAX_IV_LEN=$(MAX_IV_LEN)
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
-DEFINES += -DMAX_TRACE_NUM_ITEMS=$(MAX_TRACE_NUM_ITEMS)
+DEFINES += -DMAX_TRACE_LIST_ITEMS=$(MAX_TRACE_LIST_ITEMS)
 
 # The maximum number of objects is set to 2^8 = 256. This option changes that to 2^9. 
 # Without this flag, running this proof causes the CBMC error of 
@@ -110,11 +110,11 @@ UNWINDSET += aws_cryptosdk_edk_list_elements_are_valid.0:$(call addone,$(MAX_EDK
 UNWINDSET += aws_cryptosdk_enc_ctx_serialize.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
 UNWINDSET += aws_cryptosdk_hdr_size.0:$(call addone,$(MAX_EDK_LIST_ITEMS)) 
 UNWINDSET += aws_cryptosdk_hdr_write.0:$(call addone,$(MAX_EDK_LIST_ITEMS)) 
-UNWINDSET += aws_cryptosdk_keyring_trace_clear.0:$(call addone,$(MAX_TRACE_NUM_ITEMS))
-UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(MAX_TRACE_NUM_ITEMS))
-UNWINDSET += aws_cryptosdk_transfer_list.4.0:$(call addone,$(MAX_TRACE_NUM_ITEMS))
+UNWINDSET += aws_cryptosdk_keyring_trace_clear.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
+UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
+UNWINDSET += aws_cryptosdk_transfer_list.4.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
 UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_list_elements.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
-UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_TRACE_NUM_ITEMS))
+UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
 UNWINDSET += memcmp.0:$(call addone,$(MAX_BUFFER_SIZE))
 
 ###########

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
@@ -87,13 +87,18 @@ PROOF_SOURCES += $(COMMON_PROOF_STUB)/memcpy_override_havoc.c
 PROOF_SOURCES += $(COMMON_PROOF_STUB)/memset_override_havoc.c
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(PROOF_STUB)/aws_array_list_item_generator_u8_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_array_list_sort_noop_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_enc_ctx_size_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_hash_elems_array_init_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_default_allocator_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/generate_enc_materials_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/hdr_write_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/hkdf_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/keyring_trace_clean_up_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/keyring_trace_clear_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/transfer_list_stub.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
-
-REMOVE_FUNCTION_BODY += aws_array_list_get_at_ptr
 
 # We abstract these functions because manual inspection demonstrates that they are unreachable,
 # which leads to improvements in coverage metrics
@@ -102,6 +107,7 @@ REMOVE_FUNCTION_BODY += EVP_DecryptUpdate
 REMOVE_FUNCTION_BODY += EVP_sha256
 REMOVE_FUNCTION_BODY += EVP_sha384
 REMOVE_FUNCTION_BODY += EVP_sha512
+REMOVE_FUNCTION_BODY += aws_array_list_get_at_ptr
 
 UNWINDSET += array_list_item_generator.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
 UNWINDSET += aws_cryptosdk_edk_list_clear.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
@@ -109,7 +115,6 @@ UNWINDSET += aws_cryptosdk_edk_list_elements_are_bounded.0:$(call addone,$(MAX_E
 UNWINDSET += aws_cryptosdk_edk_list_elements_are_valid.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
 UNWINDSET += aws_cryptosdk_enc_ctx_serialize.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
 UNWINDSET += aws_cryptosdk_hdr_size.0:$(call addone,$(MAX_EDK_LIST_ITEMS)) 
-UNWINDSET += aws_cryptosdk_hdr_write.0:$(call addone,$(MAX_EDK_LIST_ITEMS)) 
 UNWINDSET += aws_cryptosdk_keyring_trace_clear.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
 UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
 UNWINDSET += aws_cryptosdk_transfer_list.4.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
@@ -1,0 +1,126 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#########
+# if Makefile.local exists, use it. This provides a way to override the defaults
+sinclude ../Makefile.local
+#otherwise, use the default values
+include ../Makefile.local_default
+include ../Makefile.string
+include ../Makefile.aws_byte_buf
+
+#########
+PROOF_UID = aws_cryptosdk_priv_try_gen_key
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+# Increasing the length of the edk_list or enc_ctx does not improve coverage.
+# Therefore, we choose these values for performance. 
+MAX_EDK_LIST_ITEMS ?= 1
+MAX_TABLE_SIZE ?= 2
+MAX_TRACE_NUM_ITEMS ?= 2
+
+DEFINES += -DARRAY_LIST_TYPE="struct aws_cryptosdk_edk"
+DEFINES += -DARRAY_LIST_TYPE_HEADER=\"aws/cryptosdk/edk.h\"
+DEFINES += -DAWS_CRYPTOSDK_HASH_ELEMS_ARRAY_INIT_GENERATOR=array_list_item_generator
+DEFINES += -DAWS_NO_STATIC_IMPL
+DEFINES += -DMAX_EDK_LIST_ITEMS=$(MAX_EDK_LIST_ITEMS)
+DEFINES += -DMAX_IV_LEN=$(MAX_IV_LEN)
+DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
+DEFINES += -DMAX_TRACE_NUM_ITEMS=$(MAX_TRACE_NUM_ITEMS)
+
+# The maximum number of objects is set to 2^8 = 256. This option changes that to 2^9. 
+# Without this flag, running this proof causes the CBMC error of 
+# "too many addressed objects: maximum number of objects is set to 2^n=256 (with n=8);
+# use the `--object-bits n` option to increase the maximum number"
+CBMCFLAGS += --object-bits 9
+
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/hash_table.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/math.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/array_list.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/atomics.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/byte_order.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/error.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/math.c
+PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/string.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/bn_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/ec_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/evp_override.c
+PROJECT_SOURCES += $(PROOF_SOURCE)/openssl/rand_override.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher.c
+PROJECT_SOURCES += $(SRCDIR)/source/cipher_openssl.c
+PROJECT_SOURCES += $(SRCDIR)/source/edk.c
+PROJECT_SOURCES += $(SRCDIR)/source/enc_ctx.c
+PROJECT_SOURCES += $(SRCDIR)/source/header.c
+PROJECT_SOURCES += $(SRCDIR)/source/hkdf.c
+PROJECT_SOURCES += $(SRCDIR)/source/keyring_trace.c
+PROJECT_SOURCES += $(SRCDIR)/source/list_utils.c
+PROJECT_SOURCES += $(SRCDIR)/source/materials.c
+PROJECT_SOURCES += $(SRCDIR)/source/session.c
+PROJECT_SOURCES += $(SRCDIR)/source/session_encrypt.c
+PROJECT_SOURCES += $(SRCDIR)/source/utils.c
+
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/aws_array_list_defined_type.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/aws_byte_buf_write_stub.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/aws_hash_iter_overrides.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/aws_string_destroy_override.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/error.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/memcmp_override.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/memcpy_override_havoc.c
+PROOF_SOURCES += $(COMMON_PROOF_STUB)/memset_override_havoc.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_invariants.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
+PROOF_SOURCES += $(PROOF_STUB)/aws_array_list_sort_noop_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_enc_ctx_size_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_hash_elems_array_init_stub.c
+PROOF_SOURCES += $(PROOF_STUB)/aws_default_allocator_stub.c
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+REMOVE_FUNCTION_BODY += aws_array_list_get_at_ptr
+
+# Remove function bodies to deal with CBMC function pointer removal
+# All functions removed are those removed in aws_cryptosdk_enc_ctx_serialize
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_array_list_sort
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_byte_buf_write
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_cryptosdk_enc_ctx_size
+REMOVE_FUNCTION_BODIES += --remove-function-body aws_cryptosdk_hash_elems_array_init
+
+# We abstract these functions because manual inspection demonstrates that they are unreachable,
+# which leads to improvements in coverage metrics
+# All functions removed in aws_cryptosdk_sign_header
+REMOVE_FUNCTION_BODY += EVP_DecryptUpdate
+REMOVE_FUNCTION_BODY += EVP_sha256
+REMOVE_FUNCTION_BODY += EVP_sha384
+REMOVE_FUNCTION_BODY += EVP_sha512
+
+UNWINDSET += array_list_item_generator.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+UNWINDSET += aws_cryptosdk_edk_list_clear.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_bounded.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
+UNWINDSET += aws_cryptosdk_edk_list_elements_are_valid.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
+UNWINDSET += aws_cryptosdk_enc_ctx_serialize.0:$(shell echo $$((1 + $(MAX_TABLE_SIZE))))
+UNWINDSET += aws_cryptosdk_hdr_size.0:$(call addone,$(MAX_EDK_LIST_ITEMS)) 
+UNWINDSET += aws_cryptosdk_hdr_write.0:$(call addone,$(MAX_EDK_LIST_ITEMS)) 
+UNWINDSET += aws_cryptosdk_keyring_trace_clear.0:$(call addone,$(MAX_TRACE_NUM_ITEMS))
+UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(MAX_TRACE_NUM_ITEMS))
+UNWINDSET += aws_cryptosdk_transfer_list.4.0:$(call addone,$(MAX_TRACE_NUM_ITEMS))
+UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_list_elements.0:$(call addone,$(MAX_EDK_LIST_ITEMS))
+UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_TRACE_NUM_ITEMS))
+UNWINDSET += memcmp.0:$(call addone,$(MAX_BUFFER_SIZE))
+
+###########
+include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
@@ -93,13 +93,6 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 REMOVE_FUNCTION_BODY += aws_array_list_get_at_ptr
 
-# Remove function bodies to deal with CBMC function pointer removal
-# All functions removed are those removed in aws_cryptosdk_enc_ctx_serialize
-REMOVE_FUNCTION_BODIES += --remove-function-body aws_array_list_sort
-REMOVE_FUNCTION_BODIES += --remove-function-body aws_byte_buf_write
-REMOVE_FUNCTION_BODIES += --remove-function-body aws_cryptosdk_enc_ctx_size
-REMOVE_FUNCTION_BODIES += --remove-function-body aws_cryptosdk_hash_elems_array_init
-
 # We abstract these functions because manual inspection demonstrates that they are unreachable,
 # which leads to improvements in coverage metrics
 # All functions removed in aws_cryptosdk_sign_header

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
@@ -83,7 +83,6 @@ PROOF_SOURCES += $(PROOF_STUB)/aws_array_list_item_generator_u8_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_array_list_sort_noop_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_enc_ctx_size_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_hash_elems_array_init_stub.c
-PROOF_SOURCES += $(PROOF_STUB)/aws_default_allocator_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/generate_enc_materials_stub.c
 # Stubbing out aws_cryptosdk_hdr_write leads to a huge gain in performance
 # Not including this stub would also require you to set CBMC_OBJECT_BITS = 9

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
@@ -39,14 +39,6 @@ DEFINES += -DMAX_IV_LEN=$(MAX_IV_LEN)
 DEFINES += -DMAX_TABLE_SIZE=$(MAX_TABLE_SIZE)
 DEFINES += -DMAX_TRACE_LIST_ITEMS=$(MAX_TRACE_LIST_ITEMS)
 
-# The maximum number of objects is set to 2^8 = 256. This option changes that to 2^9. 
-# Without this flag, running this proof causes the CBMC error of 
-# "too many addressed objects: maximum number of objects is set to 2^n=256 (with n=8);
-# use the `--object-bits n` option to increase the maximum number"
-# The proof hits the error when the line "rv = aws_cryptosdk_hdr_write(&session->header,
-# &actual_size, session->header_copy, session->header_size);" is reached.
-CBMC_OBJECT_BITS = 9
-
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/hash_table.c
@@ -93,6 +85,8 @@ PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_enc_ctx_size_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_hash_elems_array_init_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_default_allocator_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/generate_enc_materials_stub.c
+# Stubbing out aws_cryptosdk_hdr_write leads to a huge gain in performance
+# Not including this stub would also require you to set CBMC_OBJECT_BITS = 9
 PROOF_SOURCES += $(PROOF_STUB)/hdr_write_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/hkdf_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/keyring_trace_clean_up_stub.c

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/aws_cryptosdk_priv_try_gen_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/aws_cryptosdk_priv_try_gen_key_harness.c
@@ -39,7 +39,7 @@ int generate_enc_materials(
  * multiple functions (see Makefile). It also requires a quite specific
  * configuration for the session struct (cmm's vtable must include a
  * pointer to the function declared above, alg_props can be NULL or valid,
- * etc.) so we do not use the session_setup method to initialize it
+ * etc.) so we do not use the session_setup method to initialize it.
  */
 void aws_cryptosdk_priv_try_gen_key_harness() {
     /* Nondet Input */

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/aws_cryptosdk_priv_try_gen_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/aws_cryptosdk_priv_try_gen_key_harness.c
@@ -155,7 +155,7 @@ int generate_enc_materials(
 
     // Set up the keyring trace
     __CPROVER_assume(aws_array_list_is_bounded(
-        &materials->keyring_trace, MAX_TRACE_NUM_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+        &materials->keyring_trace, MAX_TRACE_LIST_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
     __CPROVER_assume(materials->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     ensure_array_list_has_allocated_data_member(&materials->keyring_trace);
     __CPROVER_assume(aws_array_list_is_valid(&materials->keyring_trace));
@@ -172,7 +172,8 @@ int generate_enc_materials(
 
 void aws_cryptosdk_priv_try_gen_key_harness() {
     /* Nondet Input */
-    struct aws_cryptosdk_session *session = malloc(sizeof(*session));
+    struct aws_cryptosdk_session *session =
+        session_setup(MAX_TABLE_SIZE, MAX_TRACE_LIST_ITEMS, MAX_EDK_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
 
     /* Assumptions */
     __CPROVER_assume(session != NULL);
@@ -214,7 +215,7 @@ void aws_cryptosdk_priv_try_gen_key_harness() {
     struct aws_array_list *keyring_trace = malloc(sizeof(*keyring_trace));
     __CPROVER_assume(keyring_trace != NULL);
     __CPROVER_assume(aws_array_list_is_bounded(
-        keyring_trace, MAX_TRACE_NUM_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+        keyring_trace, MAX_TRACE_LIST_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
     __CPROVER_assume(keyring_trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
     ensure_array_list_has_allocated_data_member(keyring_trace);
     __CPROVER_assume(aws_array_list_is_valid(keyring_trace));

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/aws_cryptosdk_priv_try_gen_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/aws_cryptosdk_priv_try_gen_key_harness.c
@@ -1,0 +1,246 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <aws/cryptosdk/materials.h>
+#include <aws/cryptosdk/private/keyring_trace.h>
+#include <cbmc_invariants.h>
+#include <cipher_openssl.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/cryptosdk/make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+#include <proof_helpers/proof_allocators.h>
+#include <proof_helpers/utils.h>
+
+#include <aws/cryptosdk/private/cipher.h>
+#include <aws/cryptosdk/private/hkdf.h>
+#include <aws/cryptosdk/private/session.h>
+#include <aws/cryptosdk/session.h>
+
+/* Stub this for performance but check the preconditions.
+ No modified data structure is used again.
+ Original function is here:
+ https://github.com/aws/aws-encryption-sdk-c/blob/master/source/hkdf.c#148 */
+int aws_cryptosdk_hkdf(
+    struct aws_byte_buf *okm,
+    enum aws_cryptosdk_sha_version which_sha,
+    const struct aws_byte_buf *salt,
+    const struct aws_byte_buf *ikm,
+    const struct aws_byte_buf *info) {
+    assert(aws_byte_buf_is_valid(salt));
+    assert(aws_byte_buf_is_valid(ikm));
+    assert(aws_byte_buf_is_valid(info));
+    if (nondet_bool()) {
+        return AWS_OP_ERR;
+    }
+    return AWS_OP_SUCCESS;
+}
+
+/* Stub this because of the override of aws_array_list_get_at_ptr and for performance.
+ The contents of session_>keyring_trace are nondet in the construction of the harness.
+ Also neither keyring trace is later used.
+ Original function is here:
+ https://github.com/aws/aws-encryption-sdk-c/blob/master/source/list_utils.c#L17 */
+int aws_cryptosdk_transfer_list(struct aws_array_list *dest, struct aws_array_list *src) {
+    assert(src != dest);
+    assert(aws_array_list_is_valid(dest));
+    assert(aws_array_list_is_valid(src));
+    assert(dest->item_size == src->item_size);
+
+    if (nondet_bool()) {
+        return AWS_OP_ERR;
+    }
+    return AWS_OP_SUCCESS;
+}
+
+void array_list_item_generator(struct aws_array_list *elems) {
+    assert(elems->item_size == sizeof(struct aws_hash_element));
+    for (size_t index = 0; index < elems->length; ++index) {
+        struct aws_hash_element *val = (struct aws_hash_element *)((uint8_t *)elems->data + (elems->item_size * index));
+        /* Due to the cast to uint16, the entire size of the enc_ctx must be less than < UINT16_MAX
+         * This is a simple way to ensure this without a call to enc_ctx_size. */
+        struct aws_string *key = ensure_string_is_allocated_nondet_length();
+        __CPROVER_assume(aws_string_is_valid(key));
+        __CPROVER_assume(key->len <= UINT8_MAX);
+        val->key                 = key;
+        struct aws_string *value = ensure_string_is_allocated_nondet_length();
+        __CPROVER_assume(aws_string_is_valid(value));
+        __CPROVER_assume(value->len <= UINT8_MAX);
+        val->value = value;
+    }
+}
+
+/* Stub this because of the override of aws_array_list_get_at_ptr
+ Original function is here:
+ https://github.com/aws/aws-encryption-sdk-c/blob/master/source/keyring_trace.c#L235 */
+void aws_cryptosdk_keyring_trace_clear(struct aws_array_list *trace) {
+    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(trace));
+    AWS_FATAL_PRECONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    aws_array_list_clear(trace);
+}
+
+/* Stub this until https://github.com/diffblue/cbmc/issues/5344 is fixed
+ Original function is here:
+ https://github.com/aws/aws-encryption-sdk-c/blob/master/source/edk.c#L44 */
+void aws_cryptosdk_edk_list_clean_up(struct aws_array_list *encrypted_data_keys) {
+    assert(aws_cryptosdk_edk_list_is_valid(encrypted_data_keys));
+    aws_array_list_clean_up(encrypted_data_keys);
+}
+
+/**
+ * Receives encryption request from user and attempts to generate encryption materials,
+ * including an encrypted data key and a list of EDKs for doing encryption.
+ *
+ * On success returns AWS_OP_SUCCESS and allocates encryption materials object at address
+ * pointed to by output.
+ *
+ * On failure returns AWS_OP_ERR, sets address pointed to by output to NULL, and sets
+ * internal AWS error code.
+ */
+int generate_enc_materials(
+    struct aws_cryptosdk_cmm *cmm,
+    struct aws_cryptosdk_enc_materials **output,
+    struct aws_cryptosdk_enc_request *request) {
+    assert(aws_cryptosdk_cmm_base_is_valid(cmm));
+    assert(AWS_OBJECT_PTR_IS_WRITABLE(output));
+    assert(aws_cryptosdk_enc_request_is_valid(request));
+
+    struct aws_cryptosdk_enc_materials *materials = malloc(sizeof(*materials));
+    if (materials == NULL) {
+        *output = NULL;
+        return AWS_OP_ERR;
+    }
+
+    // Set up the allocator
+    // Request->alloc is session->alloc
+    materials->alloc = request->alloc;
+    __CPROVER_assume(aws_allocator_is_valid(materials->alloc));
+    __CPROVER_assume(materials->alloc != NULL);
+
+    // Set up the signctx
+    materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
+    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(materials->signctx));
+
+    // Set up the unencrypted_data_key
+    __CPROVER_assume(aws_byte_buf_is_bounded(&materials->unencrypted_data_key, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&materials->unencrypted_data_key);
+    __CPROVER_assume(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
+
+    // Set up the edk_list
+    // edk_list Precondition: We have a valid list */
+    __CPROVER_assume(aws_cryptosdk_edk_list_is_bounded(&materials->encrypted_data_keys, MAX_EDK_LIST_ITEMS));
+    ensure_cryptosdk_edk_list_has_allocated_list(&materials->encrypted_data_keys);
+    __CPROVER_assume(aws_cryptosdk_edk_list_is_valid(&materials->encrypted_data_keys));
+
+    // The alloc is session->alloc
+    materials->encrypted_data_keys.alloc = request->alloc;
+
+    // edk_list Precondition: The list has valid list elements
+    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_bounded(&materials->encrypted_data_keys, MAX_BUFFER_SIZE));
+    ensure_cryptosdk_edk_list_has_allocated_list_elements(&materials->encrypted_data_keys);
+    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_valid(&materials->encrypted_data_keys));
+
+    // Set up the keyring trace
+    __CPROVER_assume(aws_array_list_is_bounded(
+        &materials->keyring_trace, MAX_TRACE_NUM_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+    __CPROVER_assume(materials->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&materials->keyring_trace);
+    __CPROVER_assume(aws_array_list_is_valid(&materials->keyring_trace));
+    ensure_trace_has_allocated_records(&materials->keyring_trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&materials->keyring_trace));
+
+    // Set the alg_id
+    enum aws_cryptosdk_alg_id alg_id;
+    materials->alg = alg_id;
+
+    *output = materials;
+    return AWS_OP_SUCCESS;
+}
+
+void aws_cryptosdk_priv_try_gen_key_harness() {
+    /* Nondet Input */
+    struct aws_cryptosdk_session *session = malloc(sizeof(*session));
+
+    /* Assumptions */
+    __CPROVER_assume(session != NULL);
+
+    const struct aws_cryptosdk_cmm_vt vtable = { .vt_size = sizeof(struct aws_cryptosdk_cmm_vt),
+                                                 .name    = ensure_c_str_is_allocated(SIZE_MAX),
+                                                 .destroy = nondet_voidp(),
+                                                 .generate_enc_materials =
+                                                     nondet_bool() ? generate_enc_materials : NULL,
+                                                 .decrypt_materials = nondet_voidp() };
+    __CPROVER_assume(aws_cryptosdk_cmm_vtable_is_valid(&vtable));
+
+    struct aws_cryptosdk_cmm *cmm = malloc(sizeof(*cmm));
+    __CPROVER_assume(cmm);
+    cmm->vtable = &vtable;
+    __CPROVER_assume(aws_cryptosdk_cmm_base_is_valid(cmm));
+    session->cmm = cmm;
+
+    enum aws_cryptosdk_alg_id alg_id;
+    struct aws_cryptosdk_alg_properties *props = aws_cryptosdk_alg_props(alg_id);
+    __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
+    session->alg_props = props;
+
+    struct aws_cryptosdk_hdr *hdr = ensure_nondet_hdr_has_allocated_members(MAX_TABLE_SIZE);
+
+    __CPROVER_assume(aws_cryptosdk_hdr_members_are_bounded(hdr, MAX_EDK_LIST_ITEMS, MAX_BUFFER_SIZE));
+
+    __CPROVER_assume(IMPLIES(hdr != NULL, aws_byte_buf_is_bounded(&hdr->iv, session->alg_props->iv_len)));
+    __CPROVER_assume(IMPLIES(hdr != NULL, aws_byte_buf_is_bounded(&hdr->auth_tag, session->alg_props->tag_len)));
+
+    ensure_cryptosdk_edk_list_has_allocated_list_elements(&hdr->edk_list);
+
+    __CPROVER_assume(aws_cryptosdk_hdr_is_valid(hdr));
+
+    // The header should have been cleared earlier
+    __CPROVER_assume(aws_array_list_length(&hdr->edk_list) == 0);
+
+    __CPROVER_assume(hdr->enc_ctx.p_impl != NULL);
+    ensure_hash_table_has_valid_destroy_functions(&hdr->enc_ctx);
+    size_t empty_slot_idx;
+    __CPROVER_assume(aws_hash_table_has_an_empty_slot(&hdr->enc_ctx, &empty_slot_idx));
+    session->header = *hdr;
+
+    struct aws_array_list *keyring_trace = malloc(sizeof(*keyring_trace));
+    __CPROVER_assume(keyring_trace != NULL);
+    __CPROVER_assume(aws_array_list_is_bounded(
+        keyring_trace, MAX_TRACE_NUM_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+    __CPROVER_assume(keyring_trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(keyring_trace);
+    __CPROVER_assume(aws_array_list_is_valid(keyring_trace));
+    ensure_trace_has_allocated_records(keyring_trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(keyring_trace));
+    session->keyring_trace = *keyring_trace;
+
+    session->alloc = can_fail_allocator();
+    __CPROVER_assume(aws_allocator_is_valid(session->alloc));
+    __CPROVER_assume(session->alloc != NULL);
+    session->header.edk_list.alloc = session->alloc;  // this assumption is needed for build_header
+    __CPROVER_assume(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
+
+    __CPROVER_assume(session->state == ST_GEN_KEY);
+    __CPROVER_assume(session->mode == AWS_CRYPTOSDK_ENCRYPT);
+
+    struct content_key *content_key = malloc(sizeof(*content_key));
+    __CPROVER_assume(content_key != NULL);
+    session->content_key = *content_key;
+
+    /* Function under verification */
+    aws_cryptosdk_priv_try_gen_key(session);
+}

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/aws_cryptosdk_priv_try_gen_key_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/aws_cryptosdk_priv_try_gen_key_harness.c
@@ -17,7 +17,6 @@
  */
 
 #include <aws/cryptosdk/materials.h>
-#include <aws/cryptosdk/private/keyring_trace.h>
 #include <cbmc_invariants.h>
 #include <cipher_openssl.h>
 #include <make_common_data_structures.h>
@@ -27,153 +26,17 @@
 #include <proof_helpers/utils.h>
 
 #include <aws/cryptosdk/private/cipher.h>
-#include <aws/cryptosdk/private/hkdf.h>
 #include <aws/cryptosdk/private/session.h>
 #include <aws/cryptosdk/session.h>
 
-/* Stub this for performance but check the preconditions.
- No modified data structure is used again.
- Original function is here:
- https://github.com/aws/aws-encryption-sdk-c/blob/master/source/hkdf.c#148 */
-int aws_cryptosdk_hkdf(
-    struct aws_byte_buf *okm,
-    enum aws_cryptosdk_sha_version which_sha,
-    const struct aws_byte_buf *salt,
-    const struct aws_byte_buf *ikm,
-    const struct aws_byte_buf *info) {
-    assert(aws_byte_buf_is_valid(salt));
-    assert(aws_byte_buf_is_valid(ikm));
-    assert(aws_byte_buf_is_valid(info));
-    if (nondet_bool()) {
-        return AWS_OP_ERR;
-    }
-    return AWS_OP_SUCCESS;
-}
-
-/* Stub this because of the override of aws_array_list_get_at_ptr and for performance.
- The contents of session->keyring_trace are nondet in the construction of the harness.
- Also neither keyring trace is later used.
- Original function is here:
- https://github.com/aws/aws-encryption-sdk-c/blob/master/source/list_utils.c#L17 */
-int aws_cryptosdk_transfer_list(struct aws_array_list *dest, struct aws_array_list *src) {
-    assert(src != dest);
-    assert(aws_array_list_is_valid(dest));
-    assert(aws_array_list_is_valid(src));
-    assert(dest->item_size == src->item_size);
-
-    if (nondet_bool()) {
-        return AWS_OP_ERR;
-    }
-    return AWS_OP_SUCCESS;
-}
-
-void array_list_item_generator(struct aws_array_list *elems) {
-    assert(elems->item_size == sizeof(struct aws_hash_element));
-    for (size_t index = 0; index < elems->length; ++index) {
-        struct aws_hash_element *val = (struct aws_hash_element *)((uint8_t *)elems->data + (elems->item_size * index));
-        /* Due to the cast to uint16, the entire size of the enc_ctx must be less than < UINT16_MAX
-         * This is a simple way to ensure this without a call to enc_ctx_size. */
-        struct aws_string *key = ensure_string_is_allocated_nondet_length();
-        __CPROVER_assume(aws_string_is_valid(key));
-        __CPROVER_assume(key->len <= UINT8_MAX);
-        val->key                 = key;
-        struct aws_string *value = ensure_string_is_allocated_nondet_length();
-        __CPROVER_assume(aws_string_is_valid(value));
-        __CPROVER_assume(value->len <= UINT8_MAX);
-        val->value = value;
-    }
-}
-
-/* Stub this because of the override of aws_array_list_get_at_ptr
- Original function is here:
- https://github.com/aws/aws-encryption-sdk-c/blob/master/source/keyring_trace.c#L235 */
-void aws_cryptosdk_keyring_trace_clear(struct aws_array_list *trace) {
-    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(trace));
-    AWS_FATAL_PRECONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
-    aws_array_list_clear(trace);
-}
-
-/* Stub this until https://github.com/diffblue/cbmc/issues/5344 is fixed
- Original function is here:
- https://github.com/aws/aws-encryption-sdk-c/blob/master/source/edk.c#L44 */
-void aws_cryptosdk_edk_list_clean_up(struct aws_array_list *encrypted_data_keys) {
-    assert(aws_cryptosdk_edk_list_is_valid(encrypted_data_keys));
-    aws_array_list_clean_up(encrypted_data_keys);
-}
-
-/**
- * Receives encryption request from user and attempts to generate encryption materials,
- * including an encrypted data key and a list of EDKs for doing encryption.
- *
- * On success returns AWS_OP_SUCCESS and allocates encryption materials object at address
- * pointed to by output.
- *
- * On failure returns AWS_OP_ERR, sets address pointed to by output to NULL, and sets
- * internal AWS error code.
- */
 int generate_enc_materials(
     struct aws_cryptosdk_cmm *cmm,
     struct aws_cryptosdk_enc_materials **output,
-    struct aws_cryptosdk_enc_request *request) {
-    assert(aws_cryptosdk_cmm_base_is_valid(cmm));
-    assert(AWS_OBJECT_PTR_IS_WRITABLE(output));
-    assert(aws_cryptosdk_enc_request_is_valid(request));
-
-    struct aws_cryptosdk_enc_materials *materials = malloc(sizeof(*materials));
-    if (materials == NULL) {
-        *output = NULL;
-        return AWS_OP_ERR;
-    }
-
-    // Set up the allocator
-    // Request->alloc is session->alloc
-    materials->alloc = request->alloc;
-    __CPROVER_assume(aws_allocator_is_valid(materials->alloc));
-    __CPROVER_assume(materials->alloc != NULL);
-
-    // Set up the signctx
-    materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
-    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(materials->signctx));
-
-    // Set up the unencrypted_data_key
-    __CPROVER_assume(aws_byte_buf_is_bounded(&materials->unencrypted_data_key, MAX_BUFFER_SIZE));
-    ensure_byte_buf_has_allocated_buffer_member(&materials->unencrypted_data_key);
-    __CPROVER_assume(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
-
-    // Set up the edk_list
-    __CPROVER_assume(aws_cryptosdk_edk_list_is_bounded(&materials->encrypted_data_keys, MAX_EDK_LIST_ITEMS));
-    ensure_cryptosdk_edk_list_has_allocated_list(&materials->encrypted_data_keys);
-    __CPROVER_assume(aws_cryptosdk_edk_list_is_valid(&materials->encrypted_data_keys));
-
-    // The alloc is session->alloc
-    materials->encrypted_data_keys.alloc = request->alloc;
-
-    // Precondition: The edk_list has valid list elements
-    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_bounded(&materials->encrypted_data_keys, MAX_BUFFER_SIZE));
-    ensure_cryptosdk_edk_list_has_allocated_list_elements(&materials->encrypted_data_keys);
-    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_valid(&materials->encrypted_data_keys));
-
-    // Set up the keyring trace
-    __CPROVER_assume(aws_array_list_is_bounded(
-        &materials->keyring_trace, MAX_TRACE_LIST_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
-    __CPROVER_assume(materials->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
-    ensure_array_list_has_allocated_data_member(&materials->keyring_trace);
-    __CPROVER_assume(aws_array_list_is_valid(&materials->keyring_trace));
-    ensure_trace_has_allocated_records(&materials->keyring_trace, MAX_STRING_LEN);
-    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&materials->keyring_trace));
-
-    // Set the alg_id
-    enum aws_cryptosdk_alg_id alg_id;
-    materials->alg = alg_id;
-
-    *output = materials;
-    return AWS_OP_SUCCESS;
-}
+    struct aws_cryptosdk_enc_request *request);
 
 void aws_cryptosdk_priv_try_gen_key_harness() {
     /* Nondet Input */
-    struct aws_cryptosdk_session *session =
-        session_setup(MAX_TABLE_SIZE, MAX_TRACE_LIST_ITEMS, MAX_EDK_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
+    struct aws_cryptosdk_session *session = malloc(sizeof(*session));
 
     /* Assumptions */
     __CPROVER_assume(session != NULL);

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/cbmc-batch.yaml
@@ -1,4 +1,4 @@
-cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null;--unwind;1;--unwindset;aws_cryptosdk_edk_list_clear.0:2,aws_cryptosdk_edk_list_elements_are_bounded.0:2,aws_cryptosdk_edk_list_elements_are_valid.0:2,aws_cryptosdk_edk_list_is_bounded.0:2,aws_cryptosdk_edk_list_is_valid.0:2,aws_cryptosdk_keyring_trace_clear.0:2,aws_cryptosdk_keyring_trace_is_valid.0:2,ensure_cryptosdk_edk_list_has_allocated_list_elements.0:2,ensure_cryptosdk_edk_list_has_allocated_members.0:2,ensure_trace_has_allocated_records.0:2;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: aws_cryptosdk_cmm_generate_enc_materials_harness.goto
-jobos: ubuntu16
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null;--unwind;1;--unwindset;aws_cryptosdk_edk_list_clear.0:2,aws_cryptosdk_edk_list_elements_are_bounded.0:2,aws_cryptosdk_edk_list_elements_are_valid.0:2,aws_cryptosdk_edk_list_is_bounded.0:2,aws_cryptosdk_edk_list_is_valid.0:2,aws_cryptosdk_keyring_trace_clear.0:2,aws_cryptosdk_keyring_trace_is_valid.0:2,ensure_cryptosdk_edk_list_has_allocated_list_elements.0:2,ensure_cryptosdk_edk_list_has_allocated_members.0:2,ensure_trace_has_allocated_records.0:2;--object-bits;8"
+expected: "SUCCESSFUL"
+goto: aws_cryptosdk_cmm_generate_enc_materials_harness.goto
+jobos: ubuntu16

--- a/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
+++ b/verification/cbmc/proofs/derive_data_key/derive_data_key_harness.c
@@ -31,6 +31,11 @@ void derive_data_key_harness() {
         dec_materials_setup(MAX_TRACE_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
 
     /* Assumptions */
+    if (session->alg_props == NULL) {
+        struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);
+        __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
+        session->alg_props = props;
+    }
     __CPROVER_assume(aws_cryptosdk_commitment_policy_is_valid(session->commitment_policy));
     __CPROVER_assume(session->alg_props->commitment_len <= sizeof(session->key_commitment_arr));
 

--- a/verification/cbmc/proofs/sign_header/Makefile
+++ b/verification/cbmc/proofs/sign_header/Makefile
@@ -38,6 +38,7 @@ DEFINES += -DMAX_IV_LEN=$(MAX_IV_LEN)
 DEFINES += -DAWS_CRYPTOSDK_HASH_ELEMS_ARRAY_INIT_GENERATOR=array_list_item_generator
 
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
+PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/hash_table.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/string.c
 PROJECT_SOURCES += $(COMMON_PROOF_UNINLINE)/array_list.c

--- a/verification/cbmc/proofs/sign_header/Makefile
+++ b/verification/cbmc/proofs/sign_header/Makefile
@@ -75,7 +75,6 @@ PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_array_list_sort_noop_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_enc_ctx_size_stub.c
 PROOF_SOURCES += $(PROOF_STUB)/aws_cryptosdk_hash_elems_array_init_stub.c
-PROOF_SOURCES += $(PROOF_STUB)/aws_default_allocator_stub.c
 # Stubbing out aws_cryptosdk_hdr_write leads to a huge gain in performance
 PROOF_SOURCES += $(PROOF_STUB)/hdr_write_stub.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)

--- a/verification/cbmc/proofs/sign_header/sign_header_harness.c
+++ b/verification/cbmc/proofs/sign_header/sign_header_harness.c
@@ -49,6 +49,11 @@ void sign_header_harness() {
         session_setup(MAX_TABLE_SIZE, MAX_TRACE_LIST_ITEMS, MAX_EDK_LIST_ITEMS, MAX_BUFFER_SIZE, MAX_STRING_LEN);
 
     /* Assumptions */
+    if (session->alg_props == NULL) {
+        struct aws_cryptosdk_alg_properties *props = ensure_alg_properties_attempt_allocation(MAX_STRING_LEN);
+        __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
+        session->alg_props = props;
+    }
     __CPROVER_assume(session->alg_props->impl->cipher_ctor != NULL);
     __CPROVER_assume(aws_byte_buf_is_bounded(&session->header.iv, session->alg_props->iv_len));
     __CPROVER_assume(aws_byte_buf_is_bounded(&session->header.auth_tag, session->alg_props->tag_len));

--- a/verification/cbmc/stubs/aws_array_list_item_generator_u8_stub.c
+++ b/verification/cbmc/stubs/aws_array_list_item_generator_u8_stub.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <proof_helpers/make_common_data_structures.h>
+
+/*
+ * A generator function as described in the comment
+ * in aws_cryptosdk_hash_elems_array_init_stub.c
+ * This generator is set in the Makefile
+ */
+void array_list_item_generator(struct aws_array_list *elems) {
+    assert(elems->item_size == sizeof(struct aws_hash_element));
+    for (size_t index = 0; index < elems->length; ++index) {
+        struct aws_hash_element *val = (struct aws_hash_element *)((uint8_t *)elems->data + (elems->item_size * index));
+        /* Due to the cast to uint16, the entire size of the enc_ctx must be less than < UINT16_MAX
+         * This is a simple way to ensure this without a call to enc_ctx_size. */
+        struct aws_string *key = ensure_string_is_allocated_nondet_length();
+        __CPROVER_assume(aws_string_is_valid(key));
+        __CPROVER_assume(key->len <= UINT8_MAX);
+        val->key                 = key;
+        struct aws_string *value = ensure_string_is_allocated_nondet_length();
+        __CPROVER_assume(aws_string_is_valid(value));
+        __CPROVER_assume(value->len <= UINT8_MAX);
+        val->value = value;
+    }
+}

--- a/verification/cbmc/stubs/aws_array_list_item_generator_u8_stub.c
+++ b/verification/cbmc/stubs/aws_array_list_item_generator_u8_stub.c
@@ -17,8 +17,18 @@
 
 /*
  * A generator function as described in the comment
- * in aws_cryptosdk_hash_elems_array_init_stub.c
- * This generator is set in the Makefile
+ * in aws_cryptosdk_hash_elems_array_init_stub.c:
+ *
+ * If the consumer of the list does not use the elements in the list,
+ * we can just leave it undefined. This is sound, as it gives you a totally
+ * nondet. value every time you use a list element, and is the default
+ * behaviour of CBMC. But if it is used, we need a way for the harness
+ * to specify valid values for the element, for example if they are copying
+ * values out of the table. They can do this by defining
+ * -DAWS_CRYPTOSDK_HASH_ELEMS_ARRAY_INIT_GENERATOR=the_generator_fn
+ *   where the_generator_fn has signature
+ * the_generator_fn(struct aws_array_list *elems).
+ *   [elems] is a pointer to the array_list whose values need to be set
  */
 void array_list_item_generator(struct aws_array_list *elems) {
     assert(elems->item_size == sizeof(struct aws_hash_element));

--- a/verification/cbmc/stubs/generate_enc_materials_stub.c
+++ b/verification/cbmc/stubs/generate_enc_materials_stub.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/materials.h>
+
+#include <cbmc_invariants.h>
+#include <make_common_data_structures.h>
+#include <proof_helpers/make_common_data_structures.h>
+
+/**
+ * Receives encryption request from user and attempts to generate encryption materials,
+ * including an encrypted data key and a list of EDKs for doing encryption.
+ *
+ * On success returns AWS_OP_SUCCESS and allocates encryption materials object at address
+ * pointed to by output.
+ *
+ * On failure returns AWS_OP_ERR, sets address pointed to by output to NULL, and sets
+ * internal AWS error code.
+ */
+int generate_enc_materials(
+    struct aws_cryptosdk_cmm *cmm,
+    struct aws_cryptosdk_enc_materials **output,
+    struct aws_cryptosdk_enc_request *request) {
+    assert(aws_cryptosdk_cmm_base_is_valid(cmm));
+    assert(AWS_OBJECT_PTR_IS_WRITABLE(output));
+    assert(aws_cryptosdk_enc_request_is_valid(request));
+
+    struct aws_cryptosdk_enc_materials *materials = malloc(sizeof(*materials));
+    if (materials == NULL) {
+        *output = NULL;
+        return AWS_OP_ERR;
+    }
+
+    // Set up the allocator
+    // Request->alloc is session->alloc
+    materials->alloc = request->alloc;
+    __CPROVER_assume(aws_allocator_is_valid(materials->alloc));
+    __CPROVER_assume(materials->alloc != NULL);
+
+    // Set up the signctx
+    materials->signctx = ensure_nondet_sig_ctx_has_allocated_members();
+    __CPROVER_assume(aws_cryptosdk_sig_ctx_is_valid_cbmc(materials->signctx));
+
+    // Set up the unencrypted_data_key
+    __CPROVER_assume(aws_byte_buf_is_bounded(&materials->unencrypted_data_key, MAX_BUFFER_SIZE));
+    ensure_byte_buf_has_allocated_buffer_member(&materials->unencrypted_data_key);
+    __CPROVER_assume(aws_byte_buf_is_valid(&materials->unencrypted_data_key));
+
+    // Set up the edk_list
+    __CPROVER_assume(aws_cryptosdk_edk_list_is_bounded(&materials->encrypted_data_keys, MAX_EDK_LIST_ITEMS));
+    ensure_cryptosdk_edk_list_has_allocated_list(&materials->encrypted_data_keys);
+    __CPROVER_assume(aws_cryptosdk_edk_list_is_valid(&materials->encrypted_data_keys));
+
+    // The alloc is session->alloc
+    materials->encrypted_data_keys.alloc = request->alloc;
+
+    // Precondition: The edk_list has valid list elements
+    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_bounded(&materials->encrypted_data_keys, MAX_BUFFER_SIZE));
+    ensure_cryptosdk_edk_list_has_allocated_list_elements(&materials->encrypted_data_keys);
+    __CPROVER_assume(aws_cryptosdk_edk_list_elements_are_valid(&materials->encrypted_data_keys));
+
+    // Set up the keyring trace
+    __CPROVER_assume(aws_array_list_is_bounded(
+        &materials->keyring_trace, MAX_TRACE_LIST_ITEMS, sizeof(struct aws_cryptosdk_keyring_trace_record)));
+    __CPROVER_assume(materials->keyring_trace.item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    ensure_array_list_has_allocated_data_member(&materials->keyring_trace);
+    __CPROVER_assume(aws_array_list_is_valid(&materials->keyring_trace));
+    ensure_trace_has_allocated_records(&materials->keyring_trace, MAX_STRING_LEN);
+    __CPROVER_assume(aws_cryptosdk_keyring_trace_is_valid(&materials->keyring_trace));
+
+    // Set the alg_id
+    enum aws_cryptosdk_alg_id alg_id;
+    materials->alg = alg_id;
+
+    *output = materials;
+    return AWS_OP_SUCCESS;
+}

--- a/verification/cbmc/stubs/hkdf_stub.c
+++ b/verification/cbmc/stubs/hkdf_stub.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/private/hkdf.h>
+
+#include <proof_helpers/make_common_data_structures.h>
+
+/* Stub this for performance but check the preconditions.
+ No modified data structure is used again.
+ Original function is here:
+ https://github.com/aws/aws-encryption-sdk-c/blob/master/source/hkdf.c#148 */
+int aws_cryptosdk_hkdf(
+    struct aws_byte_buf *okm,
+    enum aws_cryptosdk_sha_version which_sha,
+    const struct aws_byte_buf *salt,
+    const struct aws_byte_buf *ikm,
+    const struct aws_byte_buf *info) {
+    assert(aws_byte_buf_is_valid(salt));
+    assert(aws_byte_buf_is_valid(ikm));
+    assert(aws_byte_buf_is_valid(info));
+    if (nondet_bool()) {
+        return AWS_OP_ERR;
+    }
+    return AWS_OP_SUCCESS;
+}

--- a/verification/cbmc/stubs/hkdf_stub.c
+++ b/verification/cbmc/stubs/hkdf_stub.c
@@ -27,6 +27,7 @@ int aws_cryptosdk_hkdf(
     const struct aws_byte_buf *salt,
     const struct aws_byte_buf *ikm,
     const struct aws_byte_buf *info) {
+    assert(aws_byte_buf_is_valid(okm));
     assert(aws_byte_buf_is_valid(salt));
     assert(aws_byte_buf_is_valid(ikm));
     assert(aws_byte_buf_is_valid(info));

--- a/verification/cbmc/stubs/keyring_trace_clean_up_stub.c
+++ b/verification/cbmc/stubs/keyring_trace_clean_up_stub.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/edk.h>
+
+#include <proof_helpers/make_common_data_structures.h>
+
+/* Stub this until https://github.com/diffblue/cbmc/issues/5344 is fixed
+ Original function is here:
+ https://github.com/aws/aws-encryption-sdk-c/blob/master/source/edk.c#L44 */
+void aws_cryptosdk_edk_list_clean_up(struct aws_array_list *encrypted_data_keys) {
+    assert(aws_cryptosdk_edk_list_is_valid(encrypted_data_keys));
+    aws_array_list_clean_up(encrypted_data_keys);
+}

--- a/verification/cbmc/stubs/keyring_trace_clear_stub.c
+++ b/verification/cbmc/stubs/keyring_trace_clear_stub.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/keyring_trace.h>
+
+#include <proof_helpers/make_common_data_structures.h>
+
+/* Stub this because of the override of aws_array_list_get_at_ptr
+ Original function is here:
+ https://github.com/aws/aws-encryption-sdk-c/blob/master/source/keyring_trace.c#L235 */
+void aws_cryptosdk_keyring_trace_clear(struct aws_array_list *trace) {
+    AWS_FATAL_PRECONDITION(aws_cryptosdk_keyring_trace_is_valid(trace));
+    AWS_FATAL_PRECONDITION(trace->item_size == sizeof(struct aws_cryptosdk_keyring_trace_record));
+    aws_array_list_clear(trace);
+}

--- a/verification/cbmc/stubs/transfer_list_stub.c
+++ b/verification/cbmc/stubs/transfer_list_stub.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/cryptosdk/list_utils.h>
+
+#include <proof_helpers/make_common_data_structures.h>
+
+/* Stub this because of the override of aws_array_list_get_at_ptr and for performance.
+ The contents of session->keyring_trace are nondet in the construction of the harness.
+ Also neither keyring trace is later used.
+ Original function is here:
+ https://github.com/aws/aws-encryption-sdk-c/blob/master/source/list_utils.c#L17 */
+int aws_cryptosdk_transfer_list(struct aws_array_list *dest, struct aws_array_list *src) {
+    assert(src != dest);
+    assert(aws_array_list_is_valid(dest));
+    assert(aws_array_list_is_valid(src));
+    assert(dest->item_size == src->item_size);
+
+    if (nondet_bool()) {
+        return AWS_OP_ERR;
+    }
+    return AWS_OP_SUCCESS;
+}


### PR DESCRIPTION
Adds Makefile, harness and yaml for proof of aws_cryptosdk_priv_try_gen_key. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

