### PR TITLE
chore: compile for CBMC with warnings-as-errors

### DIFF
--- a/verification/cbmc/proofs/Makefile.common
+++ b/verification/cbmc/proofs/Makefile.common
@@ -307,8 +307,8 @@ COVERFLAGS += $(CBMC_FLAG_MALLOC_FAIL_NULL)
 NONDET_STATIC ?=
 
 # Flags to pass to goto-cc for compilation and linking
-COMPILE_FLAGS ?= -Wall
-LINK_FLAGS ?= -Wall
+COMPILE_FLAGS ?= -Wall -Werror
+LINK_FLAGS ?= -Wall -Werror
 EXPORT_FILE_LOCAL_SYMBOLS ?= --export-file-local-symbols
 
 # Preprocessor include paths -I...


### PR DESCRIPTION
*Description of changes:*

This will avoid type conflicts from silently creeping in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- n/a Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

