### PR TITLE
Avoid null-pointer arithmetic

### DIFF
--- a/source/framefmt.c
+++ b/source/framefmt.c
@@ -106,23 +106,24 @@ struct aws_cryptosdk_framestate {
  * the cursor at 'cursorptr' to refer to a block of 'size' bytes within the ciphertext
  * buffer.
  */
-#define field_sized(state, bufptr, size)                                                                 \
-    do {                                                                                                 \
-        (state)->ciphertext_size += (size);                                                              \
-        memset((bufptr), 0, sizeof(*(bufptr)));                                                          \
-        if ((state)->writing) {                                                                          \
-            if ((state)->u.buffer.capacity - (state)->u.buffer.len >= (size)) {                          \
-                (bufptr)->buffer   = (state)->u.buffer.buffer + (state)->u.buffer.len;                   \
-                (bufptr)->len      = 0;                                                                  \
-                (bufptr)->capacity = (size);                                                             \
-                (state)->u.buffer.len += (size);                                                         \
-            }                                                                                            \
-        } else {                                                                                         \
-            struct aws_byte_cursor cursor = aws_byte_cursor_advance(&(state)->u.cursor, (size_t)(size)); \
-            (bufptr)->buffer              = cursor.ptr;                                                  \
-            (bufptr)->len = (bufptr)->capacity = cursor.len;                                             \
-        }                                                                                                \
-        (state)->too_small = (state)->too_small || !(bufptr)->buffer;                                    \
+#define field_sized(state, bufptr, size)                                                                    \
+    do {                                                                                                    \
+        (state)->ciphertext_size += (size);                                                                 \
+        memset((bufptr), 0, sizeof(*(bufptr)));                                                             \
+        if ((state)->writing) {                                                                             \
+            if ((state)->u.buffer.capacity - (state)->u.buffer.len >= (size)) {                             \
+                (bufptr)->buffer =                                                                          \
+                    ((state)->u.buffer.buffer) ? ((state)->u.buffer.buffer + (state)->u.buffer.len) : NULL; \
+                (bufptr)->len      = 0;                                                                     \
+                (bufptr)->capacity = (size);                                                                \
+                (state)->u.buffer.len += (size);                                                            \
+            }                                                                                               \
+        } else {                                                                                            \
+            struct aws_byte_cursor cursor = aws_byte_cursor_advance(&(state)->u.cursor, (size_t)(size));    \
+            (bufptr)->buffer              = cursor.ptr;                                                     \
+            (bufptr)->len = (bufptr)->capacity = cursor.len;                                                \
+        }                                                                                                   \
+        (state)->too_small = (state)->too_small || !(bufptr)->buffer;                                       \
     } while (0)
 
 static int serde_last_frame(

--- a/verification/cbmc/proofs/aws_cryptosdk_enc_ctx_clone/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_enc_ctx_clone/Makefile
@@ -23,6 +23,9 @@ MAX_TABLE_SIZE ?= 4
 # Time on my laptop: 5m10s
 #########
 
+# Disable pointer overflow check
+CBMC_FLAG_POINTER_OVERFLOW_CHECK=
+
 PROOF_UID = aws_cryptosdk_enc_ctx_clone
 
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/verification/cbmc/proofs/aws_cryptosdk_enc_ctx_serialize/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_enc_ctx_serialize/Makefile
@@ -28,6 +28,9 @@ TABLE_SIZE_IN_WORDS=$(shell echo $$(($$((3 * $(MAX_TABLE_SIZE))) + 10)))
 #########
 # Vars for Makefile.common
 
+# Disable pointer overflow check
+CBMC_FLAG_POINTER_OVERFLOW_CHECK=
+
 PROOF_UID = aws_cryptosdk_enc_ctx_serialize
 
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/verification/cbmc/proofs/aws_cryptosdk_hdr_write/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_hdr_write/Makefile
@@ -17,6 +17,9 @@ sinclude ../Makefile.local
 include ../Makefile.local_default
 include ../Makefile.aws_byte_buf
 
+# Disable pointer overflow check
+CBMC_FLAG_POINTER_OVERFLOW_CHECK=
+
 PROOF_UID = aws_cryptosdk_hdr_write
 
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/Makefile
@@ -11,7 +11,6 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-###########
 # if Makefile.local exists, use it. This provides a way to override the defaults
 sinclude ../Makefile.local
 #otherwise, use the default values
@@ -31,8 +30,16 @@ PROJECT_SOURCES += $(SRCDIR)/source/framefmt.c
 
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/make_common_data_structures.c
 PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/proof_allocators.c
+PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
-###########
+
+REMOVE_FUNCTION_BODY += aws_byte_cursor_advance
+REMOVE_FUNCTION_BODY += aws_byte_cursor_advance_nospec
+REMOVE_FUNCTION_BODY += aws_byte_cursor_read
+REMOVE_FUNCTION_BODY += aws_byte_cursor_read_be32
+REMOVE_FUNCTION_BODY += aws_byte_cursor_read_be64
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_byte_order_inl_aws_ntoh32
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_byte_order_inl_aws_ntoh64
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/Makefile
@@ -34,12 +34,10 @@ PROOF_SOURCES += $(COMMON_PROOF_SOURCE)/utils.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_data_structures.c
 
+# We abstract this function because manual inspection demonstrates it is unreachable.
+# Improves coverage metrics.
 REMOVE_FUNCTION_BODY += aws_byte_cursor_advance
-REMOVE_FUNCTION_BODY += aws_byte_cursor_advance_nospec
-REMOVE_FUNCTION_BODY += aws_byte_cursor_read
 REMOVE_FUNCTION_BODY += aws_byte_cursor_read_be32
 REMOVE_FUNCTION_BODY += aws_byte_cursor_read_be64
-REMOVE_FUNCTION_BODY += __CPROVER_file_local_byte_order_inl_aws_ntoh32
-REMOVE_FUNCTION_BODY += __CPROVER_file_local_byte_order_inl_aws_ntoh64
 
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
+++ b/verification/cbmc/proofs/aws_cryptosdk_serialize_frame/aws_cryptosdk_serialize_frame_harness.c
@@ -29,9 +29,7 @@ void aws_cryptosdk_serialize_frame_harness() {
     /* Assumptions about the function input */
     ensure_byte_buf_has_allocated_buffer_member(&ciphertext_buf);
     __CPROVER_assume(aws_byte_buf_is_valid(&ciphertext_buf));
-
     __CPROVER_assume(aws_cryptosdk_frame_has_valid_type(&frame));
-
     __CPROVER_assume(aws_cryptosdk_alg_properties_is_valid(props));
 
     /* Save the old state of the ciphertext buffer */


### PR DESCRIPTION
*Issue #, if available:*
N/A.

*Description of changes:*
This PR contains two changes:
1. Avoid null-pointer arithmetic.
2. Disable pointer-overflow check for slow proofs.

We have run CBMC 5.30.1 on all proofs in ESDK-C. We must fix these issues before we update CBMC version in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

