### PR TITLE
Disable CBMC proof for aws_cryptosdk_keyring_trace_copy_all

### DIFF
--- a/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/cbmc-batch.yaml
@@ -1,4 +1,0 @@
-cbmcflags: "--flush;--bounds-check;--conversion-check;--div-by-zero-check;--float-overflow-check;--nan-check;--pointer-check;--pointer-overflow-check;--pointer-primitive-check;--signed-overflow-check;--undefined-shift-check;--unsigned-overflow-check;--unwinding-assertions;--malloc-may-fail;--malloc-fail-null;--unwind;1;--unwindset;__CPROVER_file_local_list_utils_c_list_copy_all.5:3,__CPROVER_file_local_list_utils_c_list_copy_all.6:3,aws_cryptosdk_keyring_trace_is_valid.0:3;--object-bits;8"
-expected: "SUCCESSFUL"
-goto: aws_cryptosdk_keyring_trace_copy_all_harness.goto
-jobos: ubuntu16


### PR DESCRIPTION
*Issue #, if available:* #672

*Description of changes:* This PR disables the execution of proof `aws_cryptosdk_keyring_trace_copy_all`, which is always failing to be completed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

