### PR TITLE
Add .gitignore for CBMC proofs

### DIFF
--- a/verification/cbmc/.gitignore
+++ b/verification/cbmc/.gitignore
@@ -1,5 +1,20 @@
-jobs/*/link-farm
-jobs/*/html
+# Emitted when running CBMC proofs
+proofs/**/logs
+proofs/**/gotos
+proofs/**/report
+proofs/**/html
 
-# Written by litani on each proof run
+# Emitted by CBMC Viewer
+TAGS-*
+
+# Emitted by Arpa
+arpa_cmake/
+arpa-validation-logs/
+Makefile.arpa
+
+# Emitted by litani
+.ninja_deps
+.ninja_log
 .litani_cache_dir
+
+__pycache__/


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

