### PR TITLE
feat: use latest aws-cpp-sdk

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: "aws/aws-sdk-cpp"
-          ref: "1.9.124"
           path: "aws-sdk-cpp"
           submodules: recursive
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The latest AWS-CPP-SDK is the only one supported.
There was a time when holding to 1.9.124 made sense, but not any more.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

