### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -3,6 +3,9 @@ name: test-clang-format
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "00 15 * * 1-5"
 
+permissions:
+  contents: read
+
 jobs:
   codebuild:
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'

--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   notify-issue:
     if: github.event_name == 'issues'

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -3,6 +3,9 @@ name: Pull Request Workflow
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   clang-format:
     uses: ./.github/workflows/clang-format.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: master
 
+permissions:
+  contents: read
+
 jobs:
   clang-format:
     uses: ./.github/workflows/clang-format.yml

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -3,6 +3,10 @@ name: Repo Sync
 on:
   workflow_dispatch:     # allows triggering this manually through the Actions UI
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   repo-sync:
     name: Repo Sync


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.