### PR TITLE
fix: Force MacOS build to CMake 3.19.3.

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -39,8 +39,10 @@ jobs:
       # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
       - name: Install CMake v3.19.3
         run: |
-          brew install cmake@3.19.3
-          brew switch cmake 3.19.3
+          brew uninstall cmake
+          curl -L https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-macos-universal.tar.gz | tar xz
+          cd cmake-3.19.3-macos-universal/CMake.app/Contents/bin
+          ./cmake-gui --install
 
       - name: Build and install aws-sdk-cpp
         run: |

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -31,13 +31,17 @@ jobs:
 
       # The hosted Actions runners include CMake v3.19.1 by default, which has
       # a regression that causes aws-sdk-cpp and aws-encryption-sdk-c to fail
-      # to build on the runners. We install the previous working version as a
-      # workaround. See https://github.com/aws/aws-encryption-sdk-c/issues/650.
-      - name: Install CMake v3.18.5
+      # to build on the runners.
+      # This appears to have been an issue in CMake that is fixed in 3.19.3.
+      # This workaround is required until the MacOS Action is updated to a
+      # a newer CMake, or the dependency adds a workaround for 3.19.1.
+      # See https://github.com/aws/aws-encryption-sdk-c/issues/650 and
+      # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
+      - name: Install CMake v3.19.3
         run: |
           brew uninstall cmake
-          curl -L https://github.com/Kitware/CMake/releases/download/v3.18.5/cmake-3.18.5-Darwin-x86_64.tar.gz | tar xz
-          cd cmake-3.18.5-Darwin-x86_64/CMake.app/Contents
+          curl -L https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Darwin-x86_64.tar.gz | tar xz
+          cd cmake-3.19.3-Darwin-x86_64/CMake.app/Contents
           sudo cp bin/* /usr/local/bin/
           sudo cp share/aclocal/* /usr/local/share/aclocal/
           sudo cp -R share/cmake-3.18 /usr/local/share/

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -39,12 +39,8 @@ jobs:
       # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
       - name: Install CMake v3.19.3
         run: |
-          brew uninstall cmake
-          curl -L https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Darwin-x86_64.tar.gz | tar xz
-          cd cmake-3.19.3-Darwin-x86_64/CMake.app/Contents
-          sudo cp bin/* /usr/local/bin/
-          sudo cp share/aclocal/* /usr/local/share/aclocal/
-          sudo cp -R share/cmake-3.18 /usr/local/share/
+          brew install cmake@3.19.3
+          brew switch cmake 3.19.3
 
       - name: Build and install aws-sdk-cpp
         run: |


### PR DESCRIPTION
*Issue #, if available:* #658

*Description of changes:* CMake 3.19.1 seems to have a problem with `aws-checksums` configuration. This appears to be a bug fixed in CMake because the build works fine with 3.19.3 and the older versions of CMake that this change upgrades.

Unfortunately 3.19.1 is *the* version in GitHub Actions' MacOS 10.15 image right now, see https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md

Attempting to use Homebrew, 3.19.3 is generally exposed but is not exposed to the GHA environment.

In any event, manually pulling 3.19.3 from CMake's repository the way we were pulling 3.18.5 does the trick.

I am leaving #658 open though because eventually it would be nice to remove this version pinning entirely.

(I'll retitle #658 if this fix is acceptable and is merged.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

