### PR TITLE
fix(CI): Update Ubuntu Docker Images for AWS-LC

### DIFF
--- a/codebuild/bin/install-shared-deps-awslc.sh
+++ b/codebuild/bin/install-shared-deps-awslc.sh
@@ -17,10 +17,11 @@ export NUM_CPU_THREADS=$(nproc)
 
 function download_awslc() {
     AWSLC_GIT_URL='https://github.com/awslabs/aws-lc.git'
-    AWSLC_TAG='v1.5.0'
+    AWSLC_TAG='main'
+    AWSLC_SHALLOW_SINCE="2023-04-07T00:00:01"
     rm -rf ${AWSLC_SRC_DIR}
     mkdir -p ${AWSLC_SRC_DIR}
-    git clone --depth 1 --branch ${AWSLC_TAG} "${AWSLC_GIT_URL}" "${AWSLC_SRC_DIR}"
+    git clone --shallow-since ${AWSLC_SHALLOW_SINCE} --branch ${AWSLC_TAG} "${AWSLC_GIT_URL}" "${AWSLC_SRC_DIR}"
 }
 
 function build_awslc() {

--- a/codebuild/bin/push-docker.sh
+++ b/codebuild/bin/push-docker.sh
@@ -28,6 +28,5 @@ build_image() {
     docker push $ECS_REGISTRY:$1
 }
 
-build_image trusty-gcc4x-x64
-build_image trusty-gcc4x-x86
 build_image ubuntu-latest-x64
+build_image ubuntu-latest-x64-awslc

--- a/codebuild/bin/push-docker.sh
+++ b/codebuild/bin/push-docker.sh
@@ -18,9 +18,10 @@
 
 set -euxo pipefail
 
-ECS_REGISTRY=${ECS_REGISTRY:-636124823696.dkr.ecr.us-west-2.amazonaws.com/linux-docker-images}
-
-$(aws ecr get-login --no-include-email --region us-west-2)
+ECS_SERVER="636124823696.dkr.ecr.us-west-2.amazonaws.com"
+ECS_REGISTRY=${ECS_REGISTRY:-${ECS_SERVER}/linux-docker-images}
+_AUTH_TOKEN=`aws ecr get-login-password --region us-west-2`
+docker login --password ${_AUTH_TOKEN}  --username AWS ${ECS_SERVER}
 
 build_image() {
     docker build -t $1 -f $1.Dockerfile .

--- a/codebuild/ubuntu-latest-x64-awslc.Dockerfile
+++ b/codebuild/ubuntu-latest-x64-awslc.Dockerfile
@@ -10,7 +10,9 @@ RUN dpkg -i /tmp/net-tools_*.deb /tmp/netcat-*.deb
 
 ADD bin/setup-apt-cache.sh /usr/local/bin/
 ADD bin/setup-apt.sh /usr/local/bin/
+
 RUN setup-apt-cache.sh
+ARG EXTRA_PACKAGES="clang perl golang"
 RUN setup-apt.sh
 
 ENV PATH=/usr/local/bin:/usr/bin:/bin


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-lc/pull/936


*Description of changes:*
AWS-LC fixed a recent issue with ASN1_STRING_clear_free:
https://github.com/aws/aws-lc/pull/936

This PR will pull that fix in to our CI's Docker Images.

I have used the updated scripts to update the CI images.
Every individual build of the `csdk-ubuntu-latest-x64-awslc` has passed at least twice,
but AWS CodeBuild could not "COMBINE_ARTIFACTS" due to an internal error:
```
Internal Service Error: CodeBuild is experiencing issues
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

