### PR TITLE
Use default solver in CBMC proof for aws_cryptosdk_keyring_trace_copy_all

### DIFF
--- a/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/Makefile
@@ -33,6 +33,11 @@ CBMCFLAGS +=
 DEFINES += -DAWS_NO_STATIC_IMPL
 DEFINES += -DNUM_ELEMS=$(NUM_ELEMS)
 
+# Running this proof with kissat causes it to fail due to kissat
+# getting an "out of memory" error - even if only this proof is running
+# It does not happen with the default solver, so we unset the variable here
+EXTERNAL_SAT_SOLVER =
+
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/array_list.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/byte_buf.c
 PROJECT_SOURCES += $(CBMC_ROOT)/aws-c-common/source/common.c

--- a/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/cbmc-batch.yaml
+++ b/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/cbmc-batch.yaml
@@ -1,0 +1,4 @@
+:
+  This file marks this directory as containing a CBMC proof. This file
+  is automatically clobbered in CI and replaced with parameters for
+  running the proof.


### PR DESCRIPTION
This PR restores the CBMC proof for `aws_cryptosdk_keyring_trace_copy_all` and unsets the `EXTERNAL_SAT_SOLVER` variable in the Makefile of this proof so that the proof is run with the default solver.

In the past, we have attempted to solve issue #672 by setting a limit on concurrency in CI (#674) or reducing the complexity of the proof (#676). But none of these proposals worked, as it seems that `kissat` will consume a huge amount of memory before getting an "out of memory" error. Therefore the best solution is to avoid using `kissat` in this proof.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

