### PR TITLE
fix: add apt-get update before libcurl install in CI workflow

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -27,7 +27,10 @@ jobs:
 
       - name: Install LibCurl
         if: matrix.os == 'ubuntu-22.04'
-        run: sudo apt-get install libcurl4-openssl-dev
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev --fix-missing
 
       - name: Checkout PR
         uses: actions/checkout@v4


### PR DESCRIPTION
Run `apt-get update` before installing `libcurl4-openssl-dev` to avoid stale package index failures. Also adds `--fix-missing` flag and explicit `shell: bash`.