### PR TITLE
Optimize CBMC proof for aws_cryptosdk_keyring_trace_copy_all

### DIFF
--- a/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.


### PR DESCRIPTION
This PR optimizes the CBMC proof for `aws_cryptosdk_keyring_trace_copy_all` by removing deep validators.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

