### PR TITLE
Removed OOM test, as OOM is no longer possible from aws allocators

### DIFF
--- a/aws-encryption-sdk-cpp/tests/unit/t_cpputils.cpp
+++ b/aws-encryption-sdk-cpp/tests/unit/t_cpputils.cpp
@@ -24,22 +24,6 @@ using namespace Aws::Cryptosdk::Testing;
 
 const char *TEST_STRING = "Hello World!";
 
-static void *s_bad_malloc(struct aws_allocator *allocator, size_t size) {
-    return NULL;
-}
-
-static void s_bad_free(struct aws_allocator *allocator, void *ptr) {}
-
-static void *s_bad_realloc(struct aws_allocator *allocator, void *ptr, size_t oldsize, size_t newsize) {
-    return NULL;
-}
-
-static struct aws_allocator default_bad_allocator = { s_bad_malloc, s_bad_free, s_bad_realloc };
-
-struct aws_allocator *t_aws_bad_allocator() {
-    return &default_bad_allocator;
-}
-
 int awsStringFromCAwsByteBuf_validInputs_returnAwsString() {
     struct aws_byte_buf b = aws_byte_buf_from_c_str(TEST_STRING);
     Aws::String b_string  = aws_string_from_c_aws_byte_buf(&b);
@@ -140,16 +124,6 @@ int appendKeyToEdks_appendSingleElement_elementIsAppended() {
     TEST_ASSERT_SUCCESS(t_assert_edks_with_single_element_contains_expected_values(
         &ed.edks.encrypted_data_keys, ed.enc_data, ed.data_key_id, ed.key_provider, ed.allocator));
 
-    return 0;
-}
-
-int appendKeyToEdks_allocatorThatDoesNotAllocateMemory_returnsOomError() {
-    struct aws_allocator *oom_allocator = t_aws_bad_allocator();
-    EdksTestData ed;
-    TEST_ASSERT_ERROR(
-        AWS_ERROR_OOM,
-        t_append_c_str_key_to_edks(
-            oom_allocator, &ed.edks.encrypted_data_keys, &ed.enc, ed.data_key_id, ed.key_provider));
     return 0;
 }
 
@@ -515,7 +489,6 @@ int main() {
     RUN_TEST(awsStringFromCAwsByteBuf_validInputs_returnAwsString());
     RUN_TEST(awsUtilsByteBufferFromCAwsByteBuf_validInputs_returnAwsUtils());
     RUN_TEST(appendKeyToEdks_appendSingleElement_elementIsAppended());
-    RUN_TEST(appendKeyToEdks_allocatorThatDoesNotAllocateMemory_returnsOomError());
     RUN_TEST(appendKeyToEdks_multipleElementsAppended_elementsAreAppended());
     RUN_TEST(awsStringFromCAwsString_validInputs_returnAwsString());
     RUN_TEST(awsMapFromCAwsHashHable_hashMap_returnAwsMap());


### PR DESCRIPTION
*Description of changes:* Remove test for OOM, as `aws_allocator` no longer returns any OOM errors, it will crash instead of returning `NULL` and throwing an OOM error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

