### PR TITLE
Mark high-memory usage proofs as EXPENSIVE

### DIFF
--- a/verification/cbmc/proofs/aws_cryptosdk_enc_ctx_size/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_enc_ctx_size/Makefile
@@ -58,4 +58,6 @@ UNWINDSET += aws_cryptosdk_enc_ctx_size.0:$(call addone,$(MAX_TABLE_SIZE))
 UNWINDSET += memset_override_0_impl.0:$(call addone,$(TABLE_SIZE_IN_WORDS))
 ###########
 
+EXPENSIVE = true
+
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_copy_all/Makefile
@@ -64,5 +64,7 @@ UNWINDSET += __CPROVER_file_local_list_utils_c_list_copy_all.5:$(call addone,$(N
 UNWINDSET += __CPROVER_file_local_list_utils_c_list_copy_all.6:$(call addone,$(NUM_ELEMS))
 UNWINDSET += aws_cryptosdk_keyring_trace_is_valid.0:$(call addone,$(NUM_ELEMS))
 
+EXPENSIVE = true
+
 ###########
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_eq/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_keyring_trace_eq/Makefile
@@ -43,4 +43,6 @@ UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_ITEM_SIZE)
 UNWINDSET += memcmp.0:$(call addone,$(MAX_STRING_LEN))
 ###########
 
+EXPENSIVE = true
+
 include ../Makefile.common

--- a/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
+++ b/verification/cbmc/proofs/aws_cryptosdk_priv_try_gen_key/Makefile
@@ -115,5 +115,7 @@ UNWINDSET += ensure_cryptosdk_edk_list_has_allocated_list_elements.0:$(call addo
 UNWINDSET += ensure_trace_has_allocated_records.0:$(call addone,$(MAX_TRACE_LIST_ITEMS))
 UNWINDSET += memcmp.0:$(call addone,$(MAX_BUFFER_SIZE))
 
+EXPENSIVE = true
+
 ###########
 include ../Makefile.common


### PR DESCRIPTION
This commit marks the four proofs with the highest memory requirements
as EXPENSIVE, meaning that Litani will not run those four proofs in
parallel.

Prior to this commit, the proofs required the following
resources:

* Coverage checks:
  aws_cryptosdk_keyring_trace_copy_all: ~16 GB

* Safety checks:
  aws_cryptosdk_keyring_trace_copy_all: ~16 GB
  aws_cryptosdk_keyring_trace_eq: ~12GB
  aws_cryptosdk_enc_ctx_size: ~11GB
  aws_cryptosdk_priv_try_gen_key: ~11GB

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

