### PR TITLE
fix: return type of aws_default_allocator stub in CBMC proofs

### DIFF
--- a/verification/cbmc/stubs/aws_default_allocator_stub.c
+++ b/verification/cbmc/stubs/aws_default_allocator_stub.c
@@ -15,6 +15,6 @@
 
 #include <proof_helpers/proof_allocators.h>
 
-struct aws_allocator aws_default_allocator() {
+struct aws_allocator *aws_default_allocator() {
     return can_fail_allocator();
 }


### PR DESCRIPTION
The function is expected to return a pointer, not the full struct type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

