### PR TITLE
Integrate aws-encryption-sdk-c with awslc on Ubuntu.

### DIFF
--- a/codebuild/bin/codebuild-test.sh
+++ b/codebuild/bin/codebuild-test.sh
@@ -17,6 +17,7 @@ set -euxo pipefail
 
 PATH=$PWD/build-tools/bin:$PATH
 ROOT=$PWD
+NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
 
 # End to end tests require valid credentials (instance role, etc..)
 # Disable for local runs.
@@ -67,7 +68,7 @@ run_test() {
         -GNinja \
         .. "$@" 2>&1|head -n 1000)
     cmake --build $ROOT/build -- -v
-    (cd build; ctest --output-on-failure -j8)
+    (cd build; ctest --output-on-failure -j${NUM_CPU_THREADS})
     (cd build; debug ./tests/test_local_cache_threading) || exit 1
     "$ROOT/codebuild/bin/test-install.sh" "$PREFIX_PATH" "$PWD/build"
 }
@@ -97,4 +98,3 @@ case "$TEST_MODE" in
         exit 1
         ;;
 esac
-

--- a/codebuild/bin/codebuild-test.sh
+++ b/codebuild/bin/codebuild-test.sh
@@ -17,7 +17,7 @@ set -euxo pipefail
 
 PATH=$PWD/build-tools/bin:$PATH
 ROOT=$PWD
-NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
+NUM_CPU_THREADS=$(nproc)
 
 # End to end tests require valid credentials (instance role, etc..)
 # Disable for local runs.

--- a/codebuild/bin/install-aws-deps.sh
+++ b/codebuild/bin/install-aws-deps.sh
@@ -37,7 +37,7 @@ build_pkg() {
         git clone --depth 1 --branch $GIT_REF --recurse-submodules "$GIT_URL" "$SRC_DIR"
     fi
 
-    mkdir $BUILD_DIR
+    mkdir -p $BUILD_DIR
     (cd $BUILD_DIR &&
      export LD_LIBRARY_PATH=/deps/install &&
      cmake $SRC_DIR "$@" -DCMAKE_INSTALL_PREFIX=$root/install -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja \

--- a/codebuild/bin/install-shared-deps-awslc.sh
+++ b/codebuild/bin/install-shared-deps-awslc.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is similar to |install-shared-deps.sh| except below differences:
+# 1. OpenSSL is replaced with awslc.
+# 2. LibCurl version is updated to 7.74.
+# After this script, awslc(static and shared) and curl will be installed under /deps/install.
+
+set -euxo pipefail
+
+export AWSLC_SRC_DIR=/tmp/awslc
+export INSTALL_DIR=/deps/install
+export LD_LIBRARY_PATH=${INSTALL_DIR}
+export NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
+
+function download_awslc() {
+    AWSLC_GIT_URL='https://github.com/awslabs/aws-lc.git'
+    AWSLC_GIT_REF='main'
+    rm -rf ${AWSLC_SRC_DIR}
+    mkdir -p ${AWSLC_SRC_DIR}
+    git clone --depth 1 --branch ${AWSLC_GIT_REF} --recurse-submodules "${AWSLC_GIT_URL}" "${AWSLC_SRC_DIR}"
+}
+
+function build_awslc() {
+    BUILD_DIR=/tmp/build/awslc
+    rm -rf ${BUILD_DIR}
+    mkdir -p ${BUILD_DIR}
+    CMAKE_BUILD_COMMAND="cmake ${AWSLC_SRC_DIR} $@ \
+        -GNinja \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+    if [[ !(-z "${CFLAGS+x}" || -z "${CFLAGS}") ]]; then
+        CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DCMAKE_C_FLAGS=${CFLAGS}"
+    fi
+    if [[ !(-z "${CXXFLAGS+x}" || -z "${CXXFLAGS}") ]]; then
+        CMAKE_BUILD_COMMAND="${CMAKE_BUILD_COMMAND} -DCMAKE_CXX_FLAGS=${CXXFLAGS}"
+    fi
+    (cd ${BUILD_DIR} && ${CMAKE_BUILD_COMMAND})
+    cmake --build ${BUILD_DIR}
+    cmake --build ${BUILD_DIR} --target install
+    rm -rf ${BUILD_DIR}
+}
+
+function install_libcurl() {
+    mkdir /deps/curl
+    cd /deps/curl
+    wget https://curl.haxx.se/download/curl-7.74.0.tar.gz
+    tar xzf curl-*.tar.gz
+    cd curl-*/
+    # awslc is forked from boringssl.
+    # |OPENSSL_IS_AWSLC| macro is equivalent to |OPENSSL_IS_BORINGSSL|.
+    # Replacing OPENSSL_IS_BORINGSSL with OPENSSL_IS_AWSLC.
+    find ./ -type f -exec sed -i -e 's/OPENSSL_IS_BORINGSSL/OPENSSL_IS_AWSLC/g' {} \;
+    ./configure --with-ssl=/deps/install \
+        --prefix=/deps/install \
+        --disable-ldap \
+        --without-libidn \
+        --without-gnutls \
+        --without-nss \
+        --without-gssapi
+    make -j"${NUM_CPU_THREADS}"
+    make install
+    cd /
+    rm -rf /deps/curl
+}
+
+mkdir -p /deps
+
+download_awslc
+
+build_awslc '-DBUILD_SHARED_LIBS=ON'
+build_awslc '-DBUILD_SHARED_LIBS=OFF'
+
+install_libcurl

--- a/codebuild/bin/install-shared-deps-awslc.sh
+++ b/codebuild/bin/install-shared-deps-awslc.sh
@@ -13,7 +13,7 @@ set -euxo pipefail
 export AWSLC_SRC_DIR=/tmp/awslc
 export INSTALL_DIR=/deps/install
 export LD_LIBRARY_PATH=${INSTALL_DIR}
-export NUM_CPU_THREADS=$(grep -c ^processor /proc/cpuinfo)
+export NUM_CPU_THREADS=$(nproc)
 
 function download_awslc() {
     AWSLC_GIT_URL='https://github.com/awslabs/aws-lc.git'

--- a/codebuild/ubuntu-latest-x64-awslc.Dockerfile
+++ b/codebuild/ubuntu-latest-x64-awslc.Dockerfile
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:latest
+
+# Needed for setup-apt-cache.sh
+ADD https://mirrors.kernel.org/ubuntu/pool/main/n/net-tools/net-tools_1.60+git20180626.aebd88e-1ubuntu1_amd64.deb /tmp
+ADD https://mirrors.kernel.org/ubuntu/pool/universe/n/netcat/netcat-traditional_1.10-40_amd64.deb /tmp
+RUN dpkg -i /tmp/net-tools_*.deb /tmp/netcat-*.deb
+
+ADD bin/setup-apt-cache.sh /usr/local/bin/
+ADD bin/setup-apt.sh /usr/local/bin/
+RUN setup-apt-cache.sh
+RUN setup-apt.sh
+
+ENV PATH=/usr/local/bin:/usr/bin:/bin
+
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
+ENV CFLAGS=
+ENV CXXFLAGS=
+ENV LDFLAGS=
+
+# This docker image is similar to |ubuntu-latest-x64.Dockerfile| except OpenSSL is replaced with awslc.
+# awslc is installed at /deps/install/lib.
+ENV LDFLAGS="-Wl,-rpath -Wl,/deps/install/lib -Wl,-rpath -Wl,/deps/shared/install/lib -L/deps/install/lib -L/deps/shared/install/lib"
+
+ADD bin/apt-install-pkgs /usr/local/bin/
+ADD bin/install-shared-deps-awslc.sh /usr/local/bin/
+RUN install-shared-deps-awslc.sh
+
+ADD bin/install-aws-deps.sh /usr/local/bin
+RUN install-aws-deps.sh
+
+ADD bin/install-node.sh /usr/local/bin
+RUN install-node.sh
+
+ADD bin/codebuild-test.sh /usr/local/bin/
+
+# Remove apt proxy configuration before publishing the dockerfile
+RUN rm -f /etc/apt/apt.conf.d/99proxy

--- a/codebuild/ubuntu-latest-x64-awslc.Dockerfile
+++ b/codebuild/ubuntu-latest-x64-awslc.Dockerfile
@@ -21,21 +21,13 @@ ENV CFLAGS=
 ENV CXXFLAGS=
 ENV LDFLAGS=
 
-# This docker image is similar to |ubuntu-latest-x64.Dockerfile| except OpenSSL is replaced with awslc.
-# awslc is installed at /deps/install/lib.
+# This docker image is similar to |ubuntu-latest-x64.Dockerfile| except dependencies (crypto lib, curl and aws-cpp-sdk) are not installed.
 ENV LDFLAGS="-Wl,-rpath -Wl,/deps/install/lib -Wl,-rpath -Wl,/deps/shared/install/lib -L/deps/install/lib -L/deps/shared/install/lib"
 
 ADD bin/apt-install-pkgs /usr/local/bin/
-ADD bin/install-shared-deps-awslc.sh /usr/local/bin/
-RUN install-shared-deps-awslc.sh
-
-ADD bin/install-aws-deps.sh /usr/local/bin
-RUN install-aws-deps.sh
 
 ADD bin/install-node.sh /usr/local/bin
 RUN install-node.sh
-
-ADD bin/codebuild-test.sh /usr/local/bin/
 
 # Remove apt proxy configuration before publishing the dockerfile
 RUN rm -f /etc/apt/apt.conf.d/99proxy

--- a/codebuild/ubuntu-latest-x64/batch_awslc.yml
+++ b/codebuild/ubuntu-latest-x64/batch_awslc.yml
@@ -1,0 +1,36 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+batch:
+  fast-fail: false
+  build-list:
+    - identifier: build_test_dynamic
+      buildspec: codebuild/ubuntu-latest-x64/build_test_awslc.yml
+      env:
+        variables:
+          TEST_MODE: dynamic
+    - identifier: build_test_static_debug
+      buildspec: codebuild/ubuntu-latest-x64/build_test_awslc.yml
+      env:
+        variables:
+          TEST_MODE: static_debug
+    - identifier: build_test_static_valgrind
+      buildspec: codebuild/ubuntu-latest-x64/build_test_awslc.yml
+      env:
+        variables:
+          TEST_MODE: static_valgrind
+    - identifier: compliance
+      buildspec: codebuild/ubuntu-latest-x64/compliance.yml
+

--- a/codebuild/ubuntu-latest-x64/build_test_awslc.yml
+++ b/codebuild/ubuntu-latest-x64/build_test_awslc.yml
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+
+phases:
+  install:
+    commands:
+      - codebuild/bin/install-shared-deps-awslc.sh
+      - codebuild/bin/install-aws-deps.sh
+  build:
+    commands:
+      - codebuild/bin/codebuild-test.sh

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -16,18 +16,13 @@
 #include <assert.h>
 #include <stdlib.h>
 
-// TODO(CryptoAlg-778): address build with awslc on windows.
-#if defined(__linux__)
-#    include <openssl/base.h>
-#    if defined(OPENSSL_IS_AWSLC)
-#        include <openssl/asn1.h>
-#        include <openssl/asn1t.h>
-#        include <openssl/obj.h>
-#    endif
-#endif
-
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
+
+#if defined(OPENSSL_IS_AWSLC)
+#    include <openssl/asn1.h>
+#    include <openssl/obj.h>
+#endif
 
 #include <openssl/ec.h>
 #include <openssl/ecdsa.h>

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -19,9 +19,9 @@
 #include <openssl/base.h>
 
 #if defined(OPENSSL_IS_AWSLC)
-#include <openssl/obj.h>
-#include <openssl/asn1t.h>
-#include <openssl/asn1.h>
+#    include <openssl/asn1.h>
+#    include <openssl/asn1t.h>
+#    include <openssl/obj.h>
 #endif
 
 #include <openssl/crypto.h>

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -19,11 +19,11 @@
 // TODO(CryptoAlg-778): address build with awslc on windows.
 #if defined(__linux__)
 #    include <openssl/base.h>
-#if defined(OPENSSL_IS_AWSLC)
-#    include <openssl/asn1.h>
-#    include <openssl/asn1t.h>
-#    include <openssl/obj.h>
-#endif
+#    if defined(OPENSSL_IS_AWSLC)
+#        include <openssl/asn1.h>
+#        include <openssl/asn1t.h>
+#        include <openssl/obj.h>
+#    endif
 #endif
 
 #include <openssl/crypto.h>

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -16,6 +16,14 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include <openssl/base.h>
+
+#if defined(OPENSSL_IS_AWSLC)
+#include <openssl/obj.h>
+#include <openssl/asn1t.h>
+#include <openssl/asn1.h>
+#endif
+
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
 
@@ -69,6 +77,16 @@ static void ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
 }
 
 #endif
+
+static void aws_cryptosdk_free(void *orig_ptr) {
+#if defined(OPENSSL_IS_AWSLC)
+    // All memory returned by BoringSSL/awslc API calls must  
+    // generally be freed using |OPENSSL_free|.
+    OPENSSL_free(orig_ptr);
+#else
+    free(orig_ptr);
+#endif
+}
 
 struct aws_cryptosdk_sig_ctx {
     struct aws_allocator *alloc;
@@ -296,12 +314,12 @@ static int serialize_pubkey(struct aws_allocator *alloc, EC_KEY *keypair, struct
         goto err;
     }
 
-    free(buf);
+    aws_cryptosdk_free(buf);
     return AWS_OP_SUCCESS;
 
 err:
     // buf (and tmp) hold a public key, so we don't need to zeroize them.
-    free(buf);
+    aws_cryptosdk_free(buf);
 
     *pub_key = NULL;
 
@@ -413,11 +431,11 @@ err:
     aws_secure_zero(tmparr, sizeof(tmparr));
     if (privkey_buf) {
         aws_secure_zero(privkey_buf, privkey_len);
-        free(privkey_buf);
+        aws_cryptosdk_free(privkey_buf);
     }
     if (pubkey_buf) {
         aws_secure_zero(pubkey_buf, pubkey_len);
-        free(pubkey_buf);
+        aws_cryptosdk_free(pubkey_buf);
     }
 
     // There is no error path that results in a non-NULL priv_key, so we don't need to

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -16,12 +16,14 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#include <openssl/base.h>
-
+// TODO(CryptoAlg-778): address build with awslc on windows.
+#if defined(__linux__)
+#    include <openssl/base.h>
 #if defined(OPENSSL_IS_AWSLC)
 #    include <openssl/asn1.h>
 #    include <openssl/asn1t.h>
 #    include <openssl/obj.h>
+#endif
 #endif
 
 #include <openssl/crypto.h>

--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -80,7 +80,7 @@ static void ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s) {
 
 static void aws_cryptosdk_free(void *orig_ptr) {
 #if defined(OPENSSL_IS_AWSLC)
-    // All memory returned by BoringSSL/awslc API calls must  
+    // All memory returned by BoringSSL/awslc API calls must
     // generally be freed using |OPENSSL_free|.
     OPENSSL_free(orig_ptr);
 #else

--- a/source/hkdf.c
+++ b/source/hkdf.c
@@ -16,7 +16,9 @@
 #include <aws/common/byte_buf.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/private/hkdf.h>
-#include <openssl/base.h>
+#if defined(__linux__)
+#    include <openssl/base.h>
+#endif
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/opensslv.h>

--- a/source/hkdf.c
+++ b/source/hkdf.c
@@ -16,9 +16,6 @@
 #include <aws/common/byte_buf.h>
 #include <aws/cryptosdk/error.h>
 #include <aws/cryptosdk/private/hkdf.h>
-#if defined(__linux__)
-#    include <openssl/base.h>
-#endif
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/opensslv.h>


### PR DESCRIPTION
*Issue #, if available:*
CryptoAlg-778

*Description of changes:*
This PR added a new crypto lib option -- [AWS libcrypto](https://github.com/awslabs/aws-lc).

*Call out:*
* I will submit new PRs to add awslc into other CI dimensions -- MacOS GitHub workflow and Windows CodeBuild.
* For this PR testing, new batch CodeBuild -- `csdk-ubuntu-latest-x64-awslc` should be added to CI.
   * The build spec file `./codebuild/ubuntu-latest-x64/batch_awslc.yml` should be used.

*Test:*
This PR also added a new Docker image `ubuntu-latest-x64-awslc.Dockerfile`, which is mirror of `ubuntu-latest-x64.Dockerfile` but lets the build spec install `latest` awslc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

