### PR TITLE
fix: initialize buffer in cipher_openssl.c

### DIFF
--- a/source/cipher_openssl.c
+++ b/source/cipher_openssl.c
@@ -343,7 +343,7 @@ int aws_cryptosdk_sig_get_privkey(
     unsigned char *privkey_buf = NULL, *pubkey_buf = NULL;
     ASN1_INTEGER *privkey_int = NULL;
     /* Should be long enough to encode the private + compressed public key + alg id */
-    unsigned char tmparr[MAX_PUBKEY_SIZE * 2 + 2];
+    unsigned char tmparr[MAX_PUBKEY_SIZE * 2 + 2] = { 0 };
 
     int privkey_len = 0, pubkey_len = 0;
     int rv                       = AWS_OP_ERR;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-encryption-sdk-c/issues/749

*Description of changes:*
Initialize the uninitialized buffer. It will cost a few instructions, but it's not in a tight loop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

