### PR TITLE
fix: Installation of CMake files is non-standard

### DIFF
--- a/cmake/InstallLogic.cmake
+++ b/cmake/InstallLogic.cmake
@@ -49,10 +49,10 @@ function(aws_install_target)
     configure_file("${PROJECT_SOURCE_DIR}/cmake/${AWS_INSTALL_TARGET}-config.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/${AWS_INSTALL_TARGET}-config.cmake" @ONLY)
     
-    install(EXPORT "${AWS_INSTALL_TARGET}-targets" DESTINATION "${LIBRARY_DIRECTORY}/${AWS_INSTALL_TARGET}/cmake/"
+    install(EXPORT "${AWS_INSTALL_TARGET}-targets" DESTINATION "${LIBRARY_DIRECTORY}/cmake/${AWS_INSTALL_TARGET}/"
         NAMESPACE AWS::
     )
     
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${AWS_INSTALL_TARGET}-config.cmake"
-        DESTINATION "${LIBRARY_DIRECTORY}/${AWS_INSTALL_TARGET}/cmake/")
+        DESTINATION "${LIBRARY_DIRECTORY}/cmake/${AWS_INSTALL_TARGET}/")
 endfunction(aws_install_target)


### PR DESCRIPTION
Use the standard cmake file deployment location to make 3rd party usage easier.

*Issue #810 

*Description of changes:*
This updates the installation location to be into the standard location for 3rd party projects to pick up and use more easily. 

You may not want to merge this as it may cause problems with downstream projects already using this location; potentially add a second installation location while people gradually then adopt to the standard and then eventually remove.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

