### PR TITLE
Remove unnecessary include from on_encrypt stub

### DIFF
--- a/verification/cbmc/stubs/on_encrypt_stub.c
+++ b/verification/cbmc/stubs/on_encrypt_stub.c
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-#include <stdlib.h>
-
 #include <aws/cryptosdk/default_cmm.h>
 
 #include <proof_helpers/make_common_data_structures.h>


### PR DESCRIPTION
*Description of changes:* This PR is a quick fix that removes an unnecessary include from `on_encrypt_stub.c` which was added in #656 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

