### PR TITLE
chore: use built-in SAT solver for CBMC proofs

### DIFF
--- a/.github/workflows/proof_ci.yaml
+++ b/.github/workflows/proof_ci.yaml
@@ -152,8 +152,6 @@ jobs:
           echo "$(pwd)" >> $GITHUB_PATH
       - name: Run CBMC proofs
         shell: bash
-        env:
-          EXTERNAL_SAT_SOLVER: kissat
         working-directory: ${{ env.PROOFS_DIR }}
         run: ${{ env.RUN_CBMC_PROOFS_COMMAND }}
       - name: Check repository visibility


### PR DESCRIPTION
*Description of changes:*

Invoking an external solver is not necessarily cheaper in terms of CPU or memory usage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- n/a Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

