### PR TITLE
Set concurrency limit for litani jobs

### DIFF
--- a/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.

--- a/verification/cbmc/proofs/run-cbmc-proofs.py
+++ b/verification/cbmc/proofs/run-cbmc-proofs.py
@@ -163,8 +163,8 @@ def run_build(litani, jobs):
     cmd = [str(litani), "run-build"]
     if jobs:
         cmd.extend(["-j", str(jobs)])
-    # Set a limit on the number of concurrent jobs based on CPUs
-    # https://github.com/aws/aws-encryption-sdk-c/pull/673
+    # Restrict concurrency during CI to avoid 'out of memory' errors
+    # when proofs that require a lot of memory run concurrently
     else:
         factor   = 0.75
         cpu_num  = os.cpu_count()

--- a/verification/cbmc/proofs/run-cbmc-proofs.py
+++ b/verification/cbmc/proofs/run-cbmc-proofs.py
@@ -170,9 +170,13 @@ def run_build(litani, jobs, factor):
         cmd.extend(["-j", str(jobs)])
     else:
         cpu_num  = os.cpu_count()
-        if cpu_num is not None and cpu_num > 1:
+        if cpu_num is not None:
             lim_jobs = int(factor * cpu_num)
+            lim_jobs = lim_jobs if lim_jobs else 1
             cmd.extend(["-j", str(lim_jobs)])
+        else:
+            logging.warning("Could not get the number of CPUs")
+
 
     logging.debug(" ".join(cmd))
     proc = subprocess.run(cmd)

--- a/verification/cbmc/proofs/run-cbmc-proofs.py
+++ b/verification/cbmc/proofs/run-cbmc-proofs.py
@@ -163,6 +163,13 @@ def run_build(litani, jobs):
     cmd = [str(litani), "run-build"]
     if jobs:
         cmd.extend(["-j", str(jobs)])
+    # Set a limit on the number of concurrent jobs based on CPUs
+    # https://github.com/aws/aws-encryption-sdk-c/pull/673
+    else:
+        factor   = 0.75
+        cpu_num  = os.cpu_count()
+        lim_jobs = int(factor * cpu_num)
+        cmd.extend(["-j", str(lim_jobs)])
 
     logging.debug(" ".join(cmd))
     proc = subprocess.run(cmd)

--- a/verification/cbmc/proofs/run-cbmc-proofs.py
+++ b/verification/cbmc/proofs/run-cbmc-proofs.py
@@ -168,8 +168,6 @@ def run_build(litani, jobs, factor):
     cmd = [str(litani), "run-build"]
     if jobs:
         cmd.extend(["-j", str(jobs)])
-    # Restrict concurrency during CI to avoid 'out of memory' errors
-    # when proofs that require a lot of memory run concurrently
     else:
         cpu_num  = os.cpu_count()
         if cpu_num is not None and cpu_num > 1:


### PR DESCRIPTION
This PR adds a concurrency limit for litani run-build jobs as a solution to #672. It also restores CBMC proof `aws_cryptosdk_keyring_trace_copy_all` which was temporarily disabled in #673.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

