### PR TITLE
chore: Document encryption context interoperability for invalid UTF-8

### DIFF
--- a/include/aws/cryptosdk/enc_ctx.h
+++ b/include/aws/cryptosdk/enc_ctx.h
@@ -32,6 +32,16 @@ extern "C" {
  * for the most part, aws_hash_table methods are used to manipulate these structures,
  * but we provide some higher-level helper methods in this section. These helpers
  * will mostly be of interest to developers of custom CMMs or keyrings.
+ *
+ * The values provided to the encryption context SHOULD be UTF-8 bytes.
+ * While it is technically possible to provide invalid UTF-8 bytes,
+ * doing so is strongly discouraged.
+ * Messages that include invalid UTF-8 bytes in their encryption context
+ * will not be interoperable across different language implementations
+ * of the AWS Encryption SDK.
+ * The ESDK for C permits writing and reading encryption contexts that
+ * contain invalid UTF-8 bytes, but ESDKs in other languages will neither
+ * read nor write messages whose encryption context contains invalid UTF-8.
  * @{
  */
 

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -144,7 +144,7 @@ struct aws_cryptosdk_enc_request {
      * will not be interoperable across different language implementations
      * of the AWS Encryption SDK.
      * The ESDK for C permits writing and reading encryption contexts that
-     * contain invalid UTF-8 bytes, but ESDKs in other language will neither
+     * contain invalid UTF-8 bytes, but ESDKs in other languages will neither
      * read nor write messages whose encryption context contains invalid UTF-8.
      */
     struct aws_hash_table *enc_ctx;

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -197,6 +197,21 @@ struct aws_cryptosdk_enc_materials {
  */
 struct aws_cryptosdk_dec_request {
     struct aws_allocator *alloc;
+    /**
+     * The encryption context for this message. CMMs are permitted to modify this
+     * hash table in order to inject additional keys or otherwise modify the encryption
+     * context.
+     *
+     * The values provided to the encryption context SHOULD be UTF-8 bytes.
+     * While it is technically possible to provide invalid UTF-8 bytes,
+     * doing so is strongly discouraged.
+     * Messages that include invalid UTF-8 bytes in their encryption context
+     * will not be interoperable across different language implementations
+     * of the AWS Encryption SDK.
+     * The ESDK for C permits writing and reading encryption contexts that
+     * contain invalid UTF-8 bytes, but ESDKs in other languages will neither
+     * read nor write messages whose encryption context contains invalid UTF-8.
+     */
     const struct aws_hash_table *enc_ctx;
     struct aws_array_list encrypted_data_keys;
     enum aws_cryptosdk_alg_id alg;

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -137,14 +137,14 @@ struct aws_cryptosdk_enc_request {
      * hash table in order to inject additional keys or otherwise modify the encryption
      * context.
      *
-     * The values provided to the encryption context SHOULD be UTF-8 encoded bytes.
-     * You may provide invalid UTF-8 characters in the encryption context,
+     * The values provided to the encryption context SHOULD be UTF-8 bytes.
+     * You may choose to provide invalid UTF-8 bytes in the encryption context,
      * but this is discouraged.
-     * Messages with invalid UTF-8 characters will not be interoperable
-     * with other language implementations of the encryption SDK.
-     * The encryption SDK for C will allow writing and reading messages with invalid UTF-8, but
-     * the encryption SDK in other languages will neither read nor write
-     * messages with invalid UTF-8.
+     * Messages whose encryption contexts contain invalid UTF-8 characters will
+     * not be interoperable with other language implementations of the encryption SDK.
+     * The encryption SDK for C will allow writing and reading invalid UTF-8 to encryption
+     * contexts, but the encryption SDK in other languages will neither read nor write
+     * messages whose encryption context contains invalid UTF-8 characters.
      */
     struct aws_hash_table *enc_ctx;
     /**

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -138,13 +138,14 @@ struct aws_cryptosdk_enc_request {
      * context.
      *
      * The values provided to the encryption context SHOULD be UTF-8 bytes.
-     * You may choose to provide invalid UTF-8 bytes in the encryption context,
-     * but this is discouraged.
-     * Messages whose encryption contexts contain invalid UTF-8 characters will
-     * not be interoperable with other language implementations of the encryption SDK.
-     * The encryption SDK for C will allow writing and reading invalid UTF-8 in encryption
-     * contexts, but the encryption SDK in other languages will neither read nor write
-     * messages whose encryption context contains invalid UTF-8 characters.
+     * While it is technically possible to provide invalid UTF-8 bytes,
+     * doing so is strongly discouraged.
+     * Messages that include invalid UTF-8 bytes in their encryption context
+     * will not be interoperable across different language implementations
+     * of the AWS Encryption SDK.
+     * The ESDK for C permits writing and reading encryption contexts that
+     * contain invalid UTF-8 bytes, but ESDKs in other language will neither
+     * read nor write messages whose encryption context contains invalid UTF-8.
      */
     struct aws_hash_table *enc_ctx;
     /**

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -136,6 +136,15 @@ struct aws_cryptosdk_enc_request {
      * The encryption context for this message. CMMs are permitted to modify this
      * hash table in order to inject additional keys or otherwise modify the encryption
      * context.
+     *
+     * The values provided to the encryption context SHOULD be UTF-8 encoded bytes.
+     * You may provide invalid UTF-8 characters in the encryption context,
+     * but this is discouraged.
+     * Messages with invalid UTF-8 characters will not be interoperable
+     * with other language implementations of the encryption SDK.
+     * The encryption SDK for C will allow writing and reading messages with invalid UTF-8, but
+     * the encryption SDK in other languages will neither read nor write
+     * messages with invalid UTF-8.
      */
     struct aws_hash_table *enc_ctx;
     /**

--- a/include/aws/cryptosdk/materials.h
+++ b/include/aws/cryptosdk/materials.h
@@ -142,7 +142,7 @@ struct aws_cryptosdk_enc_request {
      * but this is discouraged.
      * Messages whose encryption contexts contain invalid UTF-8 characters will
      * not be interoperable with other language implementations of the encryption SDK.
-     * The encryption SDK for C will allow writing and reading invalid UTF-8 to encryption
+     * The encryption SDK for C will allow writing and reading invalid UTF-8 in encryption
      * contexts, but the encryption SDK in other languages will neither read nor write
      * messages whose encryption context contains invalid UTF-8 characters.
      */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

