### PR TITLE
feat(examples): add DiscoveryFilter example

### DIFF
--- a/examples/kms_discovery.cpp
+++ b/examples/kms_discovery.cpp
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <aws/core/utils/ARN.h>
 #include <aws/cryptosdk/cpp/kms_keyring.h>
 #include <aws/cryptosdk/session.h>
 
@@ -115,6 +116,9 @@ int main(int argc, char **argv) {
 
     const char *key_arn_us_west_2    = argv[1];
     const char *key_arn_eu_central_1 = argv[2];
+    const char *aws_account_id       = argv[3];
+
+    Aws::Utils::ARN parsed_arn_us_west_2(key_arn_us_west_2);
 
     struct aws_allocator *alloc         = aws_default_allocator();
     const char *plaintext_original      = "Hello world!";
@@ -197,6 +201,17 @@ int main(int argc, char **argv) {
     decryption_keyrings.push_back(Aws::Cryptosdk::KmsKeyring::Builder()
                                       .WithKmsClient(create_kms_client(Aws::Region::EU_CENTRAL_1))
                                       .BuildDiscovery());
+
+    /* This will only attempt to decrypt using keys owned by the specified AWS
+     * account. It will succeed if the message was encrypted with any KMS key
+     * owned by the specified AWS account and for which you have Decrypt
+     * permissions.
+     */
+    const Aws::String filter_account_id = parsed_arn_us_west_2.GetAccountId();
+    std::shared_ptr<Aws::Cryptosdk::KmsKeyring::DiscoveryFilter> discovery_filter =
+        Aws::Cryptosdk::KmsKeyring::DiscoveryFilter::Builder("aws").AddAccount(filter_account_id).Build();
+    decryption_keyrings.push_back(Aws::Cryptosdk::KmsKeyring::Builder()
+            .BuildDiscovery(discovery_filter));
 
     for (struct aws_cryptosdk_keyring *keyring : decryption_keyrings) {
         uint8_t plaintext_result[BUFFER_SIZE];

--- a/examples/kms_discovery.cpp
+++ b/examples/kms_discovery.cpp
@@ -210,8 +210,7 @@ int main(int argc, char **argv) {
     const Aws::String filter_account_id = parsed_arn_us_west_2.GetAccountId();
     std::shared_ptr<Aws::Cryptosdk::KmsKeyring::DiscoveryFilter> discovery_filter =
         Aws::Cryptosdk::KmsKeyring::DiscoveryFilter::Builder("aws").AddAccount(filter_account_id).Build();
-    decryption_keyrings.push_back(Aws::Cryptosdk::KmsKeyring::Builder()
-            .BuildDiscovery(discovery_filter));
+    decryption_keyrings.push_back(Aws::Cryptosdk::KmsKeyring::Builder().BuildDiscovery(discovery_filter));
 
     for (struct aws_cryptosdk_keyring *keyring : decryption_keyrings) {
         uint8_t plaintext_result[BUFFER_SIZE];

--- a/examples/kms_discovery.cpp
+++ b/examples/kms_discovery.cpp
@@ -116,7 +116,6 @@ int main(int argc, char **argv) {
 
     const char *key_arn_us_west_2    = argv[1];
     const char *key_arn_eu_central_1 = argv[2];
-    const char *aws_account_id       = argv[3];
 
     Aws::Utils::ARN parsed_arn_us_west_2(key_arn_us_west_2);
 


### PR DESCRIPTION
*Issue #, if available:* #736

*Description of changes:* Adds a discovery KMS keyring that uses a DiscoveryFilter in the `kms_discovery.cpp` example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

