### PR TITLE
chore: Use continuous-integration environment for private submodule access

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -7,6 +7,7 @@ on: ["pull_request", "push"]
 jobs:
   OSX:
     runs-on: ${{ matrix.os }}
+    environment: continuous-integration
 
     strategy:
       matrix:
@@ -20,6 +21,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+        if: ${{ github.repository == 'aws/aws-encryption-sdk-c' }}
+
+      - name: Checkout PR with CI bot token
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          token: ${{ secrets.CI_BOT_TOKEN }}
+        if: ${{ github.repository == 'aws/private-aws-encryption-sdk-c-staging' }}
 
       - name: Checkout AWS C++ SDK
         uses: actions/checkout@v2


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.