### PR TITLE
WIP: aws-sdk-cpp >= 1.8.110 fixes cmake?

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -26,21 +26,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: "aws/aws-sdk-cpp"
-          ref: "1.8.32"
+          ref: "1.8.128"
           path: "aws-sdk-cpp"
-
-      # The hosted Actions runners include CMake v3.19.1 by default, which has
-      # a regression that causes aws-sdk-cpp and aws-encryption-sdk-c to fail
-      # to build on the runners. We install the previous working version as a
-      # workaround. See https://github.com/aws/aws-encryption-sdk-c/issues/650.
-      - name: Install CMake v3.18.5
-        run: |
-          brew uninstall cmake
-          curl -L https://github.com/Kitware/CMake/releases/download/v3.18.5/cmake-3.18.5-Darwin-x86_64.tar.gz | tar xz
-          cd cmake-3.18.5-Darwin-x86_64/CMake.app/Contents
-          sudo cp bin/* /usr/local/bin/
-          sudo cp share/aclocal/* /usr/local/share/aclocal/
-          sudo cp -R share/cmake-3.18 /usr/local/share/
 
       - name: Build and install aws-sdk-cpp
         run: |


### PR DESCRIPTION
*Issue #, if available:* #658

*Description of changes:* WIP Change: Testing an update to `aws-sdk-cpp` via GHA to see if this resolves build issue with `cmake` 3.19; will finish upgrade if this appears to resolve the issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

